### PR TITLE
fix(commandcode): open the error chunk with the assistant role

### DIFF
--- a/open-sse/translator/response/commandcode-to-openai.js
+++ b/open-sse/translator/response/commandcode-to-openai.js
@@ -168,7 +168,17 @@ export function commandCodeToOpenAIResponse(chunk, state) {
       state.finishReason = OPENAI_FINISH.STOP;
       const errVal = event.error ?? event.message ?? "unknown";
       const errStr = typeof errVal === "string" ? errVal : JSON.stringify(errVal);
-      out.push(makeChunk(state, { content: `\n\n[CommandCode error: ${errStr}]` }));
+      // Same first-delta contract as every other content branch here. An upstream
+      // error is frequently the FIRST event (a 503 before any token), and this was
+      // the one branch that emitted content without the opening `role` and without
+      // advancing chunkIndex -- so the error chunk carried no role, and any text
+      // arriving after it still thought it was chunk zero and sent a second one.
+      const errText = `\n\n[CommandCode error: ${errStr}]`;
+      const delta = state.chunkIndex === 0
+        ? { role: ROLE.ASSISTANT, content: errText }
+        : { content: errText };
+      state.chunkIndex++;
+      out.push(makeChunk(state, delta));
       out.push(makeChunk(state, {}, OPENAI_FINISH.STOP));
       break;
     }

--- a/tests/unit/commandcode-to-openai.test.js
+++ b/tests/unit/commandcode-to-openai.test.js
@@ -124,4 +124,37 @@ describe("commandcode-to-openai — error event", () => {
     expect(text).toContain("Boom");
     expect(text).not.toContain("[object Object]");
   });
+
+  // An upstream error is routinely the FIRST event on the stream -- a 503 arrives
+  // before any token. Every other content branch opens with `role: "assistant"`;
+  // this one did not, so the only delta a client received for a failed turn had no
+  // role on it.
+  it("opens with the assistant role when the error is the first event", () => {
+    const { chunks } = feed([
+      { type: "error", error: { type: "server_error", message: "Service temporarily unavailable", statusCode: 503 } },
+    ]);
+    expect(chunks[0].choices[0].delta.role).toBe("assistant");
+    expect(chunks[0].choices[0].delta.content).toContain("Service temporarily unavailable");
+  });
+
+  it("does not open with a role when content already went out", () => {
+    const { chunks } = feed([
+      { type: "text-delta", text: "Hello" },
+      { type: "error", error: "boom" },
+    ]);
+    expect(chunks[0].choices[0].delta.role).toBe("assistant");
+    expect(chunks[1].choices[0].delta.role).toBeUndefined();
+  });
+
+  // The branch used to leave chunkIndex at 0, so text arriving after the error still
+  // believed it was the opening chunk and sent a second role delta.
+  it("sends the role exactly once when text follows the error", () => {
+    const { chunks } = feed([
+      { type: "error", error: "boom" },
+      { type: "text-delta", text: "recovered" },
+    ]);
+    const withRole = chunks.filter((c) => c.choices[0].delta.role === "assistant");
+    expect(withRole).toHaveLength(1);
+    expect(chunks[0].choices[0].delta.role).toBe("assistant");
+  });
 });


### PR DESCRIPTION
## The inconsistency

`commandcode-to-openai.js` has one first-delta convention, followed by every content-emitting branch:

```js
// text-delta
const delta = state.chunkIndex === 0 ? { role: ROLE.ASSISTANT, content: text } : { content: text };
state.chunkIndex++;

// reasoning-delta
const delta = reasoningDelta(text, state.chunkIndex === 0);
state.chunkIndex++;

// tool-input-start / tool-call
...(state.chunkIndex === 0 ? { role: ROLE.ASSISTANT } : {}),
state.chunkIndex++;
```

`error` was the one branch that did neither:

```js
out.push(makeChunk(state, { content: `\n\n[CommandCode error: ${errStr}]` }));
```

No `role`, no `chunkIndex++`.

## Why it bites

An upstream error is routinely the **first** event on the stream. The example in #3468 is exactly that shape — a 503 before any token:

```
[CommandCode error: {"type":"server_error","message":"Service temporarily unavailable. Please try again shortly.","statusCode":503,"isRetryable":true}]
```

So for a failed turn, the only content delta a client receives carries no `role`. The OpenAI streaming contract puts `role` on the opening delta, and the branch right next door already honours it.

Second effect, from the missing `chunkIndex++`: if any text arrives after the error chunk, that text still believes it is chunk zero and emits `role` a **second** time.

## The change

Eleven lines in one branch, shaped like the `text-delta` branch beside it. The message text is byte-identical — this is about the envelope, not the content.

## Tests

Three added to `tests/unit/commandcode-to-openai.test.js`, using the file's existing `feed()` helper:

- error as the first event → the chunk opens with `role: "assistant"`
- error after text → no role on the error chunk
- error then text → exactly one role delta across the stream

Mutation-checked, each mutation verified to have applied before running:

| mutation | result |
|---|---|
| drop the `chunkIndex === 0` role branch | **2 failed** — "opens with the assistant role…", "sends the role exactly once…" |
| drop `state.chunkIndex++` (verified 5 → 4 sites in the file) | **1 failed** — "sends the role exactly once…" |

Both reverted.

## Suite

`tests/unit/commandcode-to-openai.test.js`: 9 → **12 passed**, 0 failed.

Full suite, both endpoints measured on this branch's base `699edac3`:

| tree | result |
|---|---|
| clean `origin/master` | 78 failed files, **140 failed / 1385 passed** |
| this branch | 78 failed files, **140 failed / 1388 passed** |

Failures unchanged; passes up by exactly the three tests added. (The 140 are pre-existing on `master` — I re-measured rather than reusing an older figure, since the count has moved a good deal recently.)

## What this does not do

It does not make 9router fail over on a CommandCode 503, which is what #3468 actually asks for. That needs the round-robin path to treat an in-band stream error as a retryable attempt failure, and by the time this translator runs the response has already begun — a real design question about whether and when a started stream may be retried. I did not want to guess at it inside a one-branch consistency fix, so I am sending this on its own and leaving #3468 open.

What this does fix is a defect I found while reading that path: the error chunk was malformed regardless of failover.
