### PR TITLE
fix(session): evict the least-recently-used session, not the first one stored

### DIFF
--- a/open-sse/utils/sessionManager.js
+++ b/open-sse/utils/sessionManager.js
@@ -50,10 +50,17 @@ export function deriveSessionId(connectionId) {
     const existing = runtimeSessionStore.get(connectionId);
     if (existing) {
         existing.lastUsed = Date.now();
+        // Re-insert so Map iteration order tracks use, not first insert. The
+        // eviction below takes the first key, and without this it would take the
+        // oldest connection — which for a long-running instance is the busiest
+        // one, whose session id is exactly what must stay stable.
+        runtimeSessionStore.delete(connectionId);
+        runtimeSessionStore.set(connectionId, existing);
         return existing.sessionId;
     }
 
-    // Evict oldest entry if store exceeds max size (safety cap between cleanup cycles)
+    // Evict least-recently-used entry if store exceeds max size (safety cap
+    // between cleanup cycles)
     const MAX_SESSIONS = 1000;
     if (runtimeSessionStore.size >= MAX_SESSIONS) {
       const oldest = runtimeSessionStore.keys().next().value;
@@ -183,6 +190,10 @@ function assistantTextSessionId(scope, body) {
     const existing = assistantSessionStore.get(hash);
     if (existing) {
         existing.lastUsed = Date.now();
+        // Same reason as deriveSessionId: keep Map order in use order so the
+        // eviction below drops the least-recently-used conversation.
+        assistantSessionStore.delete(hash);
+        assistantSessionStore.set(hash, existing);
         return existing.sessionId;
     }
     if (assistantSessionStore.size >= MAX_ASSISTANT_SESSIONS) {

--- a/tests/unit/session-store-lru.test.js
+++ b/tests/unit/session-store-lru.test.js
@@ -1,0 +1,77 @@
+// The session stores exist to keep one id stable per connection/conversation so
+// upstream prompt caches keep hitting. Their size caps evict `keys().next()`,
+// which is only the least-recently-used entry if Map order tracks use —
+// resolveContinuationId re-inserts on read for exactly that reason.
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearSessionStore,
+  deriveSessionId,
+  resolveContinuationId,
+  resolveSessionId,
+} from "../../open-sse/utils/sessionManager.js";
+
+const MAX_SESSIONS = 1000;
+const MAX_ASSISTANT_SESSIONS = 5000;
+
+beforeEach(() => {
+  clearSessionStore();
+});
+
+describe("deriveSessionId eviction", () => {
+  it("keeps the connection that is still being used when the cap is reached", () => {
+    const hot = "conn-hot";
+    const hotId = deriveSessionId(hot);
+    for (let i = 1; i < MAX_SESSIONS; i++) deriveSessionId(`conn-${i}`);
+
+    // Still in use — inserted first, but the most recently touched.
+    expect(deriveSessionId(hot)).toBe(hotId);
+
+    // One more connection pushes the store over the cap.
+    deriveSessionId("conn-new");
+
+    expect(deriveSessionId(hot)).toBe(hotId);
+  });
+
+  it("evicts the least-recently-used connection, not the first inserted", () => {
+    const first = deriveSessionId("conn-0");
+    for (let i = 1; i < MAX_SESSIONS; i++) deriveSessionId(`conn-${i}`);
+    deriveSessionId("conn-0"); // touch: conn-1 is now the LRU
+    deriveSessionId("conn-new");
+
+    expect(deriveSessionId("conn-0")).toBe(first);
+  });
+
+  it("keeps an untouched connection stable while under the cap", () => {
+    const id = deriveSessionId("conn-quiet");
+    for (let i = 0; i < 10; i++) deriveSessionId(`conn-${i}`);
+    expect(deriveSessionId("conn-quiet")).toBe(id);
+  });
+});
+
+describe("assistant-anchored session eviction", () => {
+  const bodyFor = (n) => ({
+    messages: [{ role: "assistant", content: `conversation ${n} `.padEnd(80, "x") }],
+  });
+  const idFor = (n) => resolveSessionId({ body: bodyFor(n), connectionId: "c", scope: "codex" });
+
+  it("keeps the conversation that is still being used when the cap is reached", () => {
+    const hotId = idFor(0);
+    for (let i = 1; i < MAX_ASSISTANT_SESSIONS; i++) idFor(i);
+
+    expect(idFor(0)).toBe(hotId);
+    idFor(MAX_ASSISTANT_SESSIONS); // pushes over the cap
+    expect(idFor(0)).toBe(hotId);
+  });
+});
+
+describe("resolveContinuationId eviction (already LRU — guards the reference behaviour)", () => {
+  it("keeps the continuation that is still being used", () => {
+    const opts = (n) => ({ sessionId: `s-${n}`, connectionId: "c", scope: "kiro" });
+    const hot = resolveContinuationId(opts(0));
+    for (let i = 1; i < 5000; i++) resolveContinuationId(opts(i));
+
+    expect(resolveContinuationId(opts(0))).toBe(hot);
+    resolveContinuationId(opts(5000));
+    expect(resolveContinuationId(opts(0))).toBe(hot);
+  });
+});


### PR DESCRIPTION
## Problem

`sessionManager.js` keeps three bounded stores, each capped by evicting `keys().next().value` — the front of the Map. That is the least-recently-used entry **only if** Map order tracks use.

`resolveContinuationId` makes sure it does, and says so:

```js
const existing = continuationStore.get(key);
if (existing) {
    existing.lastUsed = Date.now();
    continuationStore.delete(key);
    continuationStore.set(key, existing);      // ← move to the back
    return existing.continuationId;
}
...
if (continuationStore.size >= MAX_CONTINUATION_SESSIONS) {
    continuationStore.delete(continuationStore.keys().next().value);
}
```

`deriveSessionId` and `assistantTextSessionId` do not:

```js
const existing = runtimeSessionStore.get(connectionId);
if (existing) {
    existing.lastUsed = Date.now();            // recorded, never acted on
    return existing.sessionId;
}
...
const oldest = runtimeSessionStore.keys().next().value;   // = first inserted
runtimeSessionStore.delete(oldest);
```

`lastUsed` is written on every hit but only ever read by the TTL sweep, so the cap evicts by **insertion** order. On a long-running instance the first-inserted connection is typically the one that has been talking the longest — so at 1000 connections (or 5000 assistant-anchored conversations) the store throws away the busiest session first, and can keep doing it every time a new connection appears.

That is the one outcome these stores exist to prevent. The module's own docstring:

> Within a running instance, the ID is stable for that connection. […] This enables prompt caching

A rotated session id means a fresh upstream prompt cache for a live conversation.

## Fix

Do in both stores what `resolveContinuationId` already does — re-insert on a hit so the front of the Map is genuinely the LRU entry. `delete` + `set` on a `Map` is O(1); no new state, no change to TTL sweeping, and the eviction lines are untouched.

## Verification

`tests/unit/session-store-lru.test.js`, 5 tests through the public API:

- a connection still in use survives the cap being reached
- the LRU connection is evicted, not the first inserted
- a quiet connection under the cap is unaffected
- the same for the assistant-anchored store, driven through `resolveSessionId` with real message bodies
- the same for `resolveContinuationId` — which passes either way, and is there to guard the reference behaviour the other two now copy

Against the current file:

```
FAIL  deriveSessionId eviction > keeps the connection that is still being used when the cap is reached
FAIL  deriveSessionId eviction > evicts the least-recently-used connection, not the first inserted
FAIL  assistant-anchored session eviction > keeps the conversation that is still being used when the cap is reached
Tests  3 failed | 2 passed (5)
```

Full offline suite (`vitest run unit auth translator`, `CI=true`, excluding `real/`), same command on both sides:

| | tests | failed |
|---|---|---|
| `origin/master` (699edac3) | 1910 | 95 |
| this branch | 1915 | 95 |

Identical failure sets — `comm` on the sorted full test names returns nothing either way. `eslint` clean.