### PR TITLE
fix(db): let the sql.js adapter exit on SIGINT/SIGTERM

### DIFF
--- a/src/lib/db/adapters/sqljsAdapter.js
+++ b/src/lib/db/adapters/sqljsAdapter.js
@@ -105,11 +105,16 @@ export async function createSqlJsAdapter(filePath) {
     db.close();
   }
 
-  // Flush on shutdown
+  // Flush on shutdown. `once` plus an explicit exit, matching the native
+  // adapters: installing a SIGINT/SIGTERM listener replaces Node's default
+  // terminate action, so a handler that only flushes leaves the process running
+  // after Ctrl-C, and `docker stop` waits out its whole grace period before
+  // SIGKILL. `on` would also stack a listener per adapter created.
   const flush = () => { if (dirty) try { persist(); } catch {} };
-  process.on("beforeExit", flush);
-  process.on("SIGINT", flush);
-  process.on("SIGTERM", flush);
+  const onShutdown = () => { flush(); process.exit(0); };
+  process.once("beforeExit", flush);
+  process.once("SIGINT", onShutdown);
+  process.once("SIGTERM", onShutdown);
 
   return { driver: "sql.js", run, get, all, exec, transaction, close, raw: db };
 }

--- a/tests/unit/db-adapter-shutdown.test.js
+++ b/tests/unit/db-adapter-shutdown.test.js
@@ -1,0 +1,89 @@
+// Installing a SIGINT/SIGTERM listener replaces Node's default terminate action.
+// Every DB adapter installs one to flush before shutdown, so each of them also
+// has to exit — otherwise Ctrl-C is swallowed and `docker stop` waits out its
+// full grace period before SIGKILL.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createSqlJsAdapter } from "../../src/lib/db/adapters/sqljsAdapter.js";
+
+const SIGNALS = ["SIGINT", "SIGTERM"];
+
+let tempDir;
+let adapter;
+let baseline;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-sqljs-shutdown-"));
+  baseline = Object.fromEntries(SIGNALS.map((s) => [s, process.listeners(s).slice()]));
+});
+
+afterEach(() => {
+  try { adapter?.close(); } catch { /* already closed */ }
+  adapter = undefined;
+  // Drop whatever the adapter installed so one test cannot affect the next.
+  for (const signal of SIGNALS) {
+    for (const listener of process.listeners(signal)) {
+      if (!baseline[signal].includes(listener)) process.removeListener(signal, listener);
+    }
+  }
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+async function makeAdapter() {
+  adapter = await createSqlJsAdapter(path.join(tempDir, "data.sqlite"));
+  return adapter;
+}
+
+const added = (signal) => process.listeners(signal).filter((l) => !baseline[signal].includes(l));
+
+describe("sql.js adapter shutdown", () => {
+  it.each(SIGNALS)("%s exits the process after flushing", async (signal) => {
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => {});
+    try {
+      await makeAdapter();
+      expect(added(signal)).toHaveLength(1);
+
+      process.emit(signal);
+
+      // Without this the handler flushes and returns, and because a listener is
+      // registered Node no longer terminates on the signal either.
+      expect(exit).toHaveBeenCalledWith(0);
+    } finally {
+      exit.mockRestore();
+    }
+  });
+
+  it.each(SIGNALS)("does not keep handling %s after the first one", async (signal) => {
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => {});
+    try {
+      await makeAdapter();
+      process.emit(signal);
+      // Registered with `once`, so the handler is consumed. `on` would leave it
+      // in place and stack another one per adapter created.
+      expect(added(signal)).toHaveLength(0);
+    } finally {
+      exit.mockRestore();
+    }
+  });
+
+  it("still persists a pending write when the signal arrives", async () => {
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => {});
+    try {
+      const db = await makeAdapter();
+      const file = path.join(tempDir, "data.sqlite");
+      db.exec("CREATE TABLE t (v TEXT)");
+      db.run("INSERT INTO t(v) VALUES(?)", ["kept"]);
+      expect(fs.existsSync(file)).toBe(false); // the save is debounced
+
+      process.emit("SIGTERM");
+
+      expect(fs.existsSync(file)).toBe(true);
+      expect(fs.statSync(file).size).toBeGreaterThan(0);
+    } finally {
+      exit.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Installing a `SIGINT` or `SIGTERM` listener replaces Node's default action for that signal, which is to terminate. Whoever installs one owns the exit.

The three native adapters do own it:

```js
// betterSqliteAdapter.js / bunSqliteAdapter.js / nodeSqliteAdapter.js
const onShutdown = () => gracefulClose();
process.once("beforeExit", onShutdown);
process.once("SIGINT",  () => { onShutdown(); process.exit(0); });
process.once("SIGTERM", () => { onShutdown(); process.exit(0); });
```

`sqljsAdapter.js` does not:

```js
const flush = () => { if (dirty) try { persist(); } catch {} };
process.on("beforeExit", flush);
process.on("SIGINT",  flush);     // flushes, returns, process keeps running
process.on("SIGTERM", flush);
```

So on the pure-JS fallback — the Docker image and any install where the native bindings are unavailable — the handler writes the database out and then hands control back to an event loop that is still alive:

- **Ctrl-C does nothing visible.** The signal is consumed by the flush; the server keeps serving. You have to send it twice or kill the process.
- **`docker stop` always takes the full grace period.** SIGTERM is absorbed, the container never exits on its own, and Docker SIGKILLs it ten seconds later. Anything in flight dies hard, every time.

Confirmed against the current file — creating the adapter installs one listener on each signal:

```
SIGINT listeners after create: 1 (was 0)
SIGTERM listeners: 1
```

`process.on` rather than `process.once` is the smaller half of the same divergence: a second adapter in one process stacks a second handler.

## Fix

Match the other three:

```js
const flush = () => { if (dirty) try { persist(); } catch {} };
const onShutdown = () => { flush(); process.exit(0); };
process.once("beforeExit", flush);
process.once("SIGINT", onShutdown);
process.once("SIGTERM", onShutdown);
```

`beforeExit` keeps the plain `flush` — there is nothing to exit from there.

## Verification

`tests/unit/db-adapter-shutdown.test.js`, 5 tests against a real adapter over a temp-dir database, with `process.exit` stubbed and the signal delivered through `process.emit`:

- `SIGINT` and `SIGTERM` each call `process.exit(0)` after flushing
- neither handler survives the first signal (`once`, not `on`)
- a write still pending behind the 100ms save debounce is persisted when the signal arrives — the file does not exist before, and does after

Each test restores any listener the adapter added, so the vitest worker is left as it was found.

Against the current file:

```
FAIL  SIGINT exits the process after flushing
FAIL  SIGTERM exits the process after flushing
FAIL  does not keep handling SIGINT after the first one
FAIL  does not keep handling SIGTERM after the first one
Tests  4 failed | 1 passed (5)
```

The fifth — the flush itself — passes either way; it is there so the exit cannot be added by dropping the persist.

Full offline suite (`vitest run unit auth translator`, `CI=true`, excluding `real/`), same command on both sides:

| | tests | failed |
|---|---|---|
| `origin/master` (699edac3) | 1910 | 95 |
| this branch | 1915 | 95 |

Identical failure sets — `comm` on the sorted full test names returns nothing either way. `eslint` clean.

I could not send a real signal to a real server here (Windows has no POSIX signal delivery to a child, and there is no Linux runtime on this machine), so what is verified is the handler's behaviour, not an end-to-end `docker stop`. The claim that a registered listener suppresses the default terminate is Node's documented behaviour for `SIGINT`/`SIGTERM`, and it is the same reasoning the three native adapters already encode.