### PR TITLE
fix(providers): give every connection probe a deadline

### DIFF
--- a/src/app/api/provider-nodes/validate/route.js
+++ b/src/app/api/provider-nodes/validate/route.js
@@ -1,16 +1,8 @@
 import { NextResponse } from "next/server";
 import { assertPublicUrl } from "@/shared/utils/ssrfGuard.js";
 import { isLocalRequest } from "@/dashboardGuard";
+import { fetchWithTimeout } from "@/lib/network/fetchWithTimeout.js";
 
-// Fetch with timeout wrapper
-const fetchWithTimeout = (url, options, timeout = 10000) => {
-  return Promise.race([
-    fetch(url, options),
-    new Promise((_, reject) => 
-      setTimeout(() => reject(new Error("Request timeout")), timeout)
-    )
-  ]);
-};
 
 // Validate URL format
 const isValidUrl = (url) => {

--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -6,6 +6,7 @@ import { resolveOllamaLocalHost, resolveXiaomiTokenplanBaseUrl, PROVIDERS } from
 import { openaiToCommandCodeRequest } from "open-sse/translator/request/openai-to-commandcode.js";
 import { resolveQoderCredentials, resolveQoderModels } from "open-sse/services/qoderModels.js";
 import { normalizeProviderId } from "@/lib/providerNormalization";
+import { fetchWithTimeout } from "@/lib/network/fetchWithTimeout.js";
 
 // Probe a webSearch/webFetch provider using its searchConfig/fetchConfig.
 // Returns true if API key is accepted (status !== 401 && !== 403).
@@ -38,7 +39,7 @@ async function probeWebProvider(provider, apiKey) {
     body = JSON.stringify({ query: "ping", q: "ping", url: "https://example.com" });
   }
 
-  const res = await fetch(url, { method: cfg.method, headers, body, signal: AbortSignal.timeout(8000) });
+  const res = await fetchWithTimeout(url, { method: cfg.method, headers, body, signal: AbortSignal.timeout(8000) });
   return res.status !== 401 && res.status !== 403;
 }
 
@@ -72,7 +73,7 @@ async function probeMediaProvider(provider, apiKey) {
   }
 
   const method = cfg.method || "POST";
-  const res = await fetch(cfg.baseUrl, {
+  const res = await fetchWithTimeout(cfg.baseUrl, {
     method,
     headers,
     body: method === "GET" ? undefined : JSON.stringify({ input: "ping", text: "ping", prompt: "ping", model: getDefaultModel(provider) || "test" }),
@@ -104,7 +105,7 @@ export async function POST(request) {
           return NextResponse.json({ error: "OpenAI Compatible node not found" }, { status: 404 });
         }
         const modelsUrl = `${node.baseUrl?.replace(/\/$/, "")}/models`;
-        const res = await fetch(modelsUrl, {
+        const res = await fetchWithTimeout(modelsUrl, {
           headers: { "Authorization": `Bearer ${apiKey}` },
         });
         isValid = res.ok;
@@ -121,7 +122,7 @@ export async function POST(request) {
           return NextResponse.json({ error: "Custom Embedding node not found" }, { status: 404 });
         }
         const baseUrl = node.baseUrl?.replace(/\/$/, "");
-        const modelsRes = await fetch(`${baseUrl}/models`, {
+        const modelsRes = await fetchWithTimeout(`${baseUrl}/models`, {
           headers: { "Authorization": `Bearer ${apiKey}` },
         });
         if (modelsRes.ok) {
@@ -132,7 +133,7 @@ export async function POST(request) {
           return NextResponse.json({ valid: false, error: "Invalid API key" });
         }
         // Fallback: probe /embeddings with a common test model — many providers lack /models
-        const embedRes = await fetch(`${baseUrl}/embeddings`, {
+        const embedRes = await fetchWithTimeout(`${baseUrl}/embeddings`, {
           method: "POST",
           headers: { "Authorization": `Bearer ${apiKey}`, "Content-Type": "application/json" },
           body: JSON.stringify({ model: "test", input: "ping" }),
@@ -159,7 +160,7 @@ export async function POST(request) {
         const messagesUrl = `${normalizedBase}/v1/messages`;
         const model = node.defaultModel || "claude-3-haiku-20240307";
 
-        const res = await fetch(messagesUrl, {
+        const res = await fetchWithTimeout(messagesUrl, {
           method: "POST",
           headers: {
             "x-api-key": apiKey,
@@ -189,7 +190,7 @@ export async function POST(request) {
           return NextResponse.json({ valid: false, error: "Missing Account ID" });
         }
         const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1/chat/completions`;
-        const cfRes = await fetch(url, {
+        const cfRes = await fetchWithTimeout(url, {
           method: "POST",
           headers: { "Authorization": `Bearer ${apiKey}`, "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -219,7 +220,7 @@ export async function POST(request) {
         };
         if (organization) headers["OpenAI-Organization"] = organization;
 
-        const azureRes = await fetch(url, {
+        const azureRes = await fetchWithTimeout(url, {
           method: "POST",
           headers,
           body: JSON.stringify({
@@ -254,21 +255,21 @@ export async function POST(request) {
 
       switch (provider) {
         case "openai":
-          const openaiRes = await fetch("https://api.openai.com/v1/models", {
+          const openaiRes = await fetchWithTimeout("https://api.openai.com/v1/models", {
             headers: { "Authorization": `Bearer ${apiKey}` },
           });
           isValid = openaiRes.ok;
           break;
 
         case "vercel-ai-gateway":
-          const vercelAiGatewayRes = await fetch("https://ai-gateway.vercel.sh/v1/models", {
+          const vercelAiGatewayRes = await fetchWithTimeout("https://ai-gateway.vercel.sh/v1/models", {
             headers: { "Authorization": `Bearer ${apiKey}` },
           });
           isValid = vercelAiGatewayRes.ok;
           break;
 
         case "anthropic":
-          const anthropicRes = await fetch("https://api.anthropic.com/v1/messages", {
+          const anthropicRes = await fetchWithTimeout("https://api.anthropic.com/v1/messages", {
             method: "POST",
             headers: {
               "x-api-key": apiKey,
@@ -285,12 +286,12 @@ export async function POST(request) {
           break;
 
         case "gemini":
-          const geminiRes = await fetch(`https://generativelanguage.googleapis.com/v1/models?key=${apiKey}`);
+          const geminiRes = await fetchWithTimeout(`https://generativelanguage.googleapis.com/v1/models?key=${apiKey}`);
           isValid = geminiRes.ok;
           break;
 
         case "openrouter":
-          const openrouterRes = await fetch("https://openrouter.ai/api/v1/models", {
+          const openrouterRes = await fetchWithTimeout("https://openrouter.ai/api/v1/models", {
             headers: { "Authorization": `Bearer ${apiKey}` },
           });
           isValid = openrouterRes.ok;
@@ -311,7 +312,7 @@ export async function POST(request) {
 
           if (isOpenAiFormat) {
             const testModel = getDefaultModel(provider);
-            const res = await fetch(cfg.baseUrl, {
+            const res = await fetchWithTimeout(cfg.baseUrl, {
               method: "POST",
               headers: { "Authorization": `Bearer ${apiKey}`, "content-type": "application/json" },
               body: JSON.stringify({ model: testModel, max_tokens: 1, messages: [{ role: "user", content: "test" }] }),
@@ -319,7 +320,7 @@ export async function POST(request) {
             isValid = res.status !== 401 && res.status !== 403;
           } else {
             const testModel = getDefaultModel(provider) || "claude-sonnet-4-20250514";
-            const res = await fetch(cfg.baseUrl, {
+            const res = await fetchWithTimeout(cfg.baseUrl, {
               method: "POST",
               headers: {
                 "x-api-key": apiKey,
@@ -336,7 +337,7 @@ export async function POST(request) {
         }
         case "volcengine-ark":
         case "byteplus": {
-          const res = await fetch(PROVIDERS[provider]?.baseUrl, {
+          const res = await fetchWithTimeout(PROVIDERS[provider]?.baseUrl, {
             method: "POST",
             headers: {
               "Authorization": `Bearer ${apiKey}`,
@@ -382,7 +383,7 @@ export async function POST(request) {
           };
           const headers = {};
           if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
-          const res = await fetch(endpoints[provider], { headers, signal: AbortSignal.timeout(8000) });
+          const res = await fetchWithTimeout(endpoints[provider], { headers, signal: AbortSignal.timeout(8000) });
           // xai returns 400 for bad key, 403 for valid-but-no-credit. Other providers use 401.
           if (provider === "xai") {
             isValid = res.status === 200 || res.status === 403;
@@ -396,7 +397,7 @@ export async function POST(request) {
         }
 
         case "opencode-go": {
-          const res = await fetch("https://opencode.ai/zen/go/v1/chat/completions", {
+          const res = await fetchWithTimeout("https://opencode.ai/zen/go/v1/chat/completions", {
             method: "POST",
             headers: { "Content-Type": "application/json", "Authorization": `Bearer ${apiKey}` },
             body: JSON.stringify({
@@ -418,7 +419,7 @@ export async function POST(request) {
             max_tokens: 1,
             stream: false,
           }, false);
-          const res = await fetch(cfg.baseUrl, {
+          const res = await fetchWithTimeout(cfg.baseUrl, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
@@ -433,7 +434,7 @@ export async function POST(request) {
         }
 
         case "deepgram": {
-          const res = await fetch("https://api.deepgram.com/v1/projects", {
+          const res = await fetchWithTimeout("https://api.deepgram.com/v1/projects", {
             headers: { "Authorization": `Token ${apiKey}` },
           });
           isValid = res.ok;
@@ -441,7 +442,7 @@ export async function POST(request) {
         }
 
         case "blackbox": {
-          const res = await fetch("https://api.blackbox.ai/chat/completions", {
+          const res = await fetchWithTimeout("https://api.blackbox.ai/chat/completions", {
             method: "POST",
             headers: {
               "Authorization": `Bearer ${apiKey}`,
@@ -467,7 +468,7 @@ export async function POST(request) {
             isValid = !!(saJson.client_email && saJson.private_key && saJson.project_id);
           } else {
             // Raw key: probe Vertex — 404 means key is valid (model just doesn't exist), 401 means invalid key
-            const probeRes = await fetch(
+            const probeRes = await fetchWithTimeout(
               `https://aiplatform.googleapis.com/v1/publishers/google/models/__probe__:generateContent?key=${apiKey}`,
               { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" }
             );
@@ -481,7 +482,7 @@ export async function POST(request) {
           if (saJson) {
             isValid = !!(saJson.client_email && saJson.private_key && saJson.project_id);
           } else {
-            const probeRes = await fetch(
+            const probeRes = await fetchWithTimeout(
               `https://aiplatform.googleapis.com/v1/publishers/google/models/__probe__:generateContent?key=${apiKey}`,
               { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" }
             );
@@ -501,7 +502,7 @@ export async function POST(request) {
           const statsigId = Buffer.from("e:TypeError: Cannot read properties of null (reading 'children')").toString("base64");
           const traceId = randomHex(16);
           const spanId = randomHex(8);
-          const res = await fetch("https://grok.com/rest/app-chat/conversations/new", {
+          const res = await fetchWithTimeout("https://grok.com/rest/app-chat/conversations/new", {
             method: "POST",
             headers: {
               Accept: "*/*",
@@ -550,7 +551,7 @@ export async function POST(request) {
             sessionToken = sessionToken.slice("__Secure-next-auth.session-token=".length);
           }
           const tz = typeof Intl !== "undefined" ? Intl.DateTimeFormat().resolvedOptions().timeZone : "UTC";
-          const res = await fetch("https://www.perplexity.ai/rest/sse/perplexity_ask", {
+          const res = await fetchWithTimeout("https://www.perplexity.ai/rest/sse/perplexity_ask", {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
@@ -614,7 +615,7 @@ export async function POST(request) {
           const modelsUrl = cfg.baseUrl.replace(/\/chat\/completions$/, "/models").replace(/\/chatbot$/, "/models");
           let probeOk = null;
           try {
-            const probeRes = await fetch(modelsUrl, { headers, signal: AbortSignal.timeout(8000) });
+            const probeRes = await fetchWithTimeout(modelsUrl, { headers, signal: AbortSignal.timeout(8000) });
             if (probeRes.status === 401 || probeRes.status === 403) probeOk = false;
             else if (probeRes.ok) probeOk = true;
           } catch { /* fallback to chat */ }
@@ -624,7 +625,7 @@ export async function POST(request) {
           }
           // Fallback: minimal chat probe
           const defaultModel = getDefaultModel(provider) || "test";
-          const chatRes = await fetch(cfg.baseUrl, {
+          const chatRes = await fetchWithTimeout(cfg.baseUrl, {
             method: "POST",
             headers,
             body: JSON.stringify({ model: defaultModel, messages: [{ role: "user", content: "ping" }], max_tokens: 1 }),

--- a/src/lib/network/fetchWithTimeout.js
+++ b/src/lib/network/fetchWithTimeout.js
@@ -1,0 +1,31 @@
+export const DEFAULT_FETCH_TIMEOUT_MS = 10000;
+
+/**
+ * fetch() with a deadline that actually cancels the request.
+ *
+ * Racing fetch against a rejecting timer only stops the caller waiting — the
+ * socket stays open until the upstream answers, so a hung host keeps holding a
+ * connection. Aborting the controller ends the request itself.
+ *
+ * A caller that supplies its own `signal` already owns the deadline and is
+ * passed through untouched.
+ *
+ * @param {string|URL} url
+ * @param {RequestInit} [options]
+ * @param {number} [timeoutMs]
+ * @returns {Promise<Response>}
+ */
+export async function fetchWithTimeout(url, options = {}, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS) {
+  if (options?.signal) return fetch(url, options);
+
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(new Error(`Request timed out after ${timeoutMs}ms`)),
+    timeoutMs,
+  );
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/tests/unit/fetch-with-timeout.test.js
+++ b/tests/unit/fetch-with-timeout.test.js
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DEFAULT_FETCH_TIMEOUT_MS,
+  fetchWithTimeout,
+} from "../../src/lib/network/fetchWithTimeout.js";
+
+let realFetch;
+
+beforeEach(() => {
+  realFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.useRealTimers();
+});
+
+// Resolves only when the caller aborts — stands in for an upstream that accepts
+// the connection and never answers.
+function hangingFetch() {
+  const calls = [];
+  globalThis.fetch = vi.fn((url, init) => {
+    calls.push({ url, init });
+    return new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(init.signal.reason ?? new Error("aborted")));
+    });
+  });
+  return calls;
+}
+
+describe("fetchWithTimeout", () => {
+  it("aborts the request when the deadline passes, not just the wait", async () => {
+    vi.useFakeTimers();
+    const calls = hangingFetch();
+
+    const pending = fetchWithTimeout("https://example.invalid/probe", { method: "GET" }, 500);
+    const rejects = expect(pending).rejects.toThrow(/timed out after 500ms/);
+
+    expect(calls[0].init.signal.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(500);
+    await rejects;
+
+    // The point of the abort: the request itself ends, so the socket is not
+    // left open until the upstream feels like answering.
+    expect(calls[0].init.signal.aborted).toBe(true);
+  });
+
+  it("clears its timer once the response arrives", async () => {
+    vi.useFakeTimers();
+    globalThis.fetch = vi.fn(async () => new Response("ok"));
+
+    const res = await fetchWithTimeout("https://example.invalid/probe");
+    expect(res.status).toBe(200);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("clears its timer when fetch rejects", async () => {
+    vi.useFakeTimers();
+    globalThis.fetch = vi.fn(async () => { throw new Error("ECONNREFUSED"); });
+
+    await expect(fetchWithTimeout("https://example.invalid/probe")).rejects.toThrow("ECONNREFUSED");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("leaves a caller-supplied signal in charge", async () => {
+    const calls = hangingFetch();
+    const own = AbortSignal.timeout(20);
+
+    await expect(fetchWithTimeout("https://example.invalid/probe", { signal: own })).rejects.toThrow();
+    expect(calls[0].init.signal).toBe(own);
+  });
+
+  it("forwards method, headers and body unchanged", async () => {
+    globalThis.fetch = vi.fn(async () => new Response("ok"));
+    await fetchWithTimeout("https://example.invalid/probe", {
+      method: "POST",
+      headers: { "x-test": "1" },
+      body: "{}",
+    });
+
+    const init = globalThis.fetch.mock.calls[0][1];
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({ "x-test": "1" });
+    expect(init.body).toBe("{}");
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("defaults to a ten second deadline", () => {
+    expect(DEFAULT_FETCH_TIMEOUT_MS).toBe(10000);
+  });
+});
+
+// The dashboard's "test connection" buttons run these routes. A probe with no
+// deadline leaves the button spinning and the socket open for as long as the
+// upstream cares to hold it.
+describe("provider validation routes have no un-deadlined probe", () => {
+  const ROUTES = [
+    "src/app/api/providers/validate/route.js",
+    "src/app/api/provider-nodes/validate/route.js",
+  ];
+
+  it.each(ROUTES)("%s calls fetch only through fetchWithTimeout", async (rel) => {
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const { fileURLToPath } = await import("node:url");
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+    const source = fs.readFileSync(path.join(repoRoot, rel), "utf8");
+
+    const bare = [...source.matchAll(/(?<!fetchWith[A-Za-z]*)\bfetch\(/g)];
+    expect(bare.map((m) => source.slice(Math.max(0, m.index - 40), m.index + 10))).toEqual([]);
+    expect(source).toContain("fetchWithTimeout");
+  });
+});


### PR DESCRIPTION
## Problem

`src/app/api/providers/validate/route.js` is what the dashboard's **Test connection** button runs: pick a provider, hit its endpoint, decide whether the credential works. It makes 27 `fetch` calls. **Six** of them carry a deadline:

```js
const res = await fetch(url, { ..., signal: AbortSignal.timeout(8000) });   // 6 of these
```

The other 21 do not:

```js
const openaiRes = await fetch("https://api.openai.com/v1/models", { headers });
const anthropicRes = await fetch("https://api.anthropic.com/v1/messages", { ... });
const geminiRes = await fetch(`https://generativelanguage.googleapis.com/v1/models?key=${apiKey}`);
const cfRes = await fetch(url, { ... });
...
```

A host that completes the TCP handshake and then never answers — a black-holed endpoint, a wrong self-hosted base URL, a proxy that swallows the request — has no deadline at all. The button spins forever, and the socket stays open until the upstream feels like closing it.

The sibling route, `src/app/api/provider-nodes/validate/route.js`, saw the problem and wrapped its probes — but in a way that only fixes half of it:

```js
const fetchWithTimeout = (url, options, timeout = 10000) => {
  return Promise.race([
    fetch(url, options),
    new Promise((_, reject) => setTimeout(() => reject(new Error("Request timeout")), timeout)),
  ]);
};
```

Racing against a timer unblocks the caller and leaves the request running. Nothing is aborted, so the connection is still held; the timer just stops anyone waiting for it.

## Fix

One helper, in `src/lib/network/fetchWithTimeout.js`, that cancels rather than abandons:

```js
export async function fetchWithTimeout(url, options = {}, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS) {
  if (options?.signal) return fetch(url, options);   // caller owns the deadline

  const controller = new AbortController();
  const timer = setTimeout(() => controller.abort(new Error(`Request timed out after ${timeoutMs}ms`)), timeoutMs);
  try {
    return await fetch(url, { ...options, signal: controller.signal });
  } finally {
    clearTimeout(timer);
  }
}
```

- `providers/validate` — all 27 call sites go through it. The six that already pass `AbortSignal.timeout(8000)` keep their own 8s deadline via the passthrough, so no existing timing changes; the other 21 get 10s.
- `provider-nodes/validate` — the local `Promise.race` copy is deleted and the route uses the shared helper, so its probes now actually abort.

Every call site keeps its own options, method, headers and error handling; the only change is the function name and, for the 21, that there is now a deadline.

## Verification

`tests/unit/fetch-with-timeout.test.js`, 8 tests.

Behaviour, against a stubbed fetch that resolves only when aborted (an upstream that accepts and never answers):

- the deadline **aborts the request** — asserted on `init.signal.aborted`, which is what separates this from the race
- the timer is cleared when the response arrives, and when fetch rejects (`vi.getTimerCount() === 0`)
- a caller-supplied `signal` is passed straight through and stays in charge
- method, headers and body reach fetch unchanged

Plus a guard over both route files: no `fetch(` that is not `fetchWithTimeout(`. This is the same style as `security-audit.test.js`, and it is what stops the 21 from creeping back one probe at a time.

Swapping the helper body back to `Promise.race` and restoring the route:

```
FAIL  aborts the request when the deadline passes, not just the wait
FAIL  clears its timer once the response arrives
FAIL  clears its timer when fetch rejects
FAIL  forwards method, headers and body unchanged
FAIL  src/app/api/providers/validate/route.js calls fetch only through fetchWithTimeout
Tests  5 failed | 3 passed (8)
```

Full offline suite (`vitest run unit auth translator`, `CI=true`, excluding `real/`), same command on both sides:

| | tests | failed |
|---|---|---|
| `origin/master` (699edac3) | 1910 | 95 |
| this branch | 1918 | 95 |

Identical failure sets — `comm` on the sorted full test names returns nothing either way. `eslint` clean on all four files.

## What I did not change

`open-sse/services/usage/shared.js` exports its own `fetchWithTimeout`, which is proxy-aware via `proxyAwareFetch`. I deliberately did not reuse it here: routing the validation probes through the outbound proxy is a behaviour change beyond adding a deadline, and these two routes have always used plain `fetch`. Worth consolidating if you want the probes proxied, but that is a separate decision.