### PR TITLE
fix(stream): add TTFT watchdog to prevent hangs when upstream stalls before first byte

### DIFF
--- a/open-sse/config/runtimeConfig.js
+++ b/open-sse/config/runtimeConfig.js
@@ -53,7 +53,7 @@ export const SEARXNG_URL = envUrl("SEARXNG_URL", "http://localhost:8888/search")
 export const STREAM_STALL_TIMEOUT_MS = envMs("STREAM_STALL_TIMEOUT_MS", 360 * 1000);
 
 // Time-to-first-token timeout (prompt prefill). Env: STREAM_FIRST_CHUNK_TIMEOUT_MS.
-export const STREAM_FIRST_CHUNK_TIMEOUT_MS = envMs("STREAM_FIRST_CHUNK_TIMEOUT_MS", 200 * 1000);
+export const STREAM_FIRST_CHUNK_TIMEOUT_MS = envMs("STREAM_FIRST_CHUNK_TIMEOUT_MS", 30000);
 
 // Fetch connect timeout: abort if upstream doesn't return response headers within this duration
 export const FETCH_CONNECT_TIMEOUT_MS = envMs("FETCH_CONNECT_TIMEOUT_MS", 60 * 1000);

--- a/open-sse/utils/streamHandler.js
+++ b/open-sse/utils/streamHandler.js
@@ -1,5 +1,5 @@
 // Stream handler with disconnect detection - shared for all providers
-import { STREAM_STALL_TIMEOUT_MS } from "../config/runtimeConfig.js";
+import { STREAM_STALL_TIMEOUT_MS, STREAM_FIRST_CHUNK_TIMEOUT_MS } from "../config/runtimeConfig.js";
 import { dbg, isDebugEnabled } from "./debugLog.js";
 
 // Get HH:MM:SS timestamp
@@ -188,13 +188,32 @@ export function createDisconnectAwareStream(transformStream, streamController, o
  * @param {TransformStream} transformStream - Transform stream for SSE
  * @param {object} streamController - Stream controller from createStreamController
  */
-export function pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal = null, stallTimeoutMs = STREAM_STALL_TIMEOUT_MS) {
+export function pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal = null, stallTimeoutMs = STREAM_STALL_TIMEOUT_MS, ttftTimeoutMs = STREAM_FIRST_CHUNK_TIMEOUT_MS) {
   let stallTimer = null;
+  let firstChunkTimer = null;
   let chunkCount = 0;
   let totalBytes = 0;
   let lastChunkAt = Date.now();
   const t0 = Date.now();
   const tag = "STREAM";
+
+  // TTFT watchdog: if no upstream bytes arrive within the TTFT window, abort.
+  // Fires only once; cleared by the first upstream byte (or any termination).
+  // Separate from the inter-chunk stall watchdog so slow-but-healthy streams
+  // (e.g. reasoning models with long prefill) are never falsely aborted.
+  const clearFirstChunk = () => {
+    if (firstChunkTimer) { clearTimeout(firstChunkTimer); firstChunkTimer = null; }
+  };
+  const armFirstChunk = () => {
+    clearFirstChunk();
+    firstChunkTimer = setTimeout(() => {
+      firstChunkTimer = null;
+      dbg(tag, `TTFT TIMEOUT ${ttftTimeoutMs}ms | no bytes received`);
+      streamController.handleError?.(new Error(`stream ttft timeout (${ttftTimeoutMs}ms)`));
+      streamController.abort?.();
+    }, ttftTimeoutMs);
+  };
+
   const clearStall = () => {
     if (stallTimer) { clearTimeout(stallTimer); stallTimer = null; }
   };
@@ -208,21 +227,22 @@ export function pipeWithDisconnect(providerResponse, transformStream, streamCont
     }, stallTimeoutMs);
   };
 
-  // Wrap controller so every termination path clears the stall timer.
-  // Without this, abort/cancel/downstream-error paths leave the timer armed
+  // Wrap controller so every termination path clears both timers.
+  // Without this, abort/cancel/downstream-error paths leave the timers armed
   // and a stale abort could fire after the request has already ended.
   const wrappedController = {
     signal: streamController.signal,
     startTime: streamController.startTime,
     isConnected: () => streamController.isConnected(),
-    handleComplete: () => { dbg(tag, `complete | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); streamController.handleComplete(); },
-    handleError: (e) => { dbg(tag, `error: ${e?.message} | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); streamController.handleError(e); },
-    handleDisconnect: (r) => { dbg(tag, `disconnect: ${r} | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); streamController.handleDisconnect(r); },
-    abort: () => { clearStall(); streamController.abort(); }
+    handleComplete: () => { dbg(tag, `complete | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearFirstChunk(); clearStall(); streamController.handleComplete(); },
+    handleError: (e) => { dbg(tag, `error: ${e?.message} | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearFirstChunk(); clearStall(); streamController.handleError(e); },
+    handleDisconnect: (r) => { dbg(tag, `disconnect: ${r} | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearFirstChunk(); clearStall(); streamController.handleDisconnect(r); },
+    abort: () => { clearFirstChunk(); clearStall(); streamController.abort(); }
   };
 
+  armFirstChunk();
   armStall();
-  dbg(tag, `pipe start | stallTimeout=${stallTimeoutMs}ms`);
+  dbg(tag, `pipe start | ttftTimeout=${ttftTimeoutMs}ms | stallTimeout=${stallTimeoutMs}ms`);
 
   const upstreamTap = new TransformStream({
     transform(chunk, controller) {
@@ -235,6 +255,7 @@ export function pipeWithDisconnect(providerResponse, transformStream, streamCont
       if (isDebugEnabled && (chunkCount <= 5 || chunkCount % 20 === 0 || gap > 5000)) {
         dbg(tag, `chunk #${chunkCount} | size=${sz}B | gap=${gap}ms | total=${totalBytes}B`);
       }
+      clearFirstChunk(); // first byte received — TTFT watchdog satisfied
       armStall();
       controller.enqueue(chunk);
     },


### PR DESCRIPTION
## Summary

Adds a first-byte-arrival (TTFT) watchdog to `pipeWithDisconnect` in `open-sse/utils/streamHandler.js`, wiring the previously-declared-but-unused `STREAM_FIRST_CHUNK_TIMEOUT_MS` constant.

## Problem

Currently, `pipeWithDisconnect` arms a single stall watchdog (`STREAM_STALL_TIMEOUT_MS = 360s`) that is reset by every arriving upstream byte. If the upstream provider *accepts* the TCP/TLS connection and returns response headers but then never emits the first SSE byte (prefill stall / hung request), the request hangs for up to 360s before the stall watchdog fires — effectively a silent hang from the client's perspective.

`FETCH_CONNECT_TIMEOUT_MS` (60s, in `base.js`) already guards the TCP/TLS/response-headers phase, but there is no guard for the gap between headers and first byte.

`STREAM_FIRST_CHUNK_TIMEOUT_MS` (200s default) was declared in `runtimeConfig.js` but had **zero usages** across the repo.

Observed real-world impact: opencode.ai zen/go/v1 route occasionally accepts a request but never emits the first byte for slow-prefill scenarios. Downstream agent clients see this as a truncated / silent response.

## Change

- **`open-sse/utils/streamHandler.js`**: `pipeWithDisconnect` now arms a **separate** `firstChunkTimer` alongside the existing `stallTimer`.
  - `firstChunkTimer` is cleared by the first upstream byte and by every termination path (complete/error/disconnect/abort).
  - If it fires, it invokes `streamController.handleError(new Error('stream ttft timeout (N ms)'))` + `streamController.abort()`, matching the existing stall-timeout code path — so the abort flows through the exact same error surfacing (structured SSE terminal via #3222's tracker, non-stream 502 via `errorResponse`).
- **`open-sse/config/runtimeConfig.js`**: reduces the default `STREAM_FIRST_CHUNK_TIMEOUT_MS` from 200s → 30s. The intent of a TTFT guard is to fail fast on hung upstreams; 200s is longer than most agent SDK client timeouts and would rarely be triggered. Still fully overridable via env var.

## Design notes

- Two-phase / separate timer (not shared): a slow-but-healthy stream (reasoning model with long prefill, then bursty output) must NOT trip the TTFT guard once bytes arrive. Reusing the stall watchdog for TTFT would either force a very long stall timeout or falsely abort long inter-chunk silences.
- Uses `streamController.handleError` + `abort`, so error propagation, terminal synthesis (compatible with the tracker from #3222), and abort-controller wiring are all reused unchanged.
- Backward-compatible signature: new `ttftTimeoutMs` parameter defaulted to `STREAM_FIRST_CHUNK_TIMEOUT_MS`, so all existing callers pick up the guard automatically.

## Testing

- Compiled clean (module imports resolve).
- Existing `streamTerminal.test.js` covers the tracker path this feeds into.
- Manual verification against the observed hang scenario (opencode.ai zen route) will follow deployment.

## Related

- Complements #3222 (@haumanto): #3222 handles mid-stream EOF-without-terminal; this handles pre-stream TTFT hang. Together they close both silent-truncation surfaces.