### PR TITLE
fix(groq): replace decommissioned models, add modelsFetcher

### DIFF
--- a/open-sse/providers/registry/groq.js
+++ b/open-sse/providers/registry/groq.js
@@ -19,10 +19,13 @@ export default {
     validateUrl: "https://api.groq.com/openai/v1/models",
   },
   models: [
-    { id: "llama-3.3-70b-versatile", name: "Llama 3.3 70B" },
-    { id: "meta-llama/llama-4-maverick-17b-128e-instruct", name: "Llama 4 Maverick" },
-    { id: "qwen/qwen3-32b", name: "Qwen3 32B" },
     { id: "openai/gpt-oss-120b", name: "GPT-OSS 120B" },
+    { id: "openai/gpt-oss-20b", name: "GPT-OSS 20B" },
+    { id: "openai/gpt-oss-safeguard-20b", name: "GPT-OSS Safeguard 20B" },
+    { id: "qwen/qwen3.6-27b", name: "Qwen3.6 27B" },
+    { id: "groq/compound", name: "Compound" },
+    { id: "groq/compound-mini", name: "Compound Mini" },
+    { id: "allam-2-7b", name: "Allam 2 7B" },
     { id: "whisper-large-v3", name: "Whisper Large v3", params: ["language","response_format","temperature","prompt"], kind: "stt" },
     { id: "whisper-large-v3-turbo", name: "Whisper Large v3 Turbo", params: ["language","response_format","temperature","prompt"], kind: "stt" },
     { id: "distil-whisper-large-v3-en", name: "Distil Whisper Large v3 EN", params: ["language","response_format","temperature","prompt"], kind: "stt" },
@@ -34,4 +37,6 @@ export default {
     authHeader: "bearer",
     format: "openai",
   },
+  modelsFetcher: { url: "https://api.groq.com/openai/v1/models", type: "openai" },
+  passthroughModels: true,
 };


### PR DESCRIPTION
## Problem

Groq has decommissioned three of the four LLM ids in `open-sse/providers/registry/groq.js`:

| model id | deprecated |
|---|---|
| `meta-llama/llama-4-maverick-17b-128e-instruct` | 2026-03-09 |
| `qwen/qwen3-32b` | 2026-07-17 |
| `llama-3.3-70b-versatile` | 2026-08-16 |

All three now return `404 model_not_found`, so 3 of the 4 advertised Groq LLMs fail out of the box. Only `openai/gpt-oss-120b` still works.

Verified against a live deployment (v0.5.55):

```
openai/gpt-oss-120b       200
llama-3.3-70b-versatile   404  The model `llama-3.3-70b-versatile` does not exist or you do not have access to it.
qwen/qwen3-32b            404
llama-4-maverick-...      404
```

## The 404 turns into a hang

Worth flagging separately, since it amplifies the above considerably.

`ERROR_RULES` in `open-sse/config/errorConfig.js` maps 404 to `COOLDOWN.long` (2 min):

```js
{ status: 404, cooldownMs: COOLDOWN.long },
```

`checkFallbackError()` in `open-sse/services/accountFallback.js` returns `shouldFallback: true` on every branch — no path returns false. So the uncapped `while (true)` in `handleSingleModelChat()` walks *every* configured Groq connection, stamps a 120s `modelLock_<model>` on each, and only then returns 503:

```
⚠️ [AUTH] groq | all 137 accounts locked for llama-3.3-70b-versatile (reset after 1m 48s)
```

An 80ms upstream 404 becomes a 15s–120s+ hang, and every Groq connection shows `testStatus: "unavailable"` in the dashboard in the meantime. A permanent `model_not_found` arguably shouldn't rotate keys at all — happy to open a separate issue for that if you'd prefer it tracked apart from this catalog fix.

## Changes

1. Replace the three dead ids with models verified live against `api.groq.com`. Every added id was smoke-tested through a real deployment and returned HTTP 200 — none are taken from docs alone.
2. Add `modelsFetcher` + `passthroughModels` so the Groq catalog self-updates, matching what `openrouter`, `venice` and `perplexity-agent` already do. `type: "openai"` is the same shape venice and perplexity-agent use.

Without a `modelsFetcher`, groq's list can only go stale again — this entry hasn't been content-updated since the June 2026 registry split.

## Notes

- `groq/compound` and `groq/compound-mini` are upstream-prefixed ids, so the registry id keeps the `groq/` prefix and clients address them as `groq/groq/compound`. Confirmed 200 in that form; the un-prefixed `compound` returns 404.
- Whisper `stt` entries left untouched — they can't be exercised via `/v1/chat/completions`, so I have no evidence either way and didn't want to churn what I couldn't verify.
- Left out `meta-llama/llama-guard-4-12b`, `llama-guard-3-8b`, `deepseek-r1-distill-llama-70b`: these timed out rather than returning a clean status, which is what the key-rotation storm looks like from outside. Probably dead, but not confirmed, so not listed. With `passthroughModels: true` an omission costs nothing, whereas a wrong entry re-creates this bug.
