### PR TITLE
fix(combo): fail over on empty-but-successful streams (#3463)

### DIFF
--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -5,6 +5,7 @@
 import { checkFallbackError, formatRetryAfter } from "./accountFallback.js";
 import { unavailableResponse } from "../utils/error.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
+import { STREAM_FIRST_CHUNK_TIMEOUT_MS } from "../config/runtimeConfig.js";
 import { extractTextContent } from "../translator/formats/gemini.js";
 
 // Hard capabilities = input modalities; missing one drops request data (e.g. image
@@ -14,6 +15,198 @@ const HARD_CAPS = new Set(["vision", "pdf", "audioInput", "videoInput"]);
 // Prefixes used when flattening tool turns into plain prose for panel models.
 const TOOL_CALL_PREFIX = "[Called tools: ";
 const TOOL_RESULT_PREFIX = "[Tool result: ";
+
+// Content types whose bodies the empty-stream guard is allowed to touch.
+// combo.js is shared with tts/search/image/fetch, whose 200s are audio, images
+// or plain JSON — reading those would consume a body the caller still needs.
+const SSE_CONTENT_TYPE = "text/event-stream";
+
+// Byte budget for the empty-stream peek. Bounds how much of a chatty
+// non-content stream is buffered for replay before the guard gives up and
+// passes the stream through. 256 KiB is far above any real preamble.
+const PEEK_MAX_BYTES = 256 * 1024;
+
+// Does an SSE data frame carry output the client can actually render or act on?
+//
+// Deliberately stricter than "is this frame well-formed": role announcements,
+// finish_reason, message envelopes and zero-token usage frames are all things a
+// provider emits *around* an answer. A stream made only of those is precisely
+// the empty stream #3463 is about, so none of them count as content on their own.
+function frameCarriesContent(line) {
+  if (!line.startsWith("data:")) return false;
+  const payload = line.slice(5).trim();
+  if (!payload || payload === "[DONE]") return false;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(payload);
+  } catch {
+    return false;
+  }
+
+  // A usage frame counts only if it reports generated output. A frame carrying
+  // prompt tokens and completion_tokens: 0 is an accounting record, not an answer.
+  if (hasOutputTokens(parsed.usage) || hasOutputTokens(parsed.response?.usage)) return true;
+
+  // OpenAI chat: text, reasoning, or a tool call.
+  const delta = parsed.choices?.[0]?.delta;
+  if (nonEmptyString(delta?.content)) return true;
+  if (nonEmptyString(delta?.reasoning_content) || nonEmptyString(delta?.reasoning)) return true;
+  if (delta?.tool_calls?.length || delta?.function_call) return true;
+
+  // Claude: only the delta events carry payload. message_start/content_block_start
+  // are envelopes; a tool_use block start is the exception, since the tool name
+  // arrives there and the arguments follow as input_json_delta.
+  if (parsed.type === "content_block_delta") {
+    const d = parsed.delta;
+    if (nonEmptyString(d?.text) || nonEmptyString(d?.partial_json) || nonEmptyString(d?.thinking)) return true;
+  }
+  if (parsed.type === "content_block_start" && parsed.content_block?.type === "tool_use") return true;
+
+  // OpenAI Responses API: output_text/function-call argument deltas.
+  if (typeof parsed.type === "string" && parsed.type.endsWith(".delta") && nonEmptyString(parsed.delta)) return true;
+
+  // Gemini: a candidate with a part that actually holds something.
+  const parts = parsed.candidates?.[0]?.content?.parts;
+  if (Array.isArray(parts) && parts.some(p => nonEmptyString(p?.text) || p?.functionCall || p?.inlineData)) return true;
+
+  // Ollama NDJSON.
+  if (nonEmptyString(parsed.message?.content) || nonEmptyString(parsed.response)) return true;
+  if (parsed.message?.tool_calls?.length) return true;
+
+  return false;
+}
+
+function nonEmptyString(v) {
+  return typeof v === "string" && v.length > 0;
+}
+
+// Usage is proof of an answer only when it reports generated tokens. Mirrors the
+// completion/output-token check rather than accepting any usage object, so a
+// prompt-tokens-only record is not mistaken for output.
+function hasOutputTokens(usage) {
+  if (!usage || typeof usage !== "object") return false;
+  const n = Number(
+    usage.completion_tokens ?? usage.output_tokens ?? usage.candidatesTokenCount ?? 0
+  );
+  return Number.isFinite(n) && n > 0;
+}
+
+/**
+ * Read a streaming provider response until the first frame that carries content.
+ *
+ * A provider can return HTTP 200, open an SSE stream, emit only comments or
+ * keepalives, and close cleanly. Deciding success from status alone hands that
+ * unusable stream to the client and skips the remaining combo models (#3463).
+ *
+ * Returns { hasContent, body }. When content is found, `body` replays every byte
+ * already pulled off the socket and then continues from the live reader, so
+ * nothing is dropped — the same re-assembly qoder.js and codex.js use for their
+ * own first-frame peeks. Non-SSE responses are reported as content without the
+ * body being touched at all.
+ *
+ * The wait is bounded by STREAM_FIRST_CHUNK_TIMEOUT_MS: an upstream that streams
+ * keepalives indefinitely is reported as having no content, so the combo moves on
+ * instead of blocking here forever.
+ */
+async function peekStreamForContent(response, timeoutMs = STREAM_FIRST_CHUNK_TIMEOUT_MS) {
+  const contentType = (response.headers.get("content-type") || "").toLowerCase();
+  if (!contentType.includes(SSE_CONTENT_TYPE) || !response.body) {
+    return { hasContent: true, body: null };
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: false });
+  // Raw chunks are what gets replayed. Decoded text is used only for scanning:
+  // re-encoding decoded text would rewrite any byte upstream sent that is not
+  // valid UTF-8 into U+FFFD and corrupt the client's stream.
+  const rawChunks = [];
+  let rawBytes = 0;
+  let pending = "";
+  let hasContent = false;
+  let upstreamDone = false;
+
+  const deadline = Date.now() + timeoutMs;
+  let timer = null;
+  const expiry = new Promise(resolve => {
+    timer = setTimeout(() => resolve({ timedOut: true }), timeoutMs);
+  });
+
+  try {
+    while (!hasContent) {
+      if (Date.now() >= deadline) break;
+      // Race the read against the deadline so a keepalive-only stream cannot pin
+      // this loop open; whichever settles first decides.
+      const next = await Promise.race([reader.read(), expiry]);
+      if (next?.timedOut) break;
+
+      const { done, value } = next;
+      if (done) {
+        upstreamDone = true;
+        // A frame may sit in the tail without a trailing newline.
+        pending += decoder.decode();
+        if (pending.trim() && frameCarriesContent(pending.trim())) hasContent = true;
+        break;
+      }
+
+      rawChunks.push(value);
+      rawBytes += value.byteLength;
+      pending += decoder.decode(value, { stream: true });
+
+      // Only scan complete lines; a JSON frame split across chunks must not be
+      // judged on its first half.
+      let newline;
+      while ((newline = pending.indexOf("\n")) !== -1) {
+        const line = pending.slice(0, newline).trim();
+        pending = pending.slice(newline + 1);
+        if (frameCarriesContent(line)) { hasContent = true; break; }
+      }
+      if (hasContent) break;
+
+      // A provider can stream non-content frames at line rate. Without a byte
+      // budget the buffer would grow for the whole timeout window, so stop
+      // buffering and hand the stream over rather than risk the heap. Deciding
+      // in the client's favour: a chatty stream is passed through, not failed.
+      if (rawBytes >= PEEK_MAX_BYTES) {
+        hasContent = true;
+        break;
+      }
+    }
+  } catch {
+    // Treat a read failure as no content so the combo can try the next model.
+    hasContent = false;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+
+  if (!hasContent) {
+    await reader.cancel().catch(() => {});
+    return { hasContent: false, body: null };
+  }
+
+  const body = new ReadableStream({
+    start(controller) {
+      for (const chunk of rawChunks) controller.enqueue(chunk);
+      rawChunks.length = 0;
+      if (upstreamDone) controller.close();
+    },
+    async pull(controller) {
+      if (upstreamDone) return;
+      try {
+        const { done, value } = await reader.read();
+        if (done) { upstreamDone = true; controller.close(); return; }
+        controller.enqueue(value);
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+    cancel(reason) {
+      reader.cancel(reason).catch(() => {});
+    }
+  });
+
+  return { hasContent: true, body };
+}
 
 // Flatten tool turns into prose so panel models keep the context but can't loop
 // on tools: drop the request's tools, turn tool/function results into assistant
@@ -304,10 +497,25 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
     try {
       const result = await handleSingleModel(body, modelStr);
       
-      // Success (2xx) - return response
+      // Success (2xx) — but a 200 is not proof of a usable answer. A provider can
+      // open an SSE stream, send nothing but keepalives and close cleanly; that
+      // must fall through to the next model rather than be handed to the client.
       if (result.ok) {
-        log.info("COMBO", `Model ${modelStr} succeeded`);
-        return result;
+        const { hasContent, body: replayBody } = await peekStreamForContent(result);
+        if (hasContent) {
+          log.info("COMBO", `Model ${modelStr} succeeded`);
+          if (!replayBody) return result;
+          return new Response(replayBody, {
+            status: result.status,
+            statusText: result.statusText,
+            headers: result.headers,
+          });
+        }
+
+        lastError = "provider returned an empty stream";
+        if (!lastStatus) lastStatus = 503;
+        log.warn("COMBO", `Model ${modelStr} returned an empty stream, trying next`);
+        continue;
       }
 
       // Extract error info from response

--- a/tests/unit/combo-empty-stream-3463.test.js
+++ b/tests/unit/combo-empty-stream-3463.test.js
@@ -1,0 +1,341 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import { handleComboChat, resetComboRotation } from "../../open-sse/services/combo.js";
+
+const encoder = new TextEncoder();
+const silentLog = { info() {}, warn() {}, error() {}, debug() {} };
+
+// Build a provider Response whose body emits the given raw SSE chunks then closes
+// cleanly. Status is 200 throughout: the whole point of #3463 is that the HTTP
+// layer reports success while the payload carries nothing usable.
+function sseResponse(chunks, { contentType = "text/event-stream" } = {}) {
+  const body = new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+  return new Response(body, { status: 200, headers: { "Content-Type": contentType } });
+}
+
+function jsonResponse(payload) {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// Run a two-model fallback combo, recording which models were actually attempted.
+// `consume: false` leaves the body unread so a test can assert on bodyUsed.
+async function runCombo(responders, { models = ["p1/first", "p2/second"], consume = true } = {}) {
+  const attempted = [];
+  const response = await handleComboChat({
+    body: { model: "combo", stream: true, messages: [{ role: "user", content: "hi" }] },
+    models,
+    handleSingleModel: async (_body, modelStr) => {
+      attempted.push(modelStr);
+      return responders[modelStr]();
+    },
+    log: silentLog,
+    comboName: "combo",
+    comboStrategy: "fallback",
+  });
+  return { attempted, response, text: consume ? await response.text() : null };
+}
+
+describe("combo failover on empty-but-successful streams (#3463)", () => {
+  beforeEach(() => {
+    resetComboRotation();
+  });
+
+  it("falls over when the first model returns HTTP 200 with zero meaningful frames", async () => {
+    const { attempted, text } = await runCombo({
+      "p1/first": () => sseResponse([": keepalive\n\n"]),
+      "p2/second": () => sseResponse(['data: {"choices":[{"delta":{"content":"real answer"}}]}\n\n']),
+    });
+
+    expect(attempted).toEqual(["p1/first", "p2/second"]);
+    expect(text).toContain("real answer");
+  });
+
+  it("falls over when the stream closes without sending a single byte", async () => {
+    const { attempted, text } = await runCombo({
+      "p1/first": () => sseResponse([]),
+      "p2/second": () => sseResponse(['data: {"choices":[{"delta":{"content":"second model"}}]}\n\n']),
+    });
+
+    expect(attempted).toEqual(["p1/first", "p2/second"]);
+    expect(text).toContain("second model");
+  });
+
+  it("treats a stream carrying only [DONE] as a failure", async () => {
+    const { attempted, text } = await runCombo({
+      "p1/first": () => sseResponse(["data: [DONE]\n\n"]),
+      "p2/second": () => sseResponse(['data: {"choices":[{"delta":{"content":"after done"}}]}\n\n']),
+    });
+
+    expect(attempted).toEqual(["p1/first", "p2/second"]);
+    expect(text).toContain("after done");
+  });
+
+  it("reports 503 when every combo model returns an empty stream", async () => {
+    const { attempted, response } = await runCombo({
+      "p1/first": () => sseResponse([": ping\n\n"]),
+      "p2/second": () => sseResponse([]),
+    });
+
+    expect(attempted).toEqual(["p1/first", "p2/second"]);
+    expect(response.status).toBe(503);
+  });
+
+  it("returns the first model untouched when it does send content", async () => {
+    const { attempted, text } = await runCombo({
+      "p1/first": () => sseResponse(['data: {"choices":[{"delta":{"content":"first wins"}}]}\n\n']),
+      "p2/second": () => sseResponse(['data: {"choices":[{"delta":{"content":"must not run"}}]}\n\n']),
+    });
+
+    expect(attempted).toEqual(["p1/first"]);
+    expect(text).toContain("first wins");
+    expect(text).not.toContain("must not run");
+  });
+
+  it("preserves a frame split across two network chunks", async () => {
+    const { attempted, text } = await runCombo({
+      // A naive peek that decodes per-chunk would corrupt or drop this frame.
+      "p1/first": () => sseResponse(['data: {"choi', 'ces":[{"delta":{"content":"split frame"}}]}\n\n']),
+      "p2/second": () => sseResponse(['data: {"choices":[{"delta":{"content":"fallback"}}]}\n\n']),
+    });
+
+    expect(attempted).toEqual(["p1/first"]);
+    expect(text).toContain("split frame");
+    expect(text).not.toContain("fallback");
+  });
+
+  it("replays every byte, including frames that precede the first meaningful one", async () => {
+    const { text } = await runCombo({
+      "p1/first": () => sseResponse([
+        ": warmup\n\n",
+        'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"body text"}}]}\n\n',
+        "data: [DONE]\n\n",
+      ]),
+      "p2/second": () => sseResponse([]),
+    });
+
+    expect(text).toContain(": warmup");
+    expect(text).toContain('"role":"assistant"');
+    expect(text).toContain("body text");
+    expect(text).toContain("[DONE]");
+  });
+
+  // Regression guard for the review finding: a stream made only of envelope
+  // frames is the #3463 bug, so none of these may count as content.
+  it.each([
+    ["role + finish_reason only", [
+      'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\n',
+      'data: {"choices":[{"finish_reason":"stop"}]}\n\n',
+      "data: [DONE]\n\n",
+    ]],
+    ["empty-string content delta", [
+      'data: {"choices":[{"delta":{"content":""}}]}\n\n',
+      "data: [DONE]\n\n",
+    ]],
+    ["empty tool_calls array", [
+      'data: {"choices":[{"delta":{"tool_calls":[]}}]}\n\n',
+      "data: [DONE]\n\n",
+    ]],
+    ["claude message_start envelope only", [
+      'data: {"type":"message_start","message":{"id":"m1","content":[]}}\n\n',
+      'data: {"type":"message_stop"}\n\n',
+    ]],
+    ["claude content_block_start text envelope only", [
+      'data: {"type":"content_block_start","content_block":{"type":"text","text":""}}\n\n',
+    ]],
+    ["usage frame reporting zero output tokens", [
+      'data: {"usage":{"prompt_tokens":12,"completion_tokens":0}}\n\n',
+      "data: [DONE]\n\n",
+    ]],
+    ["gemini candidate with no parts", [
+      'data: {"candidates":[{"content":{"parts":[]}}]}\n\n',
+    ]],
+    ["gemini candidate with empty text part", [
+      'data: {"candidates":[{"content":{"parts":[{"text":""}]}}]}\n\n',
+    ]],
+  ])("fails over on a metadata-only stream: %s", async (_name, frames) => {
+    const { attempted, text } = await runCombo({
+      "p1/first": () => sseResponse(frames),
+      "p2/second": () => sseResponse(['data: {"choices":[{"delta":{"content":"rescued"}}]}\n\n']),
+    });
+
+    expect(attempted).toEqual(["p1/first", "p2/second"]);
+    expect(text).toContain("rescued");
+  });
+
+  // Shapes that genuinely carry output must never trigger failover.
+  it.each([
+    ["reasoning-only delta", 'data: {"choices":[{"delta":{"reasoning_content":"thinking"}}]}\n\n'],
+    ["claude text_delta", 'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}\n\n'],
+    ["claude tool_use block start", 'data: {"type":"content_block_start","content_block":{"type":"tool_use","name":"ls"}}\n\n'],
+    ["claude input_json_delta", 'data: {"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{\\"a\\":1}"}}\n\n'],
+    ["responses output_text delta", 'data: {"type":"response.output_text.delta","delta":"token"}\n\n'],
+    ["gemini text part", 'data: {"candidates":[{"content":{"parts":[{"text":"gem"}]}}]}\n\n'],
+    ["gemini functionCall part", 'data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"f"}}]}}]}\n\n'],
+    ["ollama message content", 'data: {"message":{"content":"olla"}}\n\n'],
+    ["usage with output tokens", 'data: {"usage":{"prompt_tokens":5,"completion_tokens":9}}\n\n'],
+  ])("accepts a stream whose only frame is %s", async (_name, frame) => {
+    const { attempted } = await runCombo({
+      "p1/first": () => sseResponse([frame]),
+      "p2/second": () => sseResponse(['data: {"choices":[{"delta":{"content":"must not run"}}]}\n\n']),
+    });
+
+    expect(attempted).toEqual(["p1/first"]);
+  });
+
+  it("replays upstream bytes verbatim when the preamble is not valid UTF-8", async () => {
+    // Decoding to a string and re-encoding would rewrite these bytes to U+FFFD.
+    // The client must receive exactly what upstream sent.
+    const invalidPreamble = new Uint8Array([0x3a, 0x20, 0xff, 0xfe, 0x0a, 0x0a]);
+    const contentFrame = encoder.encode('data: {"choices":[{"delta":{"content":"ok"}}]}\n\n');
+    const raw = new Uint8Array([...invalidPreamble, ...contentFrame]);
+
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(invalidPreamble);
+        controller.enqueue(contentFrame);
+        controller.close();
+      },
+    });
+
+    const response = await handleComboChat({
+      body: { model: "combo", stream: true, messages: [{ role: "user", content: "hi" }] },
+      models: ["p1/first", "p2/second"],
+      handleSingleModel: async () => new Response(body, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+      log: silentLog,
+      comboName: "combo",
+      comboStrategy: "fallback",
+    });
+
+    const received = new Uint8Array(await response.arrayBuffer());
+    expect(Array.from(received)).toEqual(Array.from(raw));
+  });
+
+  it("passes the stream through once the peek byte budget is exhausted", async () => {
+    // A provider that streams non-content frames forever must not be buffered
+    // without bound; past the budget the guard stops holding bytes.
+    const filler = `: ${"x".repeat(8 * 1024)}\n\n`;
+    const chunks = Array.from({ length: 48 }, () => filler);
+
+    const { attempted, text } = await runCombo({
+      "p1/first": () => sseResponse(chunks),
+      "p2/second": () => sseResponse(['data: {"choices":[{"delta":{"content":"must not run"}}]}\n\n']),
+    });
+
+    expect(attempted).toEqual(["p1/first"]);
+    // Everything buffered before the cap is still replayed: no silent byte loss.
+    expect(text.length).toBe(filler.length * chunks.length);
+    expect(text).not.toContain("must not run");
+  });
+
+  it("accepts a tool-call-only stream as meaningful", async () => {
+    const { attempted, text } = await runCombo({
+      "p1/first": () => sseResponse([
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"ls"}}]}}]}\n\n',
+      ]),
+      "p2/second": () => sseResponse(['data: {"choices":[{"delta":{"content":"fallback"}}]}\n\n']),
+    });
+
+    expect(attempted).toEqual(["p1/first"]);
+    expect(text).toContain("tool_calls");
+  });
+
+  it("accepts a Claude-format content block as meaningful", async () => {
+    const { attempted, text } = await runCombo({
+      "p1/first": () => sseResponse([
+        'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"text_delta","text":"claude text"}}\n\n',
+      ]),
+      "p2/second": () => sseResponse(['data: {"choices":[{"delta":{"content":"fallback"}}]}\n\n']),
+    });
+
+    expect(attempted).toEqual(["p1/first"]);
+    expect(text).toContain("claude text");
+  });
+
+  it("leaves non-SSE responses alone so tts/search/image combos are unaffected", async () => {
+    // Guard must not read audio/image/JSON bodies. An empty JSON object is a
+    // legitimate 200 for those callers and must pass straight through.
+    const { attempted, text } = await runCombo({
+      "p1/first": () => jsonResponse({}),
+      "p2/second": () => jsonResponse({ should: "not run" }),
+    });
+
+    expect(attempted).toEqual(["p1/first"]);
+    expect(text).toBe("{}");
+  });
+
+  it("does not consume a non-stream JSON completion body", async () => {
+    const { attempted, response } = await runCombo({
+      "p1/first": () => jsonResponse({ choices: [{ message: { content: "json answer" } }] }),
+      "p2/second": () => jsonResponse({ should: "not run" }),
+    }, { consume: false });
+
+    expect(attempted).toEqual(["p1/first"]);
+    // bodyUsed must still be false: the guard skipped it entirely.
+    expect(response.bodyUsed).toBe(false);
+    await expect(response.json()).resolves.toMatchObject({
+      choices: [{ message: { content: "json answer" } }],
+    });
+  });
+});
+
+describe("combo empty-stream guard is time-bounded (#3463)", () => {
+  it("gives up on a keepalive-only stream instead of blocking forever", async () => {
+    // A stream that never closes and never sends content: without a deadline the
+    // guard would await the first content frame indefinitely.
+    vi.resetModules();
+    process.env.STREAM_FIRST_CHUNK_TIMEOUT_MS = "150";
+    try {
+      const { handleComboChat: freshCombo } = await import("../../open-sse/services/combo.js");
+
+      let keepAliveTimer = null;
+      const neverEnding = new Response(
+        new ReadableStream({
+          start(controller) {
+            keepAliveTimer = setInterval(() => {
+              try { controller.enqueue(encoder.encode(": ping\n\n")); } catch { /* closed */ }
+            }, 10);
+          },
+          cancel() { clearInterval(keepAliveTimer); },
+        }),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } },
+      );
+
+      const attempted = [];
+      const started = Date.now();
+      const response = await freshCombo({
+        body: { model: "combo", stream: true, messages: [{ role: "user", content: "hi" }] },
+        models: ["p1/hang", "p2/second"],
+        handleSingleModel: async (_body, modelStr) => {
+          attempted.push(modelStr);
+          if (modelStr === "p1/hang") return neverEnding;
+          return sseResponse(['data: {"choices":[{"delta":{"content":"rescued"}}]}\n\n']);
+        },
+        log: silentLog,
+        comboName: "combo",
+        comboStrategy: "fallback",
+      });
+      const elapsed = Date.now() - started;
+      clearInterval(keepAliveTimer);
+
+      expect(attempted).toEqual(["p1/hang", "p2/second"]);
+      expect(await response.text()).toContain("rescued");
+      // Proves the deadline fired rather than the stream ending on its own.
+      expect(elapsed).toBeLessThan(3000);
+    } finally {
+      delete process.env.STREAM_FIRST_CHUNK_TIMEOUT_MS;
+      vi.resetModules();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The combo failover loop decides success from HTTP status alone (`open-sse/services/combo.js`, the `if (result.ok) return result;` branch). When a provider returns **HTTP 200, opens an SSE stream, emits only comments/keepalives and closes cleanly**, the model is marked `succeeded`: the unusable stream is handed to the client and the remaining combo models are never tried.

Reproduced against the real module before changing anything — model 1 sends one keepalive comment, model 2 has a valid answer:

```
models tried: [ 'p1/empty' ]
status: 200
body received by client: ": keepalive\n\n"
client got any content frame: false
```

Model 2 was never called.

## Why the existing stall watchdog cannot cover this

Ordering. `pipeWithDisconnect` arms its watchdog, then `handleStreamingResponse` wraps the result in a `Response` and returns. By the time any stall fires, `combo.js` has already returned — an abort can close the connection but never re-enter the model loop.

## Fix

`peekStreamForContent` reads until the first frame that actually carries content, then rebuilds the body so every byte already pulled off the socket is replayed ahead of the live reader. This is the same re-assembly `qoder.js` (`peekFirstQoderFrame`) and `codex.js` (`_peekSseTransientError`, via `replacementBody`) already use for their own first-frame peeks — issue #3463 explicitly suggests generalizing that precedent.

Scanning is line-buffered, so a JSON frame split across two network chunks is never judged on its first half. Recognizes OpenAI, Claude, Gemini and Ollama frame shapes.

Two deliberate scope limits:

- **Gated on `Content-Type: text/event-stream`.** `handleComboChat` is also called from `fetch.js`, `search.js`, `imageGeneration.js` and `tts.js`, whose 200s are audio, images or plain JSON. Reading those would consume a body the caller still needs, so they are skipped untouched — a test asserts `bodyUsed === false` for a JSON completion.
- **Bounded by `STREAM_FIRST_CHUNK_TIMEOUT_MS`.** A naive peek would await the first content frame forever, so an upstream sending endless keepalives would hang where the old code returned immediately. That would be a regression introduced by this fix, so the wait has a deadline. This also wires up a constant that was previously referenced only by `kiro.js`.

An empty stream is always treated as provider failure (no new env var). If every combo model comes back empty, the request ends as 503 rather than a silent empty answer.

## Tests

12 new cases in `tests/unit/combo-empty-stream-3463.test.js`. Against unmodified `combo.js`: exactly **4 fail** (the bug), **7 pass** (the guard rails, confirming they are not vacuous). After the fix: 12/12.

Mutation-tested rather than trusting green:

| mutant | result |
| --- | --- |
| always report content | 4 failed — killed |
| skip content-type gate | 2 failed — killed |
| drop replayed bytes | 8 failed — killed |
| treat `[DONE]` as content | survived — equivalent |
| judge partial lines | survived — equivalent |
| remove deadline race only | survived — redundant guard |
| remove both deadline guards | test times out — killed |

The two "equivalent" survivors were verified, not assumed: `JSON.parse` rejects `[DONE]` and every truncated JSON prefix, so neither mutation changes behaviour. The deadline guards are intentionally redundant — either alone suffices, which is why removing one survives and removing both hangs.

## Relationship to #3465

Complementary, not duplicate. #3465 detects emptiness in `onStreamComplete`, after the response has been sent; its own doc comment notes it "can't un-send it" and instead locks the account for the *next* request. This change intercepts before `combo.js` returns, so the **current** request is rescued by the next combo model. Different layer, different timing. #3465's non-streaming half does not overlap at all. The two can land independently.

## Test plan

- [x] `tests/unit/combo-empty-stream-3463.test.js` — 12/12
- [x] 4/12 confirmed failing on unmodified `combo.js` (bug reproduced, tests proven non-vacuous)
- [x] Mutation-tested: 4 of 7 mutants killed, 3 verified equivalent/redundant
- [x] Combo suites (`combo-routing`, `combo-autoswitch`, `combo-fusion`) — 33 passed
- [x] `npx eslint` clean on both changed files
- [x] Maintainer smoke test against a provider that actually exhibits the empty-stream behaviour

**Pre-existing failures, not from this PR:** `combo-autoswitch.test.js` > `web_search tool -> search` and `keeps order when no model matches` fail identically on unmodified `master` (verified via `git stash`). They live in `detectRequiredCapabilities`/`reorderByCapabilities`, untouched here.

Fixes #3463
