### PR TITLE
fix(codex): expose reasoning controls in CLI config

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -1,4 +1,4 @@
-import { detectFormat, getTargetFormat, resolveTransport } from "../services/provider.js";
+import { detectFormat, getTargetFormat, resolveTransport, hasThinkingConfig } from "../services/provider.js";
 import { translateRequest } from "../translator/index.js";
 import { applyThinking, extractThinking, stripThinkingSuffix } from "../translator/concerns/thinkingUnified.js";
 import { FORMATS } from "../translator/formats.js";
@@ -95,17 +95,22 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   const stripList = getModelStrip(alias, model);
   const upstreamModel = getModelUpstreamId(alias, model);
 
-  // Inject provider-level thinking config override (only if client hasn't set)
-  // on/off → extended type (body.thinking), none/low/medium/high → effort type (body.reasoning_effort)
+  // Inject provider-level thinking config only when the client did not provide
+  // an explicit setting. Codex uses the nested Responses shape.
   if (providerThinking?.mode && providerThinking.mode !== "auto") {
     const mode = providerThinking.mode;
-    if (mode === "on" && !body.thinking) {
+    const clientHasThinkingConfig = hasThinkingConfig(body);
+    if (mode === "on" && !clientHasThinkingConfig) {
       console.log("Injecting provider-level thinking config override: on");
       body = { ...body, thinking: { type: "enabled", budget_tokens: 10000 } };
-    } else if (mode === "off" && !body.thinking) {
+    } else if (mode === "off" && !clientHasThinkingConfig) {
       body = { ...body, thinking: { type: "disabled" } };
-    } else if (!body.reasoning_effort) {
-      body = { ...body, reasoning_effort: mode };
+    } else if (!clientHasThinkingConfig) {
+      if (body.reasoning && typeof body.reasoning === "object" && !Array.isArray(body.reasoning)) {
+        body = { ...body, reasoning: { ...body.reasoning, effort: mode } };
+      } else {
+        body = { ...body, reasoning_effort: mode };
+      }
     }
   }
 

--- a/open-sse/services/provider.js
+++ b/open-sse/services/provider.js
@@ -162,7 +162,13 @@ export function isLastMessageFromUser(body) {
 
 // Check if request has thinking config
 export function hasThinkingConfig(body) {
-  return !!(body.reasoning_effort || body.thinking?.type === "enabled");
+  return !!(
+    body?.reasoning_effort
+    || body?.reasoning?.effort
+    || body?.output_config?.effort
+    || body?.thinking === true
+    || body?.thinking?.type
+  );
 }
 
 // Normalize provider-native thinking config based on last message role.

--- a/src/app/(dashboard)/dashboard/cli-tools/components/CodexToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/CodexToolCard.js
@@ -7,6 +7,9 @@ import BaseUrlSelect from "./BaseUrlSelect";
 import ApiKeySelect from "./ApiKeySelect";
 import { matchKnownEndpoint } from "./cliEndpointMatch";
 
+const CODEX_REASONING_EFFORTS = ["auto", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"];
+const CODEX_SERVICE_TIERS = ["auto", "priority"];
+
 export default function CodexToolCard({ tool, isExpanded, onToggle, baseUrl, apiKeys, activeProviders, cloudEnabled, initialStatus, tunnelEnabled, tunnelPublicUrl, tailscaleEnabled, tailscaleUrl }) {
   const [codexStatus, setCodexStatus] = useState(initialStatus || null);
   const [checkingCodex, setCheckingCodex] = useState(false);
@@ -17,6 +20,8 @@ export default function CodexToolCard({ tool, isExpanded, onToggle, baseUrl, api
   const [selectedApiKey, setSelectedApiKey] = useState("");
   const [selectedModel, setSelectedModel] = useState("");
   const [subagentModel, setSubagentModel] = useState("");
+  const [reasoningEffort, setReasoningEffort] = useState("auto");
+  const [serviceTier, setServiceTier] = useState("auto");
   const [modalOpen, setModalOpen] = useState(false);
   const [subagentModalOpen, setSubagentModalOpen] = useState(false);
   const [modelAliases, setModelAliases] = useState({});
@@ -57,8 +62,14 @@ export default function CodexToolCard({ tool, isExpanded, onToggle, baseUrl, api
       if (modelMatch) setSelectedModel(modelMatch[1]);
 
       // Parse subagent settings
-      const subagentModelMatch = codexStatus.config.match(/\[agents\.subagent\]\s*\n\s*model\s*=\s*"([^"]+)"/m);
+      const subagentModelMatch = codexStatus.config.match(/\[agents\.subagent\][^\[]*?^\s*model\s*=\s*"([^"]+)"/m);
       if (subagentModelMatch) setSubagentModel(subagentModelMatch[1]);
+
+      const reasoningEffortMatch = codexStatus.config.match(/^model_reasoning_effort\s*=\s*"([^"]+)"/m);
+      setReasoningEffort(reasoningEffortMatch ? reasoningEffortMatch[1] : "auto");
+
+      const serviceTierMatch = codexStatus.config.match(/^service_tier\s*=\s*"([^"]+)"/m);
+      setServiceTier(serviceTierMatch ? serviceTierMatch[1] : "auto");
     }
   }, [codexStatus]);
 
@@ -109,7 +120,9 @@ export default function CodexToolCard({ tool, isExpanded, onToggle, baseUrl, api
           baseUrl: getEffectiveBaseUrl(),
           apiKey: keyToUse,
           model: selectedModel,
-          subagentModel: subagentModel || selectedModel
+          subagentModel: subagentModel || selectedModel,
+          reasoningEffort,
+          serviceTier,
         }),
       });
       const data = await res.json();
@@ -162,10 +175,16 @@ export default function CodexToolCard({ tool, isExpanded, onToggle, baseUrl, api
       : (!cloudEnabled ? "sk_9router" : "<API_KEY_FROM_DASHBOARD>");
 
     const effectiveSubagentModel = subagentModel || selectedModel;
+    const reasoningConfig = reasoningEffort !== "auto"
+      ? `model_reasoning_effort = "${reasoningEffort}"\n`
+      : "";
+    const serviceTierConfig = serviceTier !== "auto"
+      ? `service_tier = "${serviceTier}"\n`
+      : "";
 
     const configContent = `# 9Router Configuration for Codex CLI
 model = "${selectedModel}"
-model_provider = "9router"
+${reasoningConfig}${serviceTierConfig}model_provider = "9router"
 
 [model_providers.9router]
 name = "9Router"
@@ -173,6 +192,7 @@ base_url = "${getEffectiveBaseUrl()}"
 wire_api = "responses"
 
 [agents.subagent]
+description = "Runs focused tasks delegated by Codex."
 model = "${effectiveSubagentModel}"
 `;
 
@@ -313,6 +333,37 @@ model = "${effectiveSubagentModel}"
                     {selectedModel && <button onClick={() => setSelectedModel("")} className="absolute right-1 top-1/2 -translate-y-1/2 p-0.5 text-text-muted hover:text-red-500 rounded transition-colors" title="Clear"><span className="material-symbols-outlined text-[14px]">close</span></button>}
                   </div>
                   <button onClick={() => setModalOpen(true)} disabled={!activeProviders?.length} className={`w-full sm:w-auto rounded border px-2 py-2 text-xs transition-colors sm:py-1.5 whitespace-nowrap sm:shrink-0 ${activeProviders?.length ? "bg-surface border-border text-text-main hover:border-primary cursor-pointer" : "opacity-50 cursor-not-allowed border-border"}`}>Select Model</button>
+                </div>
+
+                {/* Codex native reasoning control */}
+                <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-[8rem_auto_1fr_auto] sm:items-center sm:gap-2">
+                  <span className="text-xs font-semibold text-text-main sm:text-right sm:text-sm">Reasoning</span>
+                  <span className="material-symbols-outlined hidden text-text-muted text-[14px] sm:inline">arrow_forward</span>
+                  <select
+                    value={reasoningEffort}
+                    onChange={(e) => setReasoningEffort(e.target.value)}
+                    title="Codex reasoning effort"
+                    className="w-full rounded border border-border bg-surface px-2 py-2 text-xs focus:outline-none focus:ring-1 focus:ring-primary/50 sm:py-1.5"
+                  >
+                    {CODEX_REASONING_EFFORTS.map((effort) => (
+                      <option key={effort} value={effort}>{`Thinking: ${effort.charAt(0).toUpperCase() + effort.slice(1)}`}</option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* Codex service tier controls request routing speed */}
+                <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-[8rem_auto_1fr_auto] sm:items-center sm:gap-2">
+                  <span className="text-xs font-semibold text-text-main sm:text-right sm:text-sm">Speed Tier</span>
+                  <span className="material-symbols-outlined hidden text-text-muted text-[14px] sm:inline">arrow_forward</span>
+                  <select
+                    value={serviceTier}
+                    onChange={(e) => setServiceTier(e.target.value)}
+                    title="Codex service tier"
+                    className="w-full rounded border border-border bg-surface px-2 py-2 text-xs focus:outline-none focus:ring-1 focus:ring-primary/50 sm:py-1.5"
+                  >
+                    <option value="auto">Speed: Auto</option>
+                    <option value="priority">Speed: Priority</option>
+                  </select>
                 </div>
 
                 {/* Subagent Model */}

--- a/src/app/api/cli-tools/codex-settings/route.js
+++ b/src/app/api/cli-tools/codex-settings/route.js
@@ -13,6 +13,8 @@ const execAsync = promisify(exec);
 const getCodexDir = () => path.join(os.homedir(), ".codex");
 const getCodexConfigPath = () => path.join(getCodexDir(), "config.toml");
 const getCodexAuthPath = () => path.join(getCodexDir(), "auth.json");
+const CODEX_REASONING_EFFORTS = new Set(["minimal", "low", "medium", "high", "xhigh", "max", "ultra"]);
+const CODEX_SERVICE_TIERS = new Set(["priority"]);
 
 // Flatten confbox-parsed TOML into a writable object, preserving nested tables
 const parsedToWritable = (obj) => obj ?? {};
@@ -109,7 +111,7 @@ export async function GET() {
 // POST - Update 9Router settings (merge with existing config)
 export async function POST(request) {
   try {
-    const { baseUrl, apiKey, model, subagentModel } = await request.json();
+    const { baseUrl, apiKey, model, subagentModel, reasoningEffort, serviceTier } = await request.json();
     
     if (!baseUrl || !apiKey || !model) {
       return NextResponse.json({ error: "baseUrl, apiKey and model are required" }, { status: 400 });
@@ -132,10 +134,35 @@ export async function POST(request) {
     parsed.model = model;
     parsed.model_provider = "9router";
 
+    if (reasoningEffort !== undefined) {
+      if (reasoningEffort === "auto" || reasoningEffort === null || reasoningEffort === "") {
+        delete parsed.model_reasoning_effort;
+      } else if (!CODEX_REASONING_EFFORTS.has(reasoningEffort)) {
+        return NextResponse.json({ error: "Invalid Codex reasoning effort" }, { status: 400 });
+      } else {
+        parsed.model_reasoning_effort = reasoningEffort;
+      }
+    }
+
+    if (serviceTier !== undefined) {
+      if (serviceTier === "auto" || serviceTier === null || serviceTier === "") {
+        delete parsed.service_tier;
+      } else if (!CODEX_SERVICE_TIERS.has(serviceTier)) {
+        return NextResponse.json({ error: "Invalid Codex service tier" }, { status: 400 });
+      } else {
+        parsed.service_tier = serviceTier;
+      }
+    }
+
     // Update or create 9router provider section (no api_key - Codex reads from auth.json)
     // Ensure /v1 suffix is added only once
     const normalizedBaseUrl = baseUrl.endsWith("/v1") ? baseUrl : `${baseUrl}/v1`;
+    const existingProvider = parsed.model_providers?.["9router"];
+    const providerConfig = existingProvider && typeof existingProvider === "object" && !Array.isArray(existingProvider)
+      ? existingProvider
+      : {};
     setNestedSection(parsed, "model_providers.9router", {
+      ...providerConfig,
       name: "9Router",
       base_url: normalizedBaseUrl,
       wire_api: "responses",
@@ -144,6 +171,7 @@ export async function POST(request) {
     // Add subagent configuration
     const effectiveSubagentModel = subagentModel || model;
     setNestedSection(parsed, "agents.subagent", {
+      description: "Runs focused tasks delegated by Codex.",
       model: effectiveSubagentModel,
     });
 

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -18,6 +18,7 @@ import { resolveZedModels } from "open-sse/shared/zedAuth.js";
 import { updateProviderCredentials } from "@/sse/services/tokenRefresh";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { capabilitiesFromServiceKind, getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { getThinkingLevels } from "open-sse/providers/thinkingLevels.js";
 
 // Per-provider live model resolvers. Each receives a connection record and
 // returns { models: [{ id, name? }, ...] } | null on failure.
@@ -127,6 +128,76 @@ const LIVE_MODEL_RESOLVERS = {
 const parseOpenAIStyleModels = (data) => {
   if (Array.isArray(data)) return data;
   return data?.data || data?.models || data?.results || [];
+};
+
+const CODEX_REASONING_DESCRIPTIONS = {
+  minimal: "Fast responses with minimal reasoning",
+  low: "Fast responses with lighter reasoning",
+  medium: "Balances speed and reasoning depth for everyday tasks",
+  high: "Greater reasoning depth for complex problems",
+  xhigh: "Extra high reasoning depth for complex problems",
+  max: "Maximum reasoning depth for the hardest problems",
+  ultra: "Maximum reasoning with automatic task delegation",
+};
+
+const PROVIDER_ALIAS_TO_ID = Object.fromEntries(
+  Object.entries(PROVIDER_ID_TO_ALIAS).map(([providerId, alias]) => [alias, providerId]),
+);
+
+// Codex expects its richer model catalog under `models`; keep `data` as the
+// standard OpenAI-compatible catalog for every other client.
+const toCodexModel = (model) => {
+  const [alias, ...modelParts] = String(model?.id || "").split("/");
+  const modelId = modelParts.join("/") || alias;
+  const providerId = PROVIDER_ALIAS_TO_ID[alias] || alias;
+  const levels = model?.capabilities?.reasoning
+    ? (getThinkingLevels(providerId, modelId) || [])
+    : [];
+  const supportedReasoningLevels = levels
+    .filter((level) => level !== "none")
+    .map((effort) => ({ effort, description: CODEX_REASONING_DESCRIPTIONS[effort] || `${effort} reasoning` }));
+  const defaultReasoningLevel = levels.includes("medium")
+    ? "medium"
+    : (supportedReasoningLevels[0]?.effort || "none");
+
+  return {
+    slug: model.id,
+    display_name: model.id,
+    description: `${model.id} via 9Router`,
+    default_reasoning_level: defaultReasoningLevel,
+    supported_reasoning_levels: supportedReasoningLevels,
+    shell_type: "shell_command",
+    visibility: "list",
+    supported_in_api: true,
+    priority: 0,
+    additional_speed_tiers: [],
+    service_tiers: [],
+    availability_nux: null,
+    upgrade: null,
+    base_instructions: "You are Codex, an AI coding assistant.",
+    model_messages: {},
+    include_skills_usage_instructions: false,
+    include_plugin_usage_instructions: true,
+    include_apps_usage_instructions: true,
+    default_reasoning_summary: "none",
+    support_verbosity: false,
+    default_verbosity: "low",
+    apply_patch_tool_type: "freeform",
+    web_search_tool_type: "text",
+    truncation_policy: { mode: "tokens", limit: 10000 },
+    supports_image_detail_original: model.capabilities?.vision === true,
+    context_window: model.context_length,
+    max_context_window: model.context_length,
+    effective_context_window_percent: 95,
+    experimental_supported_tools: [],
+    input_modalities: model.capabilities?.vision === true ? ["text", "image"] : ["text"],
+    supports_search_tool: model.capabilities?.search === true,
+    use_responses_lite: false,
+    node_repl_auto_review_required: false,
+    node_repl_disabled: false,
+    tool_mode: "code_mode_only",
+    multi_agent_version: "v2",
+  };
 };
 
 // Header sent by fetchCompatibleModelIds to detect cross-instance /models fetches
@@ -563,7 +634,7 @@ export async function GET(request) {
     // Detect cross-instance recursive /models fetch (another 9router fetching our /models)
     const skipDynamicFetch = request?.headers?.get(INTERNAL_MODELS_FETCH_HEADER) === "1";
     const data = await buildModelsList([LLM_KIND], { skipDynamicFetch });
-    return Response.json({ object: "list", data }, {
+    return Response.json({ object: "list", data, models: data.map(toCodexModel) }, {
       headers: { "Access-Control-Allow-Origin": "*" },
     });
   } catch (error) {

--- a/tests/unit/codex-native-passthrough-thinking.test.js
+++ b/tests/unit/codex-native-passthrough-thinking.test.js
@@ -35,7 +35,7 @@ vi.mock("../../open-sse/handlers/chatCore/sseToJsonHandler.js", () => ({
 
 const { handleChatCore } = await import("../../open-sse/handlers/chatCore.js");
 
-async function runNativeCodexRequest(model, reasoning) {
+async function runNativeCodexRequest(model, reasoning, providerThinking) {
   const body = {
     model,
     input: "hello",
@@ -55,6 +55,7 @@ async function runNativeCodexRequest(model, reasoning) {
     ponytailEnabled: false,
     pxpipeEnabled: false,
     sourceFormatOverride: "openai-responses",
+    providerThinking,
     clientRawRequest: {
       endpoint: "/v1/responses",
       body,
@@ -107,5 +108,15 @@ describe("native Codex passthrough thinking suffixes", () => {
 
     expect(body.model).toBe("gpt-5.6-terra");
     expect(body.reasoning).toEqual({ effort: "ultra" });
+  });
+
+  it("does not override native Responses reasoning with provider default", async () => {
+    const body = await runNativeCodexRequest(
+      "gpt-5.6-luna",
+      { effort: "low" },
+      { mode: "high" },
+    );
+
+    expect(body.reasoning).toEqual({ effort: "low" });
   });
 });

--- a/tests/unit/codex-settings-route.test.js
+++ b/tests/unit/codex-settings-route.test.js
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { parseTOML } from "confbox";
+
+const originalHome = process.env.HOME;
+const tempHomes = [];
+
+afterEach(() => {
+  process.env.HOME = originalHome;
+  for (const tempHome of tempHomes.splice(0)) {
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+});
+
+describe("Codex settings route", () => {
+  it("preserves provider auth and writes native reasoning settings", async () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "9router-codex-settings-"));
+    tempHomes.push(tempHome);
+    process.env.HOME = tempHome;
+
+    const codexDir = path.join(tempHome, ".codex");
+    fs.mkdirSync(codexDir);
+    fs.writeFileSync(path.join(codexDir, "config.toml"), [
+      'model = "old-model"',
+      'model_provider = "9router"',
+      "",
+      "[model_providers.9router]",
+      'name = "9Router"',
+      'base_url = "http://old/v1"',
+      'wire_api = "responses"',
+      "",
+      "[model_providers.9router.auth]",
+      'command = "python3"',
+      'args = ["-c", "print(\\\"preserve-me\\\")"]',
+    ].join("\n"));
+
+    const { POST } = await import("../../src/app/api/cli-tools/codex-settings/route.js");
+    const response = await POST(new Request("http://localhost/api/cli-tools/codex-settings", {
+      method: "POST",
+      body: JSON.stringify({
+        baseUrl: "http://127.0.0.1:20128/v1",
+        apiKey: "test-key",
+        model: "cx/gpt-5.6-luna",
+        subagentModel: "cx/gpt-5.6-luna",
+        reasoningEffort: "high",
+        serviceTier: "priority",
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    const config = parseTOML(fs.readFileSync(path.join(codexDir, "config.toml"), "utf8"));
+    expect(config.model).toBe("cx/gpt-5.6-luna");
+    expect(config.model_reasoning_effort).toBe("high");
+    expect(config.service_tier).toBe("priority");
+    expect(config.model_providers["9router"].auth.command).toBe("python3");
+    expect(config.agents.subagent.description).toBe("Runs focused tasks delegated by Codex.");
+    expect(JSON.parse(fs.readFileSync(path.join(codexDir, "auth.json"), "utf8")).OPENAI_API_KEY).toBe("test-key");
+  });
+});

--- a/tests/unit/provider-thinking-config.test.js
+++ b/tests/unit/provider-thinking-config.test.js
@@ -1,5 +1,18 @@
 import { describe, it, expect } from "vitest";
-import { normalizeThinkingConfig } from "../../open-sse/services/provider.js";
+import { hasThinkingConfig, normalizeThinkingConfig } from "../../open-sse/services/provider.js";
+
+describe("hasThinkingConfig", () => {
+  it.each([
+    [{ reasoning_effort: "low" }, true],
+    [{ reasoning: { effort: "low" } }, true],
+    [{ output_config: { effort: "high" } }, true],
+    [{ thinking: { type: "disabled" } }, true],
+    [{ reasoning: { summary: "auto" } }, false],
+    [{ messages: [] }, false],
+  ])("detects explicit thinking config in %j", (body, expected) => {
+    expect(hasThinkingConfig(body)).toBe(expected);
+  });
+});
 
 describe("normalizeThinkingConfig", () => {
   it("keeps openai reasoning_effort on non-user turns", () => {


### PR DESCRIPTION
## What changed

- Add Codex CLI controls for reasoning effort and service tier.
- Persist `model_reasoning_effort` and `service_tier` in `~/.codex/config.toml`.
- Preserve the nested provider auth table when applying settings.
- Respect client-provided reasoning settings, including nested Responses API `reasoning.effort`.
- Return a Codex-compatible model catalog from `/v1/models`.

## Validation

- Targeted tests: 66 passed.
- Codex settings route tests: 12 passed.
- Production build passed.
- Live Codex request through 9Router succeeded with reasoning effort `low`.
