### PR TITLE
fix: preserve Responses output items across provider translation

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -211,7 +211,9 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
         result.usage.completion_tokens_details = { reasoning_tokens: usage.thoughtsTokenCount };
       }
     }
-    return result;
+    return sourceFormat === FORMATS.OPENAI_RESPONSES
+      ? openAICompletionToResponses(result, customToolNames)
+      : result;
   }
 
   // Claude

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -5,6 +5,7 @@ import { FORMATS } from "../../translator/formats.js";
 import { PROVIDERS } from "../../config/providers.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { ROLE, RESPONSES_ITEM } from "../../translator/schema/index.js";
+import { geminiToOpenAIResponse } from "../../translator/response/gemini-to-openai.js";
 
 // Responses-API providers (e.g. codex) may emit SSE without content-type + use Responses output shape
 const isResponsesProvider = (p) => PROVIDERS[p]?.format === FORMATS.OPENAI_RESPONSES;
@@ -175,6 +176,31 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel) {
   return result;
 }
 
+function parseGeminiSSEToOpenAIResponse(rawSSE, fallbackModel) {
+  const state = {};
+  const chunks = [];
+  let streamError = null;
+
+  for (const line of String(rawSSE || "").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("data:")) continue;
+    const payload = trimmed.slice(5).trim();
+    if (!payload || payload === "[DONE]") continue;
+    try {
+      const parsed = JSON.parse(payload);
+      if (parsed?.error) streamError = parsed.error;
+      else chunks.push(...(geminiToOpenAIResponse(parsed, state) || []));
+    } catch { /* ignore malformed lines */ }
+  }
+
+  if (streamError) return { error: streamError };
+  if (chunks.length === 0) return null;
+  return parseSSEToOpenAIResponse(
+    chunks.map((chunk) => `data: ${JSON.stringify(chunk)}`).join("\n"),
+    fallbackModel
+  );
+}
+
 /**
  * Handle case: provider forced streaming but client wants JSON.
  * Supports both Codex/Responses API SSE and standard Chat Completions SSE.
@@ -196,10 +222,24 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
   // Branch on the UPSTREAM format (targetFormat = format we spoke to the provider in),
   // not the client format: a Responses-API client behind a chat-native forced-streaming
   // provider still receives chat SSE chunks, which must go through the standard path.
+  const isGeminiSse = [
+    FORMATS.ANTIGRAVITY,
+    FORMATS.GEMINI,
+    FORMATS.GEMINI_CLI,
+    FORMATS.VERTEX,
+  ].includes(targetFormat);
   const isCodexResponsesApi = isResponsesProvider(provider) || targetFormat === FORMATS.OPENAI_RESPONSES;
-  if (isCodexResponsesApi) {
+  if (isCodexResponsesApi || isGeminiSse) {
     try {
-      const jsonResponse = await convertResponsesStreamToJson(providerResponse.body);
+      let jsonResponse;
+      if (isGeminiSse) {
+        const parsed = parseGeminiSSEToOpenAIResponse(await providerResponse.text(), model);
+        if (!parsed) return createErrorResult(HTTP_STATUS.BAD_GATEWAY, "Invalid Gemini SSE response for non-streaming request");
+        if (parsed.error) return createErrorResult(HTTP_STATUS.BAD_GATEWAY, parsed.error.message || "Upstream SSE stream failed");
+        jsonResponse = chatCompletionToResponses(parsed, customToolNames);
+      } else {
+        jsonResponse = await convertResponsesStreamToJson(providerResponse.body);
+      }
       if (onRequestSuccess) await onRequestSuccess();
 
       const usage = jsonResponse.usage || {};

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -26,6 +26,7 @@ export function openaiToOpenAIResponsesResponse(chunk, state) {
   
   const emit = (eventType, data) => {
     data.sequence_number = nextSeq();
+    recordOutputItem(state, eventType, data);
     events.push({ event: eventType, data });
   };
 
@@ -376,10 +377,19 @@ function sendCompleted(state, emit) {
         created_at: state.created,
         status: "completed",
         background: false,
-        error: null
+        error: null,
+        output: (state.responseOutput || []).filter(Boolean)
       }
     });
   }
+}
+
+function recordOutputItem(state, eventType, data) {
+  if (eventType !== "response.output_item.added" && eventType !== "response.output_item.done") return;
+  const index = Number(data.output_index);
+  if (!Number.isInteger(index) || !data.item) return;
+  if (!state.responseOutput) state.responseOutput = [];
+  state.responseOutput[index] = data.item;
 }
 
 function flushEvents(state) {
@@ -389,6 +399,7 @@ function flushEvents(state) {
   const nextSeq = () => ++state.seq;
   const emit = (eventType, data) => {
     data.sequence_number = nextSeq();
+    recordOutputItem(state, eventType, data);
     events.push({ event: eventType, data });
   };
 

--- a/tests/unit/openai-responses-nonstream.test.js
+++ b/tests/unit/openai-responses-nonstream.test.js
@@ -9,6 +9,7 @@ vi.mock("@/lib/usageDb.js", () => ({
 const { FORMATS } = await import("../../open-sse/translator/formats.js");
 const { translateNonStreamingResponse } = await import("../../open-sse/handlers/chatCore/nonStreamingHandler.js");
 const { handleForcedSSEToJson } = await import("../../open-sse/handlers/chatCore/sseToJsonHandler.js");
+const { createSSETransformStreamWithLogger } = await import("../../open-sse/utils/stream.js");
 
 // A chat.completion body as returned by a chat-native upstream (e.g. op-ericding)
 const CHAT_TOOL_BODY = {
@@ -78,10 +79,76 @@ describe("non-stream Chat upstream for a Responses-API client (op-ericding bug)"
     expect(msg.content[0].text).toBe("hello");
   });
 
+  it("chains Antigravity response conversion into Responses output", () => {
+    const body = {
+      response: {
+        responseId: "ag-resp-1",
+        modelVersion: "gemini-3.7-flash-low",
+        candidates: [{
+          content: { parts: [{ text: "hello from antigravity" }] },
+          finishReason: "STOP",
+        }],
+      },
+    };
+    const out = translateNonStreamingResponse(body, FORMATS.ANTIGRAVITY, FORMATS.OPENAI_RESPONSES);
+
+    expect(out.object).toBe("response");
+    expect(out).not.toHaveProperty("choices");
+    const msg = (out.output || []).find((item) => item.type === "message");
+    expect(msg?.content?.[0]).toMatchObject({
+      type: "output_text",
+      text: "hello from antigravity",
+    });
+  });
+
   it("leaves chat->chat untouched", () => {
     const out = translateNonStreamingResponse(CHAT_TOOL_BODY, FORMATS.OPENAI, FORMATS.OPENAI);
     expect(out.object).toBe("chat.completion");
     expect(out.choices[0].message.tool_calls[0].function.name).toBe("shell");
+  });
+});
+
+describe("Antigravity streaming tool calls for a Responses-API client", () => {
+  it("emits a Responses function_call instead of an empty stream", async () => {
+    const encoder = new TextEncoder();
+    const raw = [
+      'data: {"response":{"responseId":"ag-tool","modelVersion":"gemini-3.7-flash-low","candidates":[{"content":{"parts":[{"functionCall":{"name":"read_file","args":{"path":"README.md"},"thoughtSignature":"sig"}}]}}]}}',
+      'data: {"response":{"responseId":"ag-tool","modelVersion":"gemini-3.7-flash-low","candidates":[{"content":{"parts":[]},"finishReason":"STOP"}]}}',
+      "data: [DONE]",
+      ""
+    ].join("\n\n");
+    const input = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(raw));
+        controller.close();
+      }
+    });
+    const output = input.pipeThrough(createSSETransformStreamWithLogger(
+      FORMATS.ANTIGRAVITY,
+      FORMATS.OPENAI_RESPONSES,
+      "antigravity",
+      { appendProviderChunk() {}, appendConvertedChunk() {} },
+      null,
+      "gemini-3.7-flash-low",
+      "test-connection",
+      { messages: [] },
+      null,
+      "test-key",
+    ));
+    const text = await new Response(output).text();
+    expect(text).toContain('"type":"response.output_item.added"');
+    expect(text).toContain('"type":"function_call"');
+    expect(text).toContain('"name":"read_file"');
+    expect(text).toContain('"type":"response.completed"');
+    const completedLine = text.split("\n").find((line) => line.startsWith("data: {") && line.includes('"type":"response.completed"'));
+    const completed = JSON.parse(completedLine.slice(6));
+    expect(completed.response.output).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: "function_call",
+        name: "read_file",
+        arguments: '{"path":"README.md"}',
+      }),
+    ]));
   });
 });
 
@@ -144,5 +211,45 @@ describe("forced-SSE JSON path for a Responses-API client behind a chat upstream
     const json = await result.response.json();
     expect(json.object).toBe("chat.completion");
     expect(json.choices[0].message.tool_calls[0].function.name).toBe("shell");
+  });
+
+  it("converts forced Antigravity SSE into Responses JSON", async () => {
+    const encoder = new TextEncoder();
+    const raw = [
+      'data: {"response":{"responseId":"ag-sse","modelVersion":"gemini-3.7-flash-low","candidates":[{"content":{"parts":[{"text":"hello from stream"}]}}]}}',
+      'data: {"response":{"responseId":"ag-sse","modelVersion":"gemini-3.7-flash-low","candidates":[{"content":{"parts":[]},"finishReason":"STOP"}]}}',
+      "data: [DONE]",
+      ""
+    ].join("\n\n");
+    const result = await handleForcedSSEToJson({
+      providerResponse: new Response(new ReadableStream({
+        start(controller) { controller.enqueue(encoder.encode(raw)); controller.close(); }
+      }), { headers: { "content-type": "text/event-stream" } }),
+      sourceFormat: FORMATS.OPENAI_RESPONSES,
+      targetFormat: FORMATS.ANTIGRAVITY,
+      provider: "antigravity",
+      model: "gemini-3.7-flash-low",
+      body: { model: "combo-ui", input: "hello" },
+      stream: false,
+      translatedBody: null,
+      finalBody: null,
+      requestStartTime: Date.now(),
+      connectionId: "test-connection",
+      apiKey: "test-key",
+      clientRawRequest: { endpoint: "/v1/responses" },
+      onRequestSuccess: vi.fn(),
+      customToolNames: null,
+      trackDone: vi.fn(),
+      appendLog: vi.fn(),
+      reqTag: "test",
+      log: null,
+    });
+    expect(result.success).toBe(true);
+    const json = await result.response.json();
+    expect(json.object).toBe("response");
+    expect(json.output?.[0]?.content?.[0]).toMatchObject({
+      type: "output_text",
+      text: "hello from stream",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- preserve emitted Responses output items in `response.completed.response.output`
- convert Gemini/Antigravity non-stream and forced-SSE Responses requests through the correct translators
- add regression coverage for text and tool-call output

## Verification
- `npm run build` passed on patched checkout
- Python OpenAI SDK text and tool streaming probes passed
- project verification: `83 passed`
- `git diff --check` passed

Vitest was not rerun in the clean checkout because repository test dependencies do not include `vitest`.