### PR TITLE
fix(stream): keep delta.reasoning chunks in streaming passthrough

### DIFF
--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -153,7 +153,7 @@ export function createSSEStream(options = {}) {
 
               const delta = parsed.choices?.[0]?.delta;
               const content = delta?.content;
-              const reasoning = delta?.reasoning_content;
+              const reasoning = delta?.reasoning_content || delta?.reasoning;
               if (content && typeof content === "string") {
                 totalContentLength += content.length;
                 accumulatedContent += content;
@@ -264,6 +264,9 @@ export function createSSEStream(options = {}) {
         if (parsed.choices?.[0]?.delta?.reasoning_content) {
           totalContentLength += parsed.choices[0].delta.reasoning_content.length;
           accumulatedThinking += parsed.choices[0].delta.reasoning_content;
+        } else if (parsed.choices?.[0]?.delta?.reasoning) {
+          totalContentLength += parsed.choices[0].delta.reasoning.length;
+          accumulatedThinking += parsed.choices[0].delta.reasoning;
         }
         
         // Gemini format

--- a/open-sse/utils/streamHelpers.js
+++ b/open-sse/utils/streamHelpers.js
@@ -40,6 +40,7 @@ export function hasValuableContent(chunk, format) {
     const delta = chunk.choices[0].delta;
     return delta.content && delta.content !== "" ||
            delta.reasoning_content && delta.reasoning_content !== "" ||
+           delta.reasoning && delta.reasoning !== "" ||
            delta.tool_calls && delta.tool_calls.length > 0 ||
            chunk.choices[0].finish_reason ||
            delta.role;

--- a/tests/unit/stream-reasoning-delta.test.js
+++ b/tests/unit/stream-reasoning-delta.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { hasValuableContent } from "../../open-sse/utils/streamHelpers.js";
+
+describe("hasValuableContent (OpenAI format)", () => {
+  it("keeps chunks carrying delta.reasoning (ollama.com/v1 style)", () => {
+    const chunk = {
+      choices: [{ index: 0, delta: { reasoning: "thinking text" }, finish_reason: null }],
+    };
+    expect(hasValuableContent(chunk, FORMATS.OPENAI)).toBe(true);
+  });
+
+  it("keeps chunks carrying delta.reasoning_content (OpenAI style)", () => {
+    const chunk = {
+      choices: [{ index: 0, delta: { reasoning_content: "thinking text" }, finish_reason: null }],
+    };
+    expect(hasValuableContent(chunk, FORMATS.OPENAI)).toBe(true);
+  });
+
+  it("drops empty chunks", () => {
+    const chunk = {
+      choices: [{ index: 0, delta: {}, finish_reason: null }],
+    };
+    expect(hasValuableContent(chunk, FORMATS.OPENAI)).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Summary

Streaming responses via OpenAI-compatible connections (e.g. ollama.com/v1/chat/completions) emit reasoning in `delta.reasoning`, not `delta.reasoning_content`. `hasValuableContent()` only recognized `reasoning_content`, so every thinking chunk was dropped except the first — which passed only because it also carried `delta.role`. Clients saw ~40 chars of thinking then the answer, while non-streaming returned full reasoning.

## Changes

- `open-sse/utils/streamHelpers.js`: `hasValuableContent` now also accepts `delta.reasoning`
- `open-sse/utils/stream.js`: count `delta.reasoning` toward `accumulatedThinking`/`totalContentLength` in passthrough and translate modes (usage estimation)
- `tests/unit/stream-reasoning-delta.test.js`: unit tests for the filter

## Verification

Live test on `oll/deepseek-v4-flash:0731` via 9router streaming:
- before: 1 reasoning chunk (~43 chars), then content
- after: 168 reasoning chunks (~1.8k chars), then content — matches direct ollama.com streaming

Non-streaming was unaffected (no per-chunk filter).