### PR TITLE
feat: New Models Discovery for all connected providers

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/components/NewModelsButton.js
+++ b/src/app/(dashboard)/dashboard/providers/components/NewModelsButton.js
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Modal } from "@/shared/components";
+
+// Compact button that shows the "New Models" discovery modal.
+// Fetches unseen model count on mount for the badge, and the full
+// model list when the modal opens.
+
+function ProviderIcon({ name }) {
+  return (
+    <span className="material-symbols-outlined text-[16px]">
+      dns
+    </span>
+  );
+}
+
+export default function NewModelsButton() {
+  const [open, setOpen] = useState(false);
+  const [unseenCount, setUnseenCount] = useState(0);
+
+  // Fetch unseen count on mount (lightweight — just a count).
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/models/new")
+      .then((r) => r.json())
+      .then((data) => {
+        if (!cancelled && data?.totalUnseen) setUnseenCount(data.totalUnseen);
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="relative flex items-center gap-1.5 rounded-lg border border-border bg-surface/60 px-3 py-1.5 text-xs font-medium text-text-muted hover:text-text-main hover:border-primary/40 transition-colors"
+        title="Check for new models across all providers"
+      >
+        <span className="material-symbols-outlined text-[16px]">new_releases</span>
+        <span className="hidden sm:inline">New Models</span>
+        {unseenCount > 0 && (
+          <span className="absolute -top-1.5 -right-1.5 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-red-500 text-white text-[10px] font-bold px-1">
+            {unseenCount > 99 ? "99+" : unseenCount}
+          </span>
+        )}
+      </button>
+      {open && <NewModelsModal onClose={() => { setOpen(false); setUnseenCount(0); }} />}
+    </>
+  );
+}
+
+function NewModelsModal({ onClose }) {
+  const [groups, setGroups] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [seeded, setSeeded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch("/api/models/new");
+        if (!res.ok) throw new Error("Failed to fetch");
+        const data = await res.json();
+        if (!cancelled) {
+          setGroups(data.groups || []);
+          setSeeded(!!data.seeded);
+        }
+      } catch (e) {
+        if (!cancelled) setError(e.message || "Error loading new models");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleMarkAllRead = async () => {
+    try {
+      await fetch("/api/models/new/acknowledge", { method: "POST" });
+      setGroups([]);
+    } catch {
+      // ignore — user can retry
+    }
+  };
+
+  return (
+    <Modal isOpen={true} onClose={onClose} title="New Models Discovery">
+      <div className="flex flex-col gap-3 max-h-[60vh] overflow-y-auto custom-scrollbar">
+        {loading ? (
+          <div className="flex items-center justify-center gap-2 py-6 text-text-muted text-sm">
+            <span className="material-symbols-outlined text-[18px] animate-spin">progress_activity</span>
+            Scanning all providers…
+          </div>
+        ) : error ? (
+          <div className="flex items-center justify-center gap-2 py-6 text-red-500 text-sm">
+            <span className="material-symbols-outlined text-[18px]">error</span>
+            {error}
+          </div>
+        ) : seeded ? (
+          <div className="flex flex-col items-center gap-2 py-8 text-text-muted text-sm">
+            <span className="material-symbols-outlined text-[28px] text-green-500">check_circle</span>
+            <span className="font-medium text-text-main">Baseline created</span>
+            <span className="text-center text-xs leading-relaxed">
+              Your current models have been recorded.
+              <br />
+              Only genuinely new models will appear here going forward.
+            </span>
+          </div>
+        ) : groups.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 py-8 text-text-muted text-sm">
+            <span className="material-symbols-outlined text-[28px]">new_releases</span>
+            <span className="font-medium text-text-main">No new models</span>
+            <span className="text-center text-xs">
+              All providers are up to date. New models will appear here when they are added.
+            </span>
+          </div>
+        ) : (
+          <>
+            {groups.map((group) => (
+              <div key={group.providerAlias} className="border border-border rounded-lg overflow-hidden">
+                <div className="flex items-center justify-between px-3 py-2 bg-surface/60 border-b border-border">
+                  <div className="flex items-center gap-2">
+                    <ProviderIcon name={group.providerAlias} />
+                    <span className="text-sm font-medium text-text-main">
+                      {group.providerName}
+                    </span>
+                    <span className="text-[10px] text-text-muted bg-bg rounded-full px-1.5 py-0.5">
+                      {group.models.length}
+                    </span>
+                  </div>
+                </div>
+                <div className="divide-y divide-border">
+                  {group.models.map((m) => (
+                    <div key={m.modelId} className="flex items-center gap-2 px-3 py-1.5">
+                      {m.isNew && (
+                        <span className="shrink-0 min-w-[32px] text-center text-[9px] font-bold text-white bg-blue-500 rounded px-1 py-0.5">
+                          NEW
+                        </span>
+                      )}
+                      {m.isFree && (
+                        <span className="shrink-0 min-w-[32px] text-center text-[9px] font-bold text-green-700 bg-green-100 dark:bg-green-900/30 dark:text-green-400 rounded px-1 py-0.5">
+                          FREE
+                        </span>
+                      )}
+                      <code className="text-xs font-mono text-text-muted truncate flex-1">
+                        {m.modelId}
+                      </code>
+                      <span className="text-[9px] text-text-muted/60 shrink-0">
+                        {new Date(m.firstSeenAt).toLocaleDateString()}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+
+            <button
+              onClick={handleMarkAllRead}
+              className="mt-1 flex items-center justify-center gap-1.5 rounded-lg border border-border px-3 py-2 text-xs font-medium text-text-muted hover:text-text-main hover:border-primary/40 transition-colors"
+            >
+              <span className="material-symbols-outlined text-[14px]">done_all</span>
+              Mark all as read
+            </button>
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/page.js
+++ b/src/app/(dashboard)/dashboard/providers/page.js
@@ -25,6 +25,7 @@ import { useNotificationStore } from "@/store/notificationStore";
 import { useHeaderSearchStore } from "@/store/headerSearchStore";
 import ModelAvailabilityBadge from "./components/ModelAvailabilityBadge";
 import AddCompatibleModal from "./components/AddCompatibleModal";
+import NewModelsButton from "./components/NewModelsButton";
 
 function getStatusDisplay(connected, error, errorCode) {
   const parts = [];
@@ -371,6 +372,19 @@ export default function ProvidersPage() {
           <p className="text-text-muted text-sm">No providers match your search</p>
         </div>
       )}
+
+      {/* New Models discovery */}
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex flex-col">
+          <h2 className="text-lg sm:text-xl font-semibold flex items-center gap-2 leading-tight">
+            Model Discovery
+          </h2>
+          <p className="text-xs text-text-muted">
+            Track new models added by any provider, including free ones
+          </p>
+        </div>
+        <NewModelsButton />
+      </div>
 
       {/* Custom Providers (OpenAI/Anthropic Compatible) — dynamic */}
       <div className="flex flex-col gap-4">

--- a/src/app/api/models/new/acknowledge/route.js
+++ b/src/app/api/models/new/acknowledge/route.js
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { acknowledgeModels } from "@/models";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/models/new/acknowledge
+// Body (optional): { items: [{ providerAlias, modelId }] }
+// Without items, acknowledges ALL currently-unseen models (e.g. "Mark all as read").
+export async function POST(request) {
+  try {
+    let items = null;
+    try {
+      const body = await request.json();
+      if (Array.isArray(body?.items)) items = body.items;
+    } catch {
+      // No/empty body → acknowledge all
+    }
+
+    await acknowledgeModels(items);
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("Error acknowledging models:", error);
+    return NextResponse.json({ error: "Failed to acknowledge models" }, { status: 500 });
+  }
+}

--- a/src/app/api/models/new/acknowledge/route.js
+++ b/src/app/api/models/new/acknowledge/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { acknowledgeModels } from "@/models";
+import { clearCache } from "@/lib/newModelsCache";
 
 export const dynamic = "force-dynamic";
 
@@ -17,6 +18,7 @@ export async function POST(request) {
     }
 
     await acknowledgeModels(items);
+    clearCache(); // force next GET to re-scan
 
     return NextResponse.json({ ok: true });
   } catch (error) {

--- a/src/app/api/models/new/route.js
+++ b/src/app/api/models/new/route.js
@@ -1,0 +1,108 @@
+import { NextResponse } from "next/server";
+import { buildModelsList } from "@/app/api/v1/models/route.js";
+import {
+  reconcileSeenModels,
+  countUnseenModels,
+} from "@/models";
+import { AI_PROVIDERS } from "@/shared/constants/providers";
+
+export const dynamic = "force-dynamic";
+
+// In-memory result cache. Live model discovery hits many upstream providers,
+// so we cache the computed result to avoid re-scanning on every modal open.
+const CACHE_TTL_MS = 2 * 60 * 1000; // 2 minutes
+let cache = { at: 0, data: null };
+
+function isProviderFree(alias) {
+  const provider = AI_PROVIDERS[alias];
+  if (!provider) return false;
+  if (provider.hasFree) return true;
+  return provider.category === "free" || provider.category === "freeTier";
+}
+
+// Core discovery logic — extracts (alias, modelId) pairs from all providers,
+// reconciles against the seen-models table, and returns the delta.
+async function discoverNewModels() {
+  const [llm, embedding, tts, image, stt] = await Promise.all([
+    buildModelsList(["llm"], {}),
+    buildModelsList(["embedding"], {}),
+    buildModelsList(["tts"], {}),
+    buildModelsList(["image"], {}),
+    buildModelsList(["stt"], {}),
+  ]);
+
+  const observed = [];
+  const seenPairs = new Set();
+  for (const m of [...llm, ...embedding, ...tts, ...image, ...stt]) {
+    const id = m?.id;
+    if (typeof id !== "string" || !id.includes("/")) continue;
+    const idx = id.indexOf("/");
+    const alias = id.slice(0, idx);
+    const modelId = id.slice(idx + 1);
+    if (!alias || !modelId) continue;
+    const key = `${alias}::${modelId}`;
+    if (seenPairs.has(key)) continue;
+    seenPairs.add(key);
+    observed.push({ providerAlias: alias, modelId, isFree: isProviderFree(alias) });
+  }
+
+  if (observed.length === 0) {
+    return { groups: [], total: 0, totalUnseen: 0, seeded: false };
+  }
+
+  const result = await reconcileSeenModels(observed);
+
+  if (result.seeded) {
+    const totalUnseen = await countUnseenModels();
+    return { groups: [], total: 0, totalUnseen, seeded: true };
+  }
+
+  const merged = [
+    ...result.new.map((m) => ({ ...m, isNew: true })),
+    ...result.unseen.map((m) => ({ ...m, isNew: false })),
+  ];
+  merged.sort((a, b) => new Date(b.firstSeenAt) - new Date(a.firstSeenAt));
+
+  const byProvider = {};
+  for (const m of merged) {
+    (byProvider[m.providerAlias] ||= []).push({
+      modelId: m.modelId,
+      isFree: m.isFree,
+      firstSeenAt: m.firstSeenAt,
+      isNew: m.isNew,
+    });
+  }
+
+  const totalUnseen = await countUnseenModels();
+
+  return {
+    groups: Object.entries(byProvider).map(([alias, models]) => ({
+      providerAlias: alias,
+      providerName: AI_PROVIDERS[alias]?.name || alias,
+      models,
+    })),
+    total: merged.length,
+    totalUnseen,
+    seeded: false,
+  };
+}
+
+// GET /api/models/new
+export async function GET() {
+  try {
+    const now = Date.now();
+    if (cache.data && now - cache.at < CACHE_TTL_MS) {
+      return NextResponse.json(cache.data);
+    }
+
+    const data = await discoverNewModels();
+    cache = { at: Date.now(), data };
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Error discovering new models:", error);
+    return NextResponse.json(
+      { error: "Failed to discover models", groups: [], total: 0, totalUnseen: 0, seeded: false },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/models/new/route.js
+++ b/src/app/api/models/new/route.js
@@ -2,16 +2,13 @@ import { NextResponse } from "next/server";
 import { buildModelsList } from "@/app/api/v1/models/route.js";
 import {
   reconcileSeenModels,
+  getUnseenModels,
   countUnseenModels,
 } from "@/models";
 import { AI_PROVIDERS } from "@/shared/constants/providers";
+import { getCachedResult, setCachedResult } from "@/lib/newModelsCache";
 
 export const dynamic = "force-dynamic";
-
-// In-memory result cache. Live model discovery hits many upstream providers,
-// so we cache the computed result to avoid re-scanning on every modal open.
-const CACHE_TTL_MS = 2 * 60 * 1000; // 2 minutes
-let cache = { at: 0, data: null };
 
 function isProviderFree(alias) {
   const provider = AI_PROVIDERS[alias];
@@ -52,15 +49,28 @@ async function discoverNewModels() {
 
   const result = await reconcileSeenModels(observed);
 
+  // Merged list = models newly detected in this scan, plus any previously
+  // seen-but-unacknowledged rows still in the DB.
+  const merged = [
+    ...result.new.map((m) => ({ ...m, isNew: true })),
+    ...result.unseen.map((m) => ({ ...m, isNew: false })),
+  ];
+
   if (result.seeded) {
     const totalUnseen = await countUnseenModels();
     return { groups: [], total: 0, totalUnseen, seeded: true };
   }
 
-  const merged = [
-    ...result.new.map((m) => ({ ...m, isNew: true })),
-    ...result.unseen.map((m) => ({ ...m, isNew: false })),
-  ];
+  // Fetch ALL unacknowledged rows so a model that was inserted manually
+  // (or detected earlier) but not in this scan's "new" list still appears.
+  const dbUnseen = await getUnseenModels();
+  const dbSet = new Set(dbUnseen.map((m) => `${m.providerAlias}::${m.modelId}`));
+  for (const m of dbUnseen) {
+    if (!merged.find((x) => x.providerAlias === m.providerAlias && x.modelId === m.modelId)) {
+      merged.push({ ...m, isNew: !dbSet.has(`${m.providerAlias}::${m.modelId}`) });
+    }
+  }
+
   merged.sort((a, b) => new Date(b.firstSeenAt) - new Date(a.firstSeenAt));
 
   const byProvider = {};
@@ -90,13 +100,13 @@ async function discoverNewModels() {
 // GET /api/models/new
 export async function GET() {
   try {
-    const now = Date.now();
-    if (cache.data && now - cache.at < CACHE_TTL_MS) {
-      return NextResponse.json(cache.data);
+    const cached = getCachedResult();
+    if (cached) {
+      return NextResponse.json(cached);
     }
 
     const data = await discoverNewModels();
-    cache = { at: Date.now(), data };
+    setCachedResult(data);
     return NextResponse.json(data);
   } catch (error) {
     console.error("Error discovering new models:", error);

--- a/src/lib/db/index.js
+++ b/src/lib/db/index.js
@@ -67,6 +67,12 @@ export {
   saveRequestDetail, getRequestDetails, getRequestDetailById, getDistinctProviders,
 } from "./repos/requestDetailsRepo.js";
 
+// Seen models (New Models discovery)
+export {
+  getSeenModels, reconcileSeenModels, acknowledgeModels, countUnseenModels,
+  seedSeenModels,
+} from "./repos/seenModelsRepo.js";
+
 // Export/import full DB
 export async function exportDb() {
   const db = await getAdapter();

--- a/src/lib/db/migrations/002-seen-models.js
+++ b/src/lib/db/migrations/002-seen-models.js
@@ -1,0 +1,28 @@
+/**
+ * Add seenModels table for New Models discovery feature.
+ * Tracks first-seen / acknowledged state for models across all providers.
+ */
+import { buildCreateTableSql } from "../schema.js";
+
+const migration = {
+  version: 2,
+  name: "add-seen-models",
+  up(db) {
+    db.exec(
+      buildCreateTableSql("seenModels", {
+        columns: {
+          id: "TEXT PRIMARY KEY",
+          providerAlias: "TEXT NOT NULL",
+          modelId: "TEXT NOT NULL",
+          isFree: "INTEGER DEFAULT 0",
+          firstSeenAt: "TEXT NOT NULL",
+          acknowledged: "INTEGER DEFAULT 0",
+        },
+      })
+    );
+    db.exec("CREATE INDEX IF NOT EXISTS idx_sm_provider ON seenModels(providerAlias)");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_sm_unseen ON seenModels(acknowledged)");
+  },
+};
+
+export default migration;

--- a/src/lib/db/migrations/index.js
+++ b/src/lib/db/migrations/index.js
@@ -2,8 +2,9 @@
 // Each migration: { version: number, name: string, up(db): void }
 // Versions MUST be unique and monotonically increasing.
 import m001 from "./001-initial.js";
+import m002 from "./002-seen-models.js";
 
-export const MIGRATIONS = [m001].sort((a, b) => a.version - b.version);
+export const MIGRATIONS = [m001, m002].sort((a, b) => a.version - b.version);
 
 export function latestVersion() {
   return MIGRATIONS.length ? MIGRATIONS[MIGRATIONS.length - 1].version : 0;

--- a/src/lib/db/repos/seenModelsRepo.js
+++ b/src/lib/db/repos/seenModelsRepo.js
@@ -109,6 +109,23 @@ export async function countUnseenModels() {
   return row ? row.c : 0;
 }
 
+// All currently-unseen (unacknowledged) models, regardless of whether they
+// appear in the live scan right now. Used to power the "New Models" modal.
+export async function getUnseenModels() {
+  const db = await getAdapter();
+  const rows = db.all(
+    `SELECT id, providerAlias, modelId, isFree, firstSeenAt, acknowledged
+     FROM seenModels WHERE acknowledged = 0`
+  );
+  return rows.map((r) => ({
+    providerAlias: r.providerAlias,
+    modelId: r.modelId,
+    isFree: !!r.isFree,
+    firstSeenAt: r.firstSeenAt,
+    acknowledged: false,
+  }));
+}
+
 // Seed the table with the current model set as already-seen (acknowledged=1).
 // Used as a first-run baseline so a fresh table doesn't report every existing
 // model as "new". Only models appearing AFTER seeding show as genuinely new.

--- a/src/lib/db/repos/seenModelsRepo.js
+++ b/src/lib/db/repos/seenModelsRepo.js
@@ -1,0 +1,128 @@
+import { getAdapter } from "../driver.js";
+
+// Tracks which provider/models the user has seen, powering the
+// "New Models" discovery feature. A row exists for every model that has
+// ever been observed (across every provider, incl. self-added compatible nodes).
+// `acknowledged = 0` means the user has not dismissed the "new" badge yet.
+
+export async function getSeenModels() {
+  const db = await getAdapter();
+  const rows = db.all(
+    `SELECT id, providerAlias, modelId, isFree, firstSeenAt, acknowledged FROM seenModels`
+  );
+  const map = new Map();
+  for (const r of rows) {
+    map.set(r.id, {
+      providerAlias: r.providerAlias,
+      modelId: r.modelId,
+      isFree: !!r.isFree,
+      firstSeenAt: r.firstSeenAt,
+      acknowledged: !!r.acknowledged,
+    });
+  }
+  return map;
+}
+
+export async function getSeenModelsCount() {
+  const db = await getAdapter();
+  const row = db.get(`SELECT COUNT(*) as c FROM seenModels`);
+  return row ? row.c : 0;
+}
+
+// Reconcile observed models against stored state.
+// `observed` is an array of { providerAlias, modelId, isFree }.
+// Returns { new: [...], unseen: [...], seeded: boolean } where:
+//   new    → models never recorded before (genuinely new since last scan)
+//   unseen → previously seen but not yet acknowledged
+//   seeded → true on first-ever scan (all existing models inserted as acknowledged)
+//
+// On first scan (empty table), all models are inserted with acknowledged=1 so
+// the user sees zero "new" models — only models that appear AFTER this point
+// will show as genuinely new.
+export async function reconcileSeenModels(observed) {
+  const db = await getAdapter();
+  const existing = await getSeenModels();
+  const now = new Date().toISOString();
+  const newModels = [];
+  const unseen = [];
+  let seeded = false;
+
+  db.transaction(() => {
+    const isFirstScan = existing.size === 0 && observed.length > 0;
+
+    for (const m of observed) {
+      const id = `${m.providerAlias}::${m.modelId}`;
+      const prev = existing.get(id);
+      if (!prev) {
+        if (isFirstScan) {
+          // First scan: seed all models as already acknowledged.
+          // Only models appearing AFTER this scan will show as new.
+          db.run(
+            `INSERT INTO seenModels(id, providerAlias, modelId, isFree, firstSeenAt, acknowledged)
+             VALUES(?, ?, ?, ?, ?, 1)`,
+            [id, m.providerAlias, m.modelId, m.isFree ? 1 : 0, now]
+          );
+          seeded = true;
+        } else {
+          db.run(
+            `INSERT INTO seenModels(id, providerAlias, modelId, isFree, firstSeenAt, acknowledged)
+             VALUES(?, ?, ?, ?, ?, 0)`,
+            [id, m.providerAlias, m.modelId, m.isFree ? 1 : 0, now]
+          );
+          newModels.push({ ...m, firstSeenAt: now, acknowledged: false });
+        }
+      } else if (!prev.acknowledged) {
+        unseen.push({
+          providerAlias: m.providerAlias,
+          modelId: m.modelId,
+          isFree: prev.isFree,
+          firstSeenAt: prev.firstSeenAt,
+          acknowledged: false,
+        });
+      }
+    }
+  });
+
+  return { new: newModels, unseen, seeded };
+}
+
+// Mark specific models acknowledged. `items` is [{ providerAlias, modelId }]
+// or omit/null to acknowledge ALL unseen models.
+export async function acknowledgeModels(items) {
+  const db = await getAdapter();
+  if (!items || items.length === 0) {
+    db.run(`UPDATE seenModels SET acknowledged = 1 WHERE acknowledged = 0`);
+    return;
+  }
+  db.transaction(() => {
+    for (const it of items) {
+      const id = `${it.providerAlias}::${it.modelId}`;
+      db.run(`UPDATE seenModels SET acknowledged = 1 WHERE id = ?`, [id]);
+    }
+  });
+}
+
+// Count of unseen (unacknowledged) models — for badge display.
+export async function countUnseenModels() {
+  const db = await getAdapter();
+  const row = db.get(`SELECT COUNT(*) as c FROM seenModels WHERE acknowledged = 0`);
+  return row ? row.c : 0;
+}
+
+// Seed the table with the current model set as already-seen (acknowledged=1).
+// Used as a first-run baseline so a fresh table doesn't report every existing
+// model as "new". Only models appearing AFTER seeding show as genuinely new.
+export async function seedSeenModels(observed) {
+  const db = await getAdapter();
+  const now = new Date().toISOString();
+  db.transaction(() => {
+    for (const m of observed) {
+      const id = `${m.providerAlias}::${m.modelId}`;
+      db.run(
+        `INSERT OR IGNORE INTO seenModels(id, providerAlias, modelId, isFree, firstSeenAt, acknowledged)
+         VALUES(?, ?, ?, ?, ?, 1)`,
+        [id, m.providerAlias, m.modelId, m.isFree ? 1 : 0, now]
+      );
+    }
+  });
+}

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -3,7 +3,7 @@
 // pre-change safety backup in migrate.js: when the stored version is lower,
 // one lightweight DB backup is taken before applying schema changes. Forgetting
 // to bump only skips that backup — it does NOT break the additive auto-sync.
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 
 export const PRAGMA_SQL = `
 PRAGMA journal_mode = WAL;
@@ -150,6 +150,23 @@ export const TABLES = {
       "CREATE INDEX IF NOT EXISTS idx_rd_provider ON requestDetails(provider)",
       "CREATE INDEX IF NOT EXISTS idx_rd_model ON requestDetails(model)",
       "CREATE INDEX IF NOT EXISTS idx_rd_conn ON requestDetails(connectionId)",
+    ],
+  },
+  // Tracks which provider/models the user has already "seen". Used by the
+  // New Models discovery feature to surface newly-added models (free or paid)
+  // across every connected provider, including self-added compatible nodes.
+  seenModels: {
+    columns: {
+      id: "TEXT PRIMARY KEY", // `${providerAlias}::${modelId}`
+      providerAlias: "TEXT NOT NULL",
+      modelId: "TEXT NOT NULL",
+      isFree: "INTEGER DEFAULT 0",
+      firstSeenAt: "TEXT NOT NULL",
+      acknowledged: "INTEGER DEFAULT 0",
+    },
+    indexes: [
+      "CREATE INDEX IF NOT EXISTS idx_sm_provider ON seenModels(providerAlias)",
+      "CREATE INDEX IF NOT EXISTS idx_sm_unseen ON seenModels(acknowledged)",
     ],
   },
 };

--- a/src/lib/newModelsCache.js
+++ b/src/lib/newModelsCache.js
@@ -1,0 +1,21 @@
+// Shared in-memory cache for the /api/models/new discovery result.
+// Imported by both GET (uses it) and POST (clears it after acknowledge).
+const CACHE_TTL_MS = 2 * 60 * 1000; // 2 minutes
+
+const cache = { at: 0, data: null };
+
+export function getCachedResult() {
+  const now = Date.now();
+  if (cache.data && now - cache.at < CACHE_TTL_MS) return cache.data;
+  return null;
+}
+
+export function setCachedResult(data) {
+  cache.at = Date.now();
+  cache.data = data;
+}
+
+export function clearCache() {
+  cache.at = 0;
+  cache.data = null;
+}

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -44,4 +44,5 @@ export {
   acknowledgeModels,
   countUnseenModels,
   seedSeenModels,
+  getUnseenModels,
 } from "@/lib/db/repos/seenModelsRepo.js";

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -36,3 +36,12 @@ export {
   validateApiKey,
   isCloudEnabled,
 } from "@/lib/localDb";
+
+// Seen models (New Models discovery)
+export {
+  getSeenModels,
+  reconcileSeenModels,
+  acknowledgeModels,
+  countUnseenModels,
+  seedSeenModels,
+} from "@/lib/db/repos/seenModelsRepo.js";


### PR DESCRIPTION
Closes #3603

Adds a "New Models" discovery feature to the Providers page. See the linked issue for full details.

### Summary

- Scans all active providers (OAuth, free-tier, API-key, self-added compatible nodes) via `buildModelsList`
- Tracks seen models in a new `seenModels` SQLite table with first-scan seeding
- Button on Providers page header with unread badge
- Modal with NEW/FREE badges per model, grouped by provider
- 2-min in-memory cache to avoid hammering upstream APIs
- Works across all SQLite drivers (better-sqlite3, node:sqlite, sql.js)