### PR TITLE
feat(providers): add multi-protocol custom providers

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -84,7 +84,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // /chat/completions), so without this guard a claude-format request would wrongly
   // route kimi to /messages.
   const modelSupportedFormats = getModelSupportedFormats(alias, model);
-  const runtimeTransport = resolveTransport(provider, sourceFormat);
+  const runtimeTransport = resolveTransport(provider, sourceFormat, credentials);
   // Per-model guard: when a model declares supportedFormats, only use the
   // sourceFormat-matched transport if that format is declared (opencode-go models
   // differ — kimi/glm only do /chat/completions). Undeclared models keep the

--- a/open-sse/services/provider.js
+++ b/open-sse/services/provider.js
@@ -145,9 +145,9 @@ export function getTargetFormat(provider, credentials = null) {
 // Resolve which transport to use for a provider given the client sourceFormat.
 // Multi-endpoint providers (transport.transports[]) pick the entry matching sourceFormat
 // to avoid lossy translation; falls back to the default transport when no match.
-export function resolveTransport(provider, sourceFormat) {
+export function resolveTransport(provider, sourceFormat, credentials = null) {
   const config = PROVIDERS[provider];
-  const transports = config?.transports;
+  const transports = config?.transports || credentials?.providerSpecificData?.transports;
   if (!Array.isArray(transports) || !transports.length) return null;
   return transports.find(t => t.format === sourceFormat) || null;
 }

--- a/src/app/(dashboard)/dashboard/providers/[id]/EditCompatibleNodeModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/EditCompatibleNodeModal.js
@@ -1,15 +1,30 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import PropTypes from "prop-types";
-import { Button, Badge, Input, Modal, Select } from "@/shared/components";
+import { Badge, Button, Input, Modal, Select } from "@/shared/components";
 
-export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose, isAnthropic }) {
+const API_TYPE_OPTIONS = [
+  { value: "chat", label: "Chat Completions" },
+  { value: "responses", label: "Responses API" },
+];
+
+export default function EditCompatibleNodeModal({
+  isOpen,
+  node,
+  onSave,
+  onClose,
+  isAnthropic,
+}) {
+  const isMulti = node?.type === "multi-compatible";
   const [formData, setFormData] = useState({
     name: "",
     prefix: "",
     apiType: "chat",
     baseUrl: "https://api.openai.com/v1",
+    openaiUrl: "",
+    anthropicUrl: "",
+    supportsResponses: false,
   });
   const [saving, setSaving] = useState(false);
   const [checkKey, setCheckKey] = useState("");
@@ -18,33 +33,46 @@ export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose,
   const [validationResult, setValidationResult] = useState(null);
 
   useEffect(() => {
-    if (node) {
-      setFormData({
-        name: node.name || "",
-        prefix: node.prefix || "",
-        apiType: node.apiType || "chat",
-        baseUrl: node.baseUrl || (isAnthropic ? "https://api.anthropic.com/v1" : "https://api.openai.com/v1"),
-      });
-    }
+    if (!node) return;
+
+    const transportUrl = (format) =>
+      node.transports?.find((transport) => transport.format === format)?.baseUrl || "";
+    setFormData({
+      name: node.name || "",
+      prefix: node.prefix || "",
+      apiType: node.apiType || "chat",
+      baseUrl:
+        node.baseUrl ||
+        (isAnthropic
+          ? "https://api.anthropic.com/v1"
+          : "https://api.openai.com/v1"),
+      openaiUrl: node.baseUrl || transportUrl("openai"),
+      anthropicUrl: transportUrl("claude"),
+      supportsResponses: Boolean(transportUrl("openai-responses")),
+    });
+    setValidationResult(null);
   }, [node, isAnthropic]);
 
-  const apiTypeOptions = [
-    { value: "chat", label: "Chat Completions" },
-    { value: "responses", label: "Responses API" },
-  ];
+  const hasRequiredEndpoints = isMulti
+    ? formData.openaiUrl.trim() && formData.anthropicUrl.trim()
+    : formData.baseUrl.trim();
 
   const handleSubmit = async () => {
-    if (!formData.name.trim() || !formData.prefix.trim() || !formData.baseUrl.trim()) return;
+    if (!formData.name.trim() || !formData.prefix.trim() || !hasRequiredEndpoints) return;
     setSaving(true);
     try {
       const payload = {
         name: formData.name,
         prefix: formData.prefix,
-        baseUrl: formData.baseUrl,
+        ...(isMulti
+          ? {
+              openaiUrl: formData.openaiUrl,
+              anthropicUrl: formData.anthropicUrl,
+              supportsResponses: formData.supportsResponses,
+            }
+          : { baseUrl: formData.baseUrl }),
       };
-      if (!isAnthropic) {
-        payload.apiType = formData.apiType;
-      }
+      if (!isAnthropic && !isMulti) payload.apiType = formData.apiType;
       await onSave(payload);
     } finally {
       setSaving(false);
@@ -58,14 +86,30 @@ export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose,
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          baseUrl: formData.baseUrl,
+          ...(isMulti
+            ? {
+                openaiUrl: formData.openaiUrl,
+                anthropicUrl: formData.anthropicUrl,
+                responsesUrl: formData.responsesUrl,
+              }
+            : { baseUrl: formData.baseUrl }),
           apiKey: checkKey,
-          type: isAnthropic ? "anthropic-compatible" : "openai-compatible",
-          modelId: checkModelId.trim() || undefined
+          type: isMulti
+            ? "multi-compatible"
+            : isAnthropic
+              ? "anthropic-compatible"
+              : "openai-compatible",
+          modelId: checkModelId.trim() || undefined,
         }),
       });
       const data = await res.json();
-      setValidationResult(data.valid ? "success" : "failed");
+      setValidationResult(data.valid ? data : "failed");
+      if (isMulti && data.valid) {
+        setFormData((prev) => ({
+          ...prev,
+          supportsResponses: Boolean(data.supportsResponses),
+        }));
+      }
     } catch {
       setValidationResult("failed");
     } finally {
@@ -75,66 +119,128 @@ export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose,
 
   if (!node) return null;
 
+  const providerLabel = isMulti
+    ? "Multi-protocol"
+    : isAnthropic
+      ? "Anthropic"
+      : "OpenAI";
+
   return (
-    <Modal isOpen={isOpen} title={`Edit ${isAnthropic ? "Anthropic" : "OpenAI"} Compatible`} onClose={onClose}>
+    <Modal isOpen={isOpen} title={`Edit ${providerLabel} Compatible`} onClose={onClose}>
       <div className="flex flex-col gap-4">
         <Input
           label="Name"
           value={formData.name}
           onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-          placeholder={`${isAnthropic ? "Anthropic" : "OpenAI"} Compatible (Prod)`}
+          placeholder={`${providerLabel} Compatible (Prod)`}
           hint="Required. A friendly label for this node."
         />
         <Input
           label="Prefix"
           value={formData.prefix}
           onChange={(e) => setFormData({ ...formData, prefix: e.target.value })}
-          placeholder={isAnthropic ? "ac-prod" : "oc-prod"}
+          placeholder={isMulti ? "multi-prod" : isAnthropic ? "ac-prod" : "oc-prod"}
           hint="Required. Used as the provider prefix for model IDs."
         />
-        {!isAnthropic && (
+        {!isAnthropic && !isMulti && (
           <Select
             label="API Type"
-            options={apiTypeOptions}
+            options={API_TYPE_OPTIONS}
             value={formData.apiType}
             onChange={(e) => setFormData({ ...formData, apiType: e.target.value })}
           />
         )}
-        <Input
-          label="Base URL"
-          value={formData.baseUrl}
-          onChange={(e) => setFormData({ ...formData, baseUrl: e.target.value })}
-          placeholder={isAnthropic ? "https://api.anthropic.com/v1" : "https://api.openai.com/v1"}
-          hint={`Use the base URL (ending in /v1) for your ${isAnthropic ? "Anthropic" : "OpenAI"}-compatible API.`}
-        />
-        <div className="flex gap-2">
+        {isMulti ? (
+          <>
+            <Input
+              label="OpenAI URL"
+              value={formData.openaiUrl}
+              onChange={(e) => setFormData({
+                ...formData,
+                openaiUrl: e.target.value,
+                supportsResponses: false,
+              })}
+              placeholder="https://provider.example/v1"
+              hint="Required. Base URL, Chat Completions URL, or Responses URL. Check detects Responses support."
+            />
+            <Input
+              label="Anthropic Messages URL"
+              value={formData.anthropicUrl}
+              onChange={(e) => setFormData({ ...formData, anthropicUrl: e.target.value })}
+              placeholder="https://provider.example/v1/messages"
+              hint="Required. Base URL or full Anthropic Messages endpoint URL."
+            />
+          </>
+        ) : (
           <Input
-            label="API Key (for Check)"
-            type="password"
-            value={checkKey}
-            onChange={(e) => setCheckKey(e.target.value)}
-            className="flex-1"
+            label="Base URL"
+            value={formData.baseUrl}
+            onChange={(e) => setFormData({ ...formData, baseUrl: e.target.value })}
+            placeholder={
+              isAnthropic
+                ? "https://api.anthropic.com/v1"
+                : "https://api.openai.com/v1"
+            }
+            hint={`Use the base URL ending in /v1 for your ${providerLabel}-compatible API.`}
           />
-          <div className="pt-6">
-            <Button onClick={handleValidate} disabled={!checkKey || validating || !formData.baseUrl.trim()} variant="secondary">
-              {validating ? "Checking..." : "Check"}
-            </Button>
-          </div>
-        </div>
+        )}
         <Input
-          label="Model ID (optional)"
+          label="API Key (for Check)"
+          type="password"
+          value={checkKey}
+          onChange={(e) => setCheckKey(e.target.value)}
+        />
+        <Input
+          label={isMulti ? "Model ID" : "Model ID (optional)"}
           value={checkModelId}
           onChange={(e) => setCheckModelId(e.target.value)}
           placeholder="e.g. my-model-id"
-          hint="If provider lacks /models endpoint, enter a model ID to validate via chat/completions instead."
+          hint={
+            isMulti
+              ? "Required to check each protocol endpoint."
+              : "If the provider lacks /models, enter a model ID to validate with inference."
+          }
         />
-        {validationResult && (
-          <Badge variant={validationResult === "success" ? "success" : "error"}>
-            {validationResult === "success" ? "Valid" : "Invalid"}
-          </Badge>
-        )}
-        <div className="flex gap-2">
-          <Button onClick={handleSubmit} fullWidth disabled={!formData.name.trim() || !formData.prefix.trim() || !formData.baseUrl.trim() || saving}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <Button
+            onClick={handleValidate}
+            disabled={
+              !checkKey ||
+              validating ||
+              !hasRequiredEndpoints ||
+              (isMulti && !checkModelId.trim())
+            }
+            variant="secondary"
+            className="w-full sm:w-auto"
+          >
+            {validating ? "Checking..." : "Check"}
+          </Button>
+          {validationResult && (
+            <>
+              <Badge variant={validationResult === "failed" ? "error" : "success"}>
+                {validationResult === "failed" ? "Invalid" : "Valid"}
+              </Badge>
+              {isMulti && validationResult !== "failed" && (
+                <span className="text-sm text-text-muted">
+                  {validationResult.supportsResponses
+                    ? "Responses supported"
+                    : "Responses will use Chat fallback"}
+                </span>
+              )}
+            </>
+          )}
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Button
+            onClick={handleSubmit}
+            fullWidth
+            disabled={
+              !formData.name.trim() ||
+              !formData.prefix.trim() ||
+              !hasRequiredEndpoints ||
+              saving
+            }
+          >
             {saving ? "Saving..." : "Save"}
           </Button>
           <Button onClick={onClose} variant="ghost" fullWidth>
@@ -154,6 +260,13 @@ EditCompatibleNodeModal.propTypes = {
     prefix: PropTypes.string,
     apiType: PropTypes.string,
     baseUrl: PropTypes.string,
+    type: PropTypes.string,
+    transports: PropTypes.arrayOf(
+      PropTypes.shape({
+        format: PropTypes.string,
+        baseUrl: PropTypes.string,
+      }),
+    ),
   }),
   onSave: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -131,9 +131,25 @@ export default function ProviderDetailPage() {
   const providerInfo = providerNode
     ? {
         id: providerNode.id,
-        name: providerNode.name || (providerNode.type === "anthropic-compatible" ? "Anthropic Compatible" : "OpenAI Compatible"),
-        color: providerNode.type === "anthropic-compatible" ? "#D97757" : "#10A37F",
-        textIcon: providerNode.type === "anthropic-compatible" ? "AC" : "OC",
+        name:
+          providerNode.name ||
+          (providerNode.type === "multi-compatible"
+            ? "Multi-protocol Compatible"
+            : providerNode.type === "anthropic-compatible"
+              ? "Anthropic Compatible"
+              : "OpenAI Compatible"),
+        color:
+          providerNode.type === "multi-compatible"
+            ? "#7C3AED"
+            : providerNode.type === "anthropic-compatible"
+              ? "#D97757"
+              : "#10A37F",
+        textIcon:
+          providerNode.type === "multi-compatible"
+            ? "MP"
+            : providerNode.type === "anthropic-compatible"
+              ? "AC"
+              : "OC",
         apiType: providerNode.apiType,
         baseUrl: providerNode.baseUrl,
         type: providerNode.type,
@@ -151,6 +167,7 @@ export default function ProviderDetailPage() {
   
   const isOpenAICompatible = isOpenAICompatibleProvider(providerId);
   const isAnthropicCompatible = isAnthropicCompatibleProvider(providerId);
+  const isMultiCompatible = providerNode?.type === "multi-compatible";
   const isCompatible = isOpenAICompatible || isAnthropicCompatible;
   const hasDualAuthModes = !isCompatible && isOAuth && supportsApiKeyAuth;
   const oauthConnectionLabel =
@@ -1263,6 +1280,7 @@ export default function ProviderDetailPage() {
 
   // Determine icon path: OpenAI Compatible providers use specialized icons
   const getHeaderIconPath = () => {
+    if (isMultiCompatible) return null;
     if (isOpenAICompatible && providerInfo.apiType) {
       return providerInfo.apiType === "responses" ? "/providers/oai-r.png" : "/providers/oai-cc.png";
     }
@@ -1359,11 +1377,33 @@ export default function ProviderDetailPage() {
         <Card>
           <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div className="min-w-0">
-              <h2 className="text-lg font-semibold">{isAnthropicCompatible ? "Anthropic Compatible Details" : "OpenAI Compatible Details"}</h2>
-              <p className="break-all text-sm text-text-muted">
-                {isAnthropicCompatible ? "Messages API" : (providerNode.apiType === "responses" ? "Responses API" : "Chat Completions")} · {(providerNode.baseUrl || "").replace(/\/$/, "")}/
-                {isAnthropicCompatible ? "messages" : (providerNode.apiType === "responses" ? "responses" : "chat/completions")}
-              </p>
+              <h2 className="text-lg font-semibold">
+                {isMultiCompatible
+                  ? "Multi-protocol Compatible Details"
+                  : isAnthropicCompatible
+                    ? "Anthropic Compatible Details"
+                    : "OpenAI Compatible Details"}
+              </h2>
+              {isMultiCompatible ? (
+                <div className="flex flex-col gap-1 text-sm text-text-muted">
+                  {providerNode.transports?.map((transport) => (
+                    <p key={transport.format} className="break-all">
+                      {transport.format === "openai"
+                        ? "Chat Completions"
+                        : transport.format === "claude"
+                          ? "Anthropic Messages"
+                          : "OpenAI Responses"}
+                      {" · "}
+                      {transport.baseUrl}
+                    </p>
+                  ))}
+                </div>
+              ) : (
+                <p className="break-all text-sm text-text-muted">
+                  {isAnthropicCompatible ? "Messages API" : (providerNode.apiType === "responses" ? "Responses API" : "Chat Completions")} · {(providerNode.baseUrl || "").replace(/\/$/, "")}/
+                  {isAnthropicCompatible ? "messages" : (providerNode.apiType === "responses" ? "responses" : "chat/completions")}
+                </p>
+              )}
             </div>
             <div className="grid grid-cols-1 gap-2 sm:flex sm:items-center">
               <Button
@@ -1393,7 +1433,7 @@ export default function ProviderDetailPage() {
                 onClick={async () => {
                   setConfirmState({
                     title: "Delete Compatible Node",
-                    message: `Delete this ${isAnthropicCompatible ? "Anthropic" : "OpenAI"} Compatible node?`,
+                    message: `Delete this ${isMultiCompatible ? "Multi-protocol" : isAnthropicCompatible ? "Anthropic" : "OpenAI"} Compatible node?`,
                     onConfirm: async () => {
                       setConfirmState(null);
                       try {

--- a/src/app/(dashboard)/dashboard/providers/components/AddCompatibleModal.js
+++ b/src/app/(dashboard)/dashboard/providers/components/AddCompatibleModal.js
@@ -27,6 +27,16 @@ const VARIANT_CONFIG = {
     errorLabel: "Anthropic Compatible",
     hasApiType: false,
   },
+  multi: {
+    title: "Add Multi-protocol Compatible",
+    type: "multi-compatible",
+    namePlaceholder: "Multi-protocol Provider (Prod)",
+    prefixPlaceholder: "multi-prod",
+    modelIdPlaceholder: "e.g. shared-model-id",
+    errorLabel: "Multi-protocol Compatible",
+    hasApiType: false,
+    isMulti: true,
+  },
 };
 
 const API_TYPE_OPTIONS = [
@@ -40,7 +50,13 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
     name: "",
     prefix: "",
     ...(config.hasApiType ? { apiType: "chat" } : {}),
-    baseUrl: config.defaultBaseUrl,
+    ...(config.isMulti
+      ? {
+          openaiUrl: "",
+          anthropicUrl: "",
+          supportsResponses: false,
+        }
+      : { baseUrl: config.defaultBaseUrl }),
   });
 
   const [formData, setFormData] = useState(initialFormData);
@@ -50,7 +66,7 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
   const [validating, setValidating] = useState(false);
   const [validationResult, setValidationResult] = useState(null);
 
-  // openai: reset baseUrl when apiType changes; anthropic: reset checks when opened
+  // openai: reset baseUrl when apiType changes; other variants: reset checks when opened
   useEffect(() => {
     if (config.hasApiType) {
       setFormData((prev) => ({ ...prev, baseUrl: config.defaultBaseUrl }));
@@ -59,10 +75,14 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
       setCheckKey("");
       setCheckModelId("");
     }
-  }, [config.hasApiType ? formData.apiType : isOpen]);
+  }, [config.hasApiType, config.defaultBaseUrl, formData.apiType, isOpen]);
+
+  const hasRequiredEndpoints = config.isMulti
+    ? formData.openaiUrl.trim() && formData.anthropicUrl.trim()
+    : formData.baseUrl.trim();
 
   const handleSubmit = async () => {
-    if (!formData.name.trim() || !formData.prefix.trim() || !formData.baseUrl.trim()) return;
+    if (!formData.name.trim() || !formData.prefix.trim() || !hasRequiredEndpoints) return;
     setSubmitting(true);
     try {
       const res = await fetch("/api/provider-nodes", {
@@ -72,7 +92,13 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
           name: formData.name,
           prefix: formData.prefix,
           ...(config.hasApiType ? { apiType: formData.apiType } : {}),
-          baseUrl: formData.baseUrl,
+          ...(config.isMulti
+            ? {
+                openaiUrl: formData.openaiUrl,
+                anthropicUrl: formData.anthropicUrl,
+                supportsResponses: formData.supportsResponses,
+              }
+            : { baseUrl: formData.baseUrl }),
           type: config.type,
         }),
       });
@@ -97,7 +123,13 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          baseUrl: formData.baseUrl,
+          ...(config.isMulti
+            ? {
+                openaiUrl: formData.openaiUrl,
+                anthropicUrl: formData.anthropicUrl,
+                supportsResponses: formData.supportsResponses,
+              }
+            : { baseUrl: formData.baseUrl }),
           apiKey: checkKey,
           type: config.type,
           modelId: checkModelId.trim() || undefined,
@@ -105,6 +137,12 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
       });
       const data = await res.json();
       setValidationResult(data);
+      if (config.isMulti && data.valid) {
+        setFormData((prev) => ({
+          ...prev,
+          supportsResponses: Boolean(data.supportsResponses),
+        }));
+      }
     } catch {
       setValidationResult({ valid: false, error: "Network error" });
     } finally {
@@ -119,9 +157,15 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
       return (
         <>
           <Badge variant="success">Valid</Badge>
-          {method === "chat" && (
+          {config.isMulti ? (
+            <span className="text-sm text-text-muted">
+              {validationResult.supportsResponses
+                ? "Responses supported"
+                : "Responses will use Chat fallback"}
+            </span>
+          ) : method === "chat" ? (
             <span className="text-sm text-text-muted">(via inference test)</span>
-          )}
+          ) : null}
         </>
       );
     }
@@ -158,13 +202,36 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
             onChange={(e) => setFormData({ ...formData, apiType: e.target.value })}
           />
         )}
-        <Input
-          label="Base URL"
-          value={formData.baseUrl}
-          onChange={(e) => setFormData({ ...formData, baseUrl: e.target.value })}
-          placeholder={config.defaultBaseUrl}
-          hint={config.baseUrlHint}
-        />
+        {config.isMulti ? (
+          <>
+            <Input
+              label="OpenAI URL"
+              value={formData.openaiUrl}
+              onChange={(e) => setFormData({
+                ...formData,
+                openaiUrl: e.target.value,
+                supportsResponses: false,
+              })}
+              placeholder="https://provider.example/v1"
+              hint="Required. Base URL, Chat Completions URL, or Responses URL. Check detects Responses support."
+            />
+            <Input
+              label="Anthropic Messages URL"
+              value={formData.anthropicUrl}
+              onChange={(e) => setFormData({ ...formData, anthropicUrl: e.target.value })}
+              placeholder="https://provider.example/v1/messages"
+              hint="Required. Base URL or full Anthropic Messages endpoint URL."
+            />
+          </>
+        ) : (
+          <Input
+            label="Base URL"
+            value={formData.baseUrl}
+            onChange={(e) => setFormData({ ...formData, baseUrl: e.target.value })}
+            placeholder={config.defaultBaseUrl}
+            hint={config.baseUrlHint}
+          />
+        )}
         <Input
           label="API Key (for Check)"
           type="password"
@@ -172,16 +239,20 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
           onChange={(e) => setCheckKey(e.target.value)}
         />
         <Input
-          label="Model ID (optional)"
+          label={config.isMulti ? "Model ID" : "Model ID (optional)"}
           value={checkModelId}
           onChange={(e) => setCheckModelId(e.target.value)}
           placeholder={config.modelIdPlaceholder}
-          hint="If provider lacks /models endpoint, enter a model ID to validate via chat/completions instead."
+          hint={
+            config.isMulti
+              ? "Required to check each protocol endpoint."
+              : "If the provider lacks /models, enter a model ID to validate with inference."
+          }
         />
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
           <Button
             onClick={handleValidate}
-            disabled={!checkKey || validating || !formData.baseUrl.trim()}
+            disabled={!checkKey || validating || !hasRequiredEndpoints || (config.isMulti && !checkModelId.trim())}
             variant="secondary"
             className="w-full sm:w-auto"
           >
@@ -196,7 +267,7 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
             disabled={
               !formData.name.trim() ||
               !formData.prefix.trim() ||
-              !formData.baseUrl.trim() ||
+              !hasRequiredEndpoints ||
               submitting
             }
           >
@@ -212,7 +283,7 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
 }
 
 AddCompatibleModal.propTypes = {
-  variant: PropTypes.oneOf(["openai", "anthropic"]).isRequired,
+  variant: PropTypes.oneOf(["openai", "anthropic", "multi"]).isRequired,
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onCreated: PropTypes.func.isRequired,

--- a/src/app/(dashboard)/dashboard/providers/page.js
+++ b/src/app/(dashboard)/dashboard/providers/page.js
@@ -103,6 +103,8 @@ export default function ProvidersPage() {
   const [showAddCompatibleModal, setShowAddCompatibleModal] = useState(false);
   const [showAddAnthropicCompatibleModal, setShowAddAnthropicCompatibleModal] =
     useState(false);
+  const [showAddMultiCompatibleModal, setShowAddMultiCompatibleModal] =
+    useState(false);
   const [testingMode, setTestingMode] = useState(null);
   const [testResults, setTestResults] = useState(null);
   const notify = useNotificationStore();
@@ -277,6 +279,17 @@ export default function ProvidersPage() {
     }))
     .filter((p) => matchSearch(p.name));
 
+  const multiCompatibleProviders = providerNodes
+    .filter((node) => node.type === "multi-compatible")
+    .map((node) => ({
+      id: node.id,
+      name: node.name || "Multi-protocol Compatible",
+      color: "#7C3AED",
+      textIcon: "MP",
+      apiType: "multi",
+    }))
+    .filter((p) => matchSearch(p.name));
+
   // Dual-auth providers (oauth + apikey) store API keys as authType "apikey"
   // (and sometimes "api_key"). Card stats must count both so totals match detail.
   // kiro has no authModes in registry but accepts both (headless uses "api_key").
@@ -359,7 +372,8 @@ export default function ProvidersPage() {
     freeTierEntries.length > 0 ||
     apikeyEntries.length > 0 ||
     compatibleProviders.length > 0 ||
-    anthropicCompatibleProviders.length > 0;
+    anthropicCompatibleProviders.length > 0 ||
+    multiCompatibleProviders.length > 0;
 
   return (
     <div className="flex min-w-0 flex-col gap-6 px-1 sm:px-0">
@@ -372,15 +386,24 @@ export default function ProvidersPage() {
         </div>
       )}
 
-      {/* Custom Providers (OpenAI/Anthropic Compatible) — dynamic */}
+      {/* Custom Providers — dynamic */}
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <h2 className="text-lg sm:text-xl font-semibold flex items-center gap-2 leading-tight">
-            Custom Providers (OpenAI/Anthropic Compatible){" "}
+            Custom Providers
           </h2>
           <div className="grid grid-cols-1 gap-2 sm:flex sm:w-auto">
             <Button
               size="sm"
+              icon="add"
+              onClick={() => setShowAddMultiCompatibleModal(true)}
+              className="w-full sm:w-auto"
+            >
+              Add Multi-protocol
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
               icon="add"
               onClick={() => setShowAddAnthropicCompatibleModal(true)}
               className="w-full sm:w-auto"
@@ -399,27 +422,30 @@ export default function ProvidersPage() {
           </div>
         </div>
         {compatibleProviders.length === 0 &&
-        anthropicCompatibleProviders.length === 0 ? (
+        anthropicCompatibleProviders.length === 0 &&
+        multiCompatibleProviders.length === 0 ? (
           <div className="flex items-center justify-center gap-2 py-2 border border-dashed border-border rounded-xl text-text-muted text-sm">
             <span className="material-symbols-outlined text-[18px]">extension</span>
-            <span>No custom providers — use buttons above to add OpenAI/Anthropic compatible endpoints</span>
+            <span>No custom providers. Use the buttons above to add one.</span>
           </div>
         ) : (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3 xl:grid-cols-4">
-            {[...compatibleProviders, ...anthropicCompatibleProviders].map(
-              (info) => (
-                <ApiKeyProviderCard
-                  key={info.id}
-                  providerId={info.id}
-                  provider={info}
-                  stats={getProviderStats(info.id, "apikey")}
-                  authType="compatible"
-                  onToggle={(active) =>
-                    handleToggleProvider(info.id, "apikey", active)
-                  }
-                />
-              ),
-            )}
+            {[
+              ...multiCompatibleProviders,
+              ...compatibleProviders,
+              ...anthropicCompatibleProviders,
+            ].map((info) => (
+              <ApiKeyProviderCard
+                key={info.id}
+                providerId={info.id}
+                provider={info}
+                stats={getProviderStats(info.id, "apikey")}
+                authType="compatible"
+                onToggle={(active) =>
+                  handleToggleProvider(info.id, "apikey", active)
+                }
+              />
+            ))}
           </div>
         )}
       </div>
@@ -621,6 +647,15 @@ export default function ProvidersPage() {
           setShowAddAnthropicCompatibleModal(false);
         }}
       />
+      <AddCompatibleModal
+        variant="multi"
+        isOpen={showAddMultiCompatibleModal}
+        onClose={() => setShowAddMultiCompatibleModal(false)}
+        onCreated={(node) => {
+          setProviderNodes((prev) => [...prev, node]);
+          setShowAddMultiCompatibleModal(false);
+        }}
+      />
 
       {/* Test Results Modal */}
       {testResults && (
@@ -790,6 +825,7 @@ function ApiKeyProviderCard({
   };
 
   const getIconPath = () => {
+    if (provider.apiType === "multi") return null;
     if (isCompatible && provider.apiType)
       return provider.apiType === "responses"
         ? "/providers/oai-r.png"
@@ -840,9 +876,11 @@ function ApiKeyProviderCard({
                     {getStatusDisplay(connected, error, errorCode)}
                     {isCompatible && (
                       <Badge variant="default" size="sm">
-                        {provider.apiType === "responses"
-                          ? "Responses"
-                          : "Chat"}
+                        {provider.apiType === "multi"
+                          ? "Chat + Messages"
+                          : provider.apiType === "responses"
+                            ? "Responses"
+                            : "Chat"}
                       </Badge>
                     )}
                     {isAnthropicCompatible && (

--- a/src/app/api/provider-nodes/[id]/route.js
+++ b/src/app/api/provider-nodes/[id]/route.js
@@ -1,12 +1,16 @@
 import { NextResponse } from "next/server";
 import { deleteProviderConnectionsByProvider, deleteProviderNode, getProviderConnections, getProviderNodeById, updateProviderConnection, updateProviderNode } from "@/models";
+import { canonicalEndpoint, openAIEndpoints } from "../endpointUrls.js";
+
+const BEARER_AUTH = { combined: true, header: "Authorization", scheme: "bearer" };
+const ANTHROPIC_AUTH = { combined: true, header: "x-api-key", scheme: "raw", anthropicVersion: true };
 
 // PUT /api/provider-nodes/[id] - Update provider node
 export async function PUT(request, { params }) {
   try {
     const { id } = await params;
     const body = await request.json();
-    const { name, prefix, apiType, baseUrl } = body;
+    const { name, prefix, apiType, baseUrl, openaiUrl, anthropicUrl, supportsResponses } = body;
     const node = await getProviderNodeById(id);
 
     if (!node) {
@@ -26,11 +30,29 @@ export async function PUT(request, { params }) {
       return NextResponse.json({ error: "Invalid OpenAI compatible API type" }, { status: 400 });
     }
 
-    if (!baseUrl?.trim()) {
+    let transports = node.transports;
+    let nextBaseUrl = baseUrl;
+    if (node.type === "multi-compatible") {
+      const openai = openAIEndpoints(openaiUrl);
+      const messagesEndpoint = canonicalEndpoint(anthropicUrl, "/messages");
+
+      if (!openai.chatUrl || !messagesEndpoint) {
+        return NextResponse.json({ error: "OpenAI and Anthropic endpoint URLs are required" }, { status: 400 });
+      }
+
+      nextBaseUrl = openai.baseUrl;
+      transports = [
+        { format: "openai", baseUrl: openai.chatUrl, auth: BEARER_AUTH },
+        { format: "claude", baseUrl: messagesEndpoint, auth: ANTHROPIC_AUTH },
+        ...(supportsResponses ? [{ format: "openai-responses", baseUrl: openai.responsesUrl, auth: BEARER_AUTH }] : []),
+      ];
+    }
+
+    if (!nextBaseUrl?.trim()) {
       return NextResponse.json({ error: "Base URL is required" }, { status: 400 });
     }
 
-    let sanitizedBaseUrl = baseUrl.trim();
+    let sanitizedBaseUrl = nextBaseUrl.trim();
     
     // Sanitize Base URL for Anthropic Compatible
     if (node.type === "anthropic-compatible") {
@@ -52,6 +74,7 @@ export async function PUT(request, { params }) {
       name: name.trim(),
       prefix: prefix.trim(),
       baseUrl: sanitizedBaseUrl,
+      ...(node.type === "multi-compatible" ? { transports } : {}),
     };
 
     if (node.type === "openai-compatible") {
@@ -66,9 +89,10 @@ export async function PUT(request, { params }) {
         providerSpecificData: {
           ...(connection.providerSpecificData || {}),
           prefix: prefix.trim(),
-          apiType: node.type === "openai-compatible" ? apiType : undefined,
+          apiType: node.type === "openai-compatible" ? apiType : node.type === "multi-compatible" ? "chat" : undefined,
           baseUrl: sanitizedBaseUrl,
           nodeName: updated.name,
+          ...(node.type === "multi-compatible" ? { transports } : {}),
         }
       })
     )));

--- a/src/app/api/provider-nodes/endpointUrls.js
+++ b/src/app/api/provider-nodes/endpointUrls.js
@@ -1,0 +1,24 @@
+function normalizeUrl(value) {
+  return typeof value === "string" ? value.trim().replace(/\/+$/, "") : "";
+}
+
+export function canonicalEndpoint(value, suffix) {
+  const endpoint = normalizeUrl(value);
+  if (!endpoint || endpoint.endsWith(suffix)) return endpoint;
+  return `${endpoint}${suffix}`;
+}
+
+export function openAIEndpoints(value) {
+  let baseUrl = normalizeUrl(value);
+  for (const suffix of ["/chat/completions", "/responses"]) {
+    if (baseUrl.endsWith(suffix)) {
+      baseUrl = baseUrl.slice(0, -suffix.length);
+      break;
+    }
+  }
+  return {
+    baseUrl,
+    chatUrl: baseUrl ? `${baseUrl}/chat/completions` : "",
+    responsesUrl: baseUrl ? `${baseUrl}/responses` : "",
+  };
+}

--- a/src/app/api/provider-nodes/route.js
+++ b/src/app/api/provider-nodes/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { createProviderNode, getProviderNodes } from "@/models";
 import { OPENAI_COMPATIBLE_PREFIX, ANTHROPIC_COMPATIBLE_PREFIX, CUSTOM_EMBEDDING_PREFIX } from "@/shared/constants/providers";
 import { generateId } from "@/shared/utils";
+import { canonicalEndpoint, openAIEndpoints } from "./endpointUrls.js";
 
 export const dynamic = "force-dynamic";
 
@@ -16,6 +17,9 @@ const ANTHROPIC_COMPATIBLE_DEFAULTS = {
 const CUSTOM_EMBEDDING_DEFAULTS = {
   baseUrl: "https://api.openai.com/v1",
 };
+
+const BEARER_AUTH = { combined: true, header: "Authorization", scheme: "bearer" };
+const ANTHROPIC_AUTH = { combined: true, header: "x-api-key", scheme: "raw", anthropicVersion: true };
 
 // GET /api/provider-nodes - List all provider nodes
 export async function GET() {
@@ -32,7 +36,7 @@ export async function GET() {
 export async function POST(request) {
   try {
     const body = await request.json();
-    const { name, prefix, apiType, baseUrl, type } = body;
+    const { name, prefix, apiType, baseUrl, type, openaiUrl, anthropicUrl, supportsResponses } = body;
 
     if (!name?.trim()) {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
@@ -44,6 +48,31 @@ export async function POST(request) {
 
     // Determine type
     const nodeType = type || "openai-compatible";
+
+    if (nodeType === "multi-compatible") {
+      const openai = openAIEndpoints(openaiUrl);
+      const messagesEndpoint = canonicalEndpoint(anthropicUrl, "/messages");
+
+      if (!openai.chatUrl || !messagesEndpoint) {
+        return NextResponse.json({ error: "OpenAI and Anthropic endpoint URLs are required" }, { status: 400 });
+      }
+
+      const transports = [
+        { format: "openai", baseUrl: openai.chatUrl, auth: BEARER_AUTH },
+        { format: "claude", baseUrl: messagesEndpoint, auth: ANTHROPIC_AUTH },
+        ...(supportsResponses ? [{ format: "openai-responses", baseUrl: openai.responsesUrl, auth: BEARER_AUTH }] : []),
+      ];
+      const node = await createProviderNode({
+        id: `${OPENAI_COMPATIBLE_PREFIX}multi-${generateId()}`,
+        type: "multi-compatible",
+        prefix: prefix.trim(),
+        apiType: "chat",
+        baseUrl: openai.baseUrl,
+        transports,
+        name: name.trim(),
+      });
+      return NextResponse.json({ node }, { status: 201 });
+    }
 
     if (nodeType === "openai-compatible") {
       if (!apiType || !["chat", "responses"].includes(apiType)) {

--- a/src/app/api/provider-nodes/validate/route.js
+++ b/src/app/api/provider-nodes/validate/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { assertPublicUrl } from "@/shared/utils/ssrfGuard.js";
 import { isLocalRequest } from "@/dashboardGuard";
+import { canonicalEndpoint, openAIEndpoints } from "../endpointUrls.js";
 
 // Fetch with timeout wrapper
 const fetchWithTimeout = (url, options, timeout = 10000) => {
@@ -55,7 +56,64 @@ const getChatErrorMessage = (status) => {
 export async function POST(request) {
   try {
     const body = await request.json();
-    const { baseUrl, apiKey, type, modelId } = body;
+    const { baseUrl, apiKey, type, modelId, openaiUrl, anthropicUrl } = body;
+
+    if (type === "multi-compatible") {
+      const openai = openAIEndpoints(openaiUrl);
+      const chatEndpoint = openai.chatUrl;
+      const messagesEndpoint = canonicalEndpoint(anthropicUrl, "/messages");
+      const responsesEndpoint = openai.responsesUrl;
+      const endpoints = [chatEndpoint, messagesEndpoint, responsesEndpoint].filter(Boolean);
+      if (!apiKey || !modelId?.trim() || !chatEndpoint || !messagesEndpoint) {
+        return NextResponse.json({ error: "Endpoint URLs, API key, and model ID required" }, { status: 400 });
+      }
+      if (endpoints.some((url) => !isValidUrl(url))) {
+        return NextResponse.json({ error: "Invalid URL format" }, { status: 400 });
+      }
+      if (!isLocalRequest(request)) {
+        try {
+          endpoints.forEach(assertPublicUrl);
+        } catch {
+          return NextResponse.json({ error: "URL not allowed" }, { status: 400 });
+        }
+      }
+
+      const model = modelId.trim();
+      const probes = [
+        ["openai", chatEndpoint, {
+          "Authorization": `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        }, { model, messages: [{ role: "user", content: "ping" }], max_tokens: 1 }],
+        ["claude", messagesEndpoint, {
+          "Authorization": `Bearer ${apiKey}`,
+          "x-api-key": apiKey,
+          "anthropic-version": "2023-06-01",
+          "Content-Type": "application/json",
+        }, { model, messages: [{ role: "user", content: "ping" }], max_tokens: 1 }],
+        ...(responsesEndpoint ? [["openai-responses", responsesEndpoint, {
+          "Authorization": `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        }, { model, input: "ping", max_output_tokens: 1 }]] : []),
+      ];
+      const results = await Promise.all(probes.map(async ([format, url, headers, probeBody]) => {
+        try {
+          const response = await fetchWithTimeout(url.replace(/\/+$/, ""), {
+            method: "POST",
+            headers,
+            body: JSON.stringify(probeBody),
+          });
+          return [format, response.ok];
+        } catch {
+          return [format, false];
+        }
+      }));
+      const endpointResults = Object.fromEntries(results);
+      return NextResponse.json({
+        valid: endpointResults.openai && endpointResults.claude,
+        supportsResponses: endpointResults["openai-responses"],
+        endpoints: endpointResults,
+      });
+    }
 
     if (!baseUrl || !apiKey) {
       return NextResponse.json({ error: "Base URL and API key required" }, { status: 400 });

--- a/src/app/api/providers/route.js
+++ b/src/app/api/providers/route.js
@@ -138,6 +138,7 @@ export async function POST(request) {
         apiType: node.apiType,
         baseUrl: node.baseUrl,
         nodeName: node.name,
+        ...(Array.isArray(node.transports) ? { transports: node.transports } : {}),
       };
     } else if (isAnthropicCompatibleProvider(provider)) {
       const node = await getProviderNodeById(provider);

--- a/src/lib/db/repos/nodesRepo.js
+++ b/src/lib/db/repos/nodesRepo.js
@@ -62,6 +62,7 @@ export async function createProviderNode(data) {
     prefix: data.prefix,
     apiType: data.apiType,
     baseUrl: data.baseUrl,
+    transports: data.transports,
     createdAt: now,
     updatedAt: now,
   };

--- a/src/sse/services/model.js
+++ b/src/sse/services/model.js
@@ -54,6 +54,12 @@ export async function getModelInfo(modelStr) {
         return { provider: matchedAnthropic.id, model: parsed.model };
       }
 
+      const multiNodes = await getProviderNodes({ type: "multi-compatible" });
+      const matchedMulti = multiNodes.find((node) => node.prefix === parsed.providerAlias);
+      if (matchedMulti) {
+        return { provider: matchedMulti.id, model: parsed.model };
+      }
+
       const embeddingNodes = await getProviderNodes({ type: "custom-embedding" });
       const matchedEmbedding = embeddingNodes.find((node) => node.prefix === parsed.providerAlias);
       if (matchedEmbedding) {

--- a/tests/unit/compatible-provider-connections.test.js
+++ b/tests/unit/compatible-provider-connections.test.js
@@ -115,6 +115,39 @@ describe("compatible provider connections API", () => {
     });
   });
 
+  it("copies multi-protocol transports into the connection", async () => {
+    const transports = [
+      {
+        format: "openai",
+        baseUrl: "https://multi.test/v1/chat/completions",
+        auth: { combined: true, header: "Authorization", scheme: "bearer" },
+      },
+      {
+        format: "claude",
+        baseUrl: "https://multi.test/v1/messages",
+        auth: { combined: true, header: "x-api-key", scheme: "raw", anthropicVersion: true },
+      },
+    ];
+    const ctx = await setupTestContext({
+      id: "openai-compatible-multi-test",
+      type: "multi-compatible",
+      name: "Multi-protocol Test Node",
+      prefix: "multi",
+      apiType: "chat",
+      baseUrl: "https://multi.test/v1",
+      transports,
+    });
+    cleanup = ctx.cleanup;
+
+    const response = await ctx.POST(makeRequest(ctx.node.id));
+    const body = await response.json();
+    const storedConnections = await ctx.getProviderConnections({ provider: ctx.node.id });
+
+    expect(response.status).toBe(201);
+    expect(body.connection.providerSpecificData.transports).toEqual(transports);
+    expect(storedConnections[0].providerSpecificData.transports).toEqual(transports);
+  });
+
   it("creates one API-key connection for an Anthropic-compatible node", async () => {
     const ctx = await setupTestContext({
       id: "anthropic-compatible-test",

--- a/tests/unit/model-routing.test.js
+++ b/tests/unit/model-routing.test.js
@@ -58,6 +58,26 @@ describe("model routing", () => {
       });
   });
 
+  it("routes multi-protocol node prefixes", async () => {
+    const ctx = await setupDb();
+    cleanup = ctx.cleanup;
+
+    await ctx.createProviderNode({
+      id: "openai-compatible-multi-test",
+      type: "multi-compatible",
+      name: "Multi-compatible Node",
+      prefix: "multi",
+      apiType: "chat",
+      baseUrl: "https://multi.test/v1",
+    });
+
+    await expect(ctx.getModelInfo("multi/shared-model"))
+      .resolves.toEqual({
+        provider: "openai-compatible-multi-test",
+        model: "shared-model",
+      });
+  });
+
   it("still routes non-reserved compatible node prefixes", async () => {
     const ctx = await setupDb();
     cleanup = ctx.cleanup;

--- a/tests/unit/multi-compatible-provider-nodes.test.js
+++ b/tests/unit/multi-compatible-provider-nodes.test.js
@@ -1,0 +1,243 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const originalDataDir = process.env.DATA_DIR;
+
+async function setup() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-multi-provider-"));
+  process.env.DATA_DIR = tempDir;
+  vi.resetModules();
+  vi.doMock("next/server", () => ({
+    NextResponse: {
+      json(body, init = {}) {
+        return new Response(JSON.stringify(body), {
+          status: init.status || 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    },
+  }));
+  vi.doMock("@/dashboardGuard", () => ({ isLocalRequest: () => true }));
+
+  const { POST } = await import("@/app/api/provider-nodes/route.js");
+  const { PUT } = await import("@/app/api/provider-nodes/[id]/route.js");
+  const { POST: validate } = await import("@/app/api/provider-nodes/validate/route.js");
+  const { POST: createConnection } = await import("@/app/api/providers/route.js");
+  const { getProviderConnections } = await import("@/models/index.js");
+  return {
+    POST,
+    PUT,
+    validate,
+    createConnection,
+    getProviderConnections,
+    cleanup() {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function makeRequest(overrides = {}) {
+  return new Request("https://9router.local/api/provider-nodes", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      type: "multi-compatible",
+      name: "Multi API",
+      prefix: "multi",
+      openaiUrl: "https://multi.test/v1/chat/completions/",
+      anthropicUrl: "https://multi.test/v1/messages/",
+      supportsResponses: true,
+      ...overrides,
+    }),
+  });
+}
+
+describe("multi-protocol compatible provider nodes", () => {
+  let cleanup = () => {};
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock("next/server");
+    vi.doUnmock("@/dashboardGuard");
+    vi.resetModules();
+    cleanup();
+    cleanup = () => {};
+    if (originalDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = originalDataDir;
+  });
+
+  it("creates native transports for each configured endpoint", async () => {
+    const ctx = await setup();
+    cleanup = ctx.cleanup;
+
+    const response = await ctx.POST(makeRequest());
+    const { node } = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(node.type).toBe("multi-compatible");
+    expect(node.id).toMatch(/^openai-compatible-multi-/);
+    expect(node.apiType).toBe("chat");
+    expect(node.baseUrl).toBe("https://multi.test/v1");
+    expect(node.transports).toEqual([
+      {
+        format: "openai",
+        baseUrl: "https://multi.test/v1/chat/completions",
+        auth: { combined: true, header: "Authorization", scheme: "bearer" },
+      },
+      {
+        format: "claude",
+        baseUrl: "https://multi.test/v1/messages",
+        auth: { combined: true, header: "x-api-key", scheme: "raw", anthropicVersion: true },
+      },
+      {
+        format: "openai-responses",
+        baseUrl: "https://multi.test/v1/responses",
+        auth: { combined: true, header: "Authorization", scheme: "bearer" },
+      },
+    ]);
+  });
+
+  it("accepts base URLs and stores full endpoint URLs", async () => {
+    const ctx = await setup();
+    cleanup = ctx.cleanup;
+
+    const response = await ctx.POST(makeRequest({
+      openaiUrl: "https://multi.test/v1/",
+      anthropicUrl: "https://multi.test/v1/",
+      supportsResponses: true,
+    }));
+    const { node } = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(node.baseUrl).toBe("https://multi.test/v1");
+    expect(node.transports.map((transport) => transport.baseUrl)).toEqual([
+      "https://multi.test/v1/chat/completions",
+      "https://multi.test/v1/messages",
+      "https://multi.test/v1/responses",
+    ]);
+  });
+
+  it("omits the optional Responses transport when support is not confirmed", async () => {
+    const ctx = await setup();
+    cleanup = ctx.cleanup;
+
+    const response = await ctx.POST(makeRequest({ supportsResponses: false }));
+    const { node } = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(node.transports.map((transport) => transport.format)).toEqual(["openai", "claude"]);
+  });
+
+  it("updates endpoint transports on existing connections", async () => {
+    const ctx = await setup();
+    cleanup = ctx.cleanup;
+
+    const createResponse = await ctx.POST(makeRequest({ responsesUrl: "" }));
+    const { node } = await createResponse.json();
+    await ctx.createConnection(new Request("https://9router.local/api/providers", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider: node.id, apiKey: "test-key", name: "Connection" }),
+    }));
+
+    const updateResponse = await ctx.PUT(new Request(`https://9router.local/api/provider-nodes/${node.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Multi API",
+        prefix: "multi",
+        openaiUrl: "https://new.test/v1",
+        anthropicUrl: "https://new.test/v1/messages",
+        supportsResponses: true,
+      }),
+    }), { params: Promise.resolve({ id: node.id }) });
+    const connections = await ctx.getProviderConnections({ provider: node.id });
+
+    expect(updateResponse.status).toBe(200);
+    expect(connections[0].providerSpecificData.transports.map((transport) => transport.baseUrl)).toEqual([
+      "https://new.test/v1/chat/completions",
+      "https://new.test/v1/messages",
+      "https://new.test/v1/responses",
+    ]);
+  });
+
+  it("validates each configured protocol endpoint", async () => {
+    const ctx = await setup();
+    cleanup = ctx.cleanup;
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "chatcmpl-test" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "msg_test" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "resp_test" }), { status: 200 }));
+
+    const response = await ctx.validate(new Request("https://9router.local/api/provider-nodes/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "multi-compatible",
+        apiKey: "test-key",
+        modelId: "shared-model",
+        openaiUrl: "https://multi.test/v1",
+        anthropicUrl: "https://multi.test/v1",
+      }),
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      valid: true,
+      supportsResponses: true,
+      endpoints: { openai: true, claude: true, "openai-responses": true },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "https://multi.test/v1/chat/completions",
+      "https://multi.test/v1/messages",
+      "https://multi.test/v1/responses",
+    ]);
+  });
+
+  it("keeps the provider valid when Responses is unsupported", async () => {
+    const ctx = await setup();
+    cleanup = ctx.cleanup;
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }))
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }))
+      .mockResolvedValueOnce(new Response("{}", { status: 404 }));
+
+    const response = await ctx.validate(new Request("https://9router.local/api/provider-nodes/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "multi-compatible",
+        apiKey: "test-key",
+        modelId: "shared-model",
+        openaiUrl: "https://multi.test/v1",
+        anthropicUrl: "https://multi.test/v1",
+      }),
+    }));
+    const body = await response.json();
+
+    expect(body).toEqual({
+      valid: true,
+      supportsResponses: false,
+      endpoints: { openai: true, claude: true, "openai-responses": false },
+    });
+  });
+
+  it("requires Chat Completions and Messages endpoint URLs", async () => {
+    const ctx = await setup();
+    cleanup = ctx.cleanup;
+
+    const missingChat = await ctx.POST(makeRequest({ openaiUrl: "" }));
+    const missingMessages = await ctx.POST(makeRequest({ anthropicUrl: "" }));
+
+    expect(missingChat.status).toBe(400);
+    expect(missingMessages.status).toBe(400);
+  });
+});

--- a/tests/unit/opencode-go-models.test.js
+++ b/tests/unit/opencode-go-models.test.js
@@ -70,6 +70,28 @@ describe("OpenCode Go multi-endpoint transports", () => {
   });
 });
 
+describe("Custom multi-protocol transports", () => {
+  const credentials = {
+    providerSpecificData: {
+      transports: [
+        { format: "openai", baseUrl: "https://multi.test/v1/chat/completions" },
+        { format: "claude", baseUrl: "https://multi.test/v1/messages" },
+      ],
+    },
+  };
+
+  it("resolves a custom transport matching the incoming format", () => {
+    expect(resolveTransport("openai-compatible-multi-test", "claude", credentials)).toEqual({
+      format: "claude",
+      baseUrl: "https://multi.test/v1/messages",
+    });
+  });
+
+  it("returns null when the custom provider has no matching endpoint", () => {
+    expect(resolveTransport("openai-compatible-multi-test", "openai-responses", credentials)).toBeNull();
+  });
+});
+
 describe("OpenCode Go per-model transport guard (chatCore logic)", () => {
   it("routes MiniMax/Qwen + claude-format client to /messages", () => {
     for (const m of CLAUDE_CAPABLE) {


### PR DESCRIPTION
## What changed

- add a custom provider type with one OpenAI URL and one Anthropic URL
- accept base URLs or full endpoint URLs without duplicating endpoint paths
- probe Chat Completions, Anthropic Messages, and OpenAI Responses during validation
- add native Responses routing only when validation confirms support
- route requests directly to matching native endpoints and skip cross-protocol translation
- fall back to Chat Completions translation when Responses is unsupported or unchecked
- persist endpoint transports on provider nodes and connections
- add dashboard create, edit, validation, and detail views

## Tests

- `cd tests && npx vitest run unit/opencode-go-models.test.js unit/compatible-provider-connections.test.js unit/model-routing.test.js unit/multi-compatible-provider-nodes.test.js unit/headroom-chat-core.test.js`
- `node tests/__baseline__/verify-providers.mjs`
- `node tests/__baseline__/verify-alias.mjs`

All 33 focused tests pass. Both baseline checks pass.
