### PR TITLE
Add error message for preventing abuse

### DIFF
--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -66,6 +66,7 @@ export const ERROR_RULES = [
   { text: "quota exceeded",           backoff: true },
   { text: "capacity",                 backoff: true },
   { text: "overloaded",               backoff: true },
+  { text: "to prevent abuse",         backoff: true },
 
   // --- Status-based rules (fallback when text doesn't match) ---
   { status: 401, cooldownMs: COOLDOWN.long },


### PR DESCRIPTION
Add AiHubMix abuse-prevention error pattern to fallback trigger

When using AiHubMix as a provider, the upstream API returns a specific  error message when free-tier quota is exhausted:

  "Sorry, to prevent abuse of free resources, accounts that have not 
   been recharged can only try 10 times. You can increase the free 
   quota after recharging"

This pattern should trigger account/provider rotation via exponential  backoff, matching the existing behavior for similar rate-limit signals  ("rate limit", "too many requests", "quota exceeded", etc.).

Added `{ text: "to prevent abuse", backoff: true }` to ERROR_RULES so  9router automatically switches to the next account when this error  occurs.