### PR TITLE
fix(stream): passthrough dedup/normalization + OpenAI non-stream contract

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -111,7 +111,10 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   const clientRequestedStreaming = body.stream === true || sourceFormat === FORMATS.ANTIGRAVITY || sourceFormat === FORMATS.GEMINI || sourceFormat === FORMATS.GEMINI_CLI;
   const providerRequiresStreaming = PROVIDERS[provider]?.forceStream === true;
-  let stream = providerRequiresStreaming ? true : (body.stream !== false);
+  // OpenAI contract: absent `stream` means NON-streaming. Defaulting missing
+  // `stream` to true made clients that omit the field (pi, plain curl) receive
+  // SSE while waiting for JSON — appearing as an empty/stalled answer.
+  let stream = providerRequiresStreaming ? true : (body.stream === true);
 
   // Image generation models require non-streaming (Google v1internal:generateContent)
   const modelType = getModelType(alias, model);

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -305,6 +305,19 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
   }
 
   reqLogger.logProviderResponse(providerResponse.status, providerResponse.statusText, providerResponse.headers, responseBody);
+
+  // Detect upstream gateway errors masked as HTTP 200 (e.g. OpenRouter
+  // sending choices[0].native_finish_reason:"network_error" with empty content).
+  const rawChoice = responseBody?.choices?.[0];
+  const nativeReason = rawChoice?.native_finish_reason;
+  const rawMsg = rawChoice?.message || {};
+  const hasContent = (typeof rawMsg.content === "string" && rawMsg.content.length > 0)
+    || (Array.isArray(rawMsg.tool_calls) && rawMsg.tool_calls.length > 0);
+  if (nativeReason && ["network_error", "error", "server_error", "timeout"].includes(nativeReason) && !hasContent) {
+    appendLog({ status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}` });
+    return createErrorResult(HTTP_STATUS.BAD_GATEWAY, `Upstream provider error: ${nativeReason}`);
+  }
+
   if (onRequestSuccess) {
     Promise.resolve()
       .then(onRequestSuccess)

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -164,6 +164,15 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel) {
     message.tool_calls = [...toolCallMap.entries()].sort((a, b) => a[0] - b[0]).map(([, tc]) => tc);
   }
 
+  // Detect upstream gateway errors masked as HTTP 200 (e.g. OpenRouter
+  // sending finish_reason:"stop" with native_finish_reason:"network_error"
+  // and zero content). Treat as stream failure so callers get an error.
+  const lastChoice = chunks[chunks.length - 1]?.choices?.[0];
+  const nativeReason = lastChoice?.native_finish_reason;
+  if (nativeReason && ["network_error", "error", "server_error", "timeout"].includes(nativeReason) && contentParts.length === 0 && toolCallMap.size === 0) {
+    return { error: { message: `Upstream stream failed: ${nativeReason}`, code: nativeReason } };
+  }
+
   const result = {
     id: first.id || `chatcmpl-${Date.now()}`,
     object: "chat.completion",

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -75,6 +75,8 @@ export function createSSEStream(options = {}) {
   let openAIResponsesTerminalSeen = false;
   let openAIResponsesDoneSent = false;
   let streamDoneSent = false;  // track duplicate [DONE] across transform + flush
+  let passthroughFinishSeen = false;  // passthrough: duplicate finish chunks from upstream
+  let passthroughDoneSent = false;    // passthrough: upstream already sent [DONE]
 
   return new TransformStream({
     transform(chunk, controller) {
@@ -105,6 +107,13 @@ export function createSSEStream(options = {}) {
         if (mode === STREAM_MODE.PASSTHROUGH) {
           let output;
           let injectedUsage = false;
+
+          // Dedup terminators: some upstreams (e.g. stealth/ox-alpha) send the
+          // finish chunk twice and/or their own [DONE]; clients like AI SDK
+          // treat anything after the first finish_reason as a protocol error.
+          const isDoneLine = trimmed.startsWith("data:") && trimmed.slice(5).trim() === "[DONE]";
+          if (isDoneLine && passthroughDoneSent) continue;
+          if (isDoneLine) passthroughDoneSent = true;
 
           if (trimmed.startsWith("data:") && trimmed.slice(5).trim() !== "[DONE]") {
             try {
@@ -169,6 +178,13 @@ export function createSSEStream(options = {}) {
               }
 
               const isFinishChunk = parsed.choices?.[0]?.finish_reason;
+              if (isFinishChunk && passthroughFinishSeen) {
+                // Duplicate finish chunk (the second usually carries only
+                // upstream-side usage) — drop it: two finish_reasons in one
+                // stream break AI SDK clients ("content after finish reason").
+                continue;
+              }
+              if (isFinishChunk) passthroughFinishSeen = true;
               if (isFinishChunk && !hasValidUsage(parsed.usage)) {
                 const estimated = estimateUsage(body, totalContentLength, FORMATS.OPENAI);
                 parsed.usage = filterUsageForFormat(estimated, FORMATS.OPENAI);
@@ -371,7 +387,7 @@ export function createSSEStream(options = {}) {
           // Without it they can hang until timeout and trigger failover.
           // Gemini-family clients (Antigravity, Vertex, Gemini) reject this sentinel with 400 syntax errors.
           const isGeminiFamily = provider === "antigravity" || provider === "gemini" || provider === "vertex";
-          if (!streamDoneSent && !isGeminiFamily) {
+          if (!streamDoneSent && !passthroughDoneSent && !isGeminiFamily) {
             const doneOutput = "data: [DONE]\n\n";
             reqLogger?.appendConvertedChunk?.(doneOutput);
             controller.enqueue(sharedEncoder.encode(doneOutput));

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -161,6 +161,14 @@ export function createSSEStream(options = {}) {
               }
 
               const delta = parsed.choices?.[0]?.delta;
+              // OpenRouter-style gateways (e.g. stealth/ox-alpha) stream
+              // reasoning under `delta.reasoning`, but OpenAI-compatible
+              // clients (Cursor, OpenCode, pi) expect `delta.reasoning_content`.
+              // Normalize so clients render reasoning instead of an empty answer.
+              if (delta && typeof delta.reasoning === "string" && delta.reasoning_content === undefined) {
+                delta.reasoning_content = delta.reasoning;
+                delete delta.reasoning;
+              }
               const content = delta?.content;
               const reasoning = delta?.reasoning_content;
               if (content && typeof content === "string") {

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -168,6 +168,7 @@ export function createSSEStream(options = {}) {
               if (delta && typeof delta.reasoning === "string" && delta.reasoning_content === undefined) {
                 delta.reasoning_content = delta.reasoning;
                 delete delta.reasoning;
+                fieldsInjected = true; // force output from the mutated parsed
               }
               const content = delta?.content;
               const reasoning = delta?.reasoning_content;

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -187,6 +187,14 @@ export function createSSEStream(options = {}) {
               }
 
               const isFinishChunk = parsed.choices?.[0]?.finish_reason;
+              const nativeReason = parsed.choices?.[0]?.native_finish_reason;
+              // Detect upstream gateway errors masked as HTTP 200 (e.g. OpenRouter
+              // sending finish_reason:"stop" with native_finish_reason:"network_error"
+              // and empty content). Error out so the stream aborts and combo fallbacks.
+              if (isFinishChunk && nativeReason && ["network_error", "error", "server_error", "timeout"].includes(nativeReason) && totalContentLength === 0) {
+                controller.error(new Error(`Upstream stream failed: ${nativeReason}`));
+                return;
+              }
               if (isFinishChunk && passthroughFinishSeen) {
                 // Duplicate finish chunk (the second usually carries only
                 // upstream-side usage) — drop it: two finish_reasons in one

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -376,6 +376,10 @@ export function createSSEStream(options = {}) {
             if (buffer.startsWith("data:") && !buffer.startsWith("data: ")) {
               output = "data: " + buffer.slice(5);
             }
+            // Ensure the trailing SSE frame ends with a newline before the
+            // [DONE] sentinel — upstreams that close without a final \n
+            // would glue "...}data: [DONE]" together and break client parsers.
+            if (!output.endsWith("\n")) output += "\n";
             reqLogger?.appendConvertedChunk?.(output);
             controller.enqueue(sharedEncoder.encode(output));
           }


### PR DESCRIPTION
## Summary

Six focused passthrough/streaming fixes, rebased cleanly on master (self-contained, no new files). Requested as a separate PR after #3456.

- **Dedup finish chunks and `[DONE]` in passthrough mode** — upstreams that emit duplicate `finish` chunks / sentinels no longer produce double-terminating streams.
- **Normalize `delta.reasoning` → `reasoning_content`** in passthrough, and force output from the mutated parsed object so the normalization actually reaches the client.
- **Newline before the `[DONE]` sentinel** when the upstream buffer lacks one — some strict clients fail to terminate the stream otherwise.
- **Honor the OpenAI contract: absent `stream` field means non-streaming** — previously only `stream: false` was treated as non-streaming.
- **Abort + fallback when upstream returns a `native_finish_reason` error with empty content** — instead of surfacing an empty assistant turn to the client.

## Testing

- vitest suite in a clean environment: identical to the pristine master baseline (54 failed / 1031 passed / 94 skipped — the 54 are pre-existing on master in a clean env, e.g. live-provider goldens).
- Live-verified on our production deployment (combo fallback + GLM/Z.AI passthrough).