### PR TITLE
fix(fallback): parse provider-reported rate-limit reset times

### DIFF
--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -39,7 +39,7 @@ export const BACKOFF_CONFIG = {
 export const TRANSIENT_COOLDOWN_MS = 30 * 1000;
 
 // Hard cap for provider-reported rate limit cooldown (e.g. codex resets_at can be 5-6h)
-export const MAX_RATE_LIMIT_COOLDOWN_MS = 30 * 60 * 1000;
+export const MAX_RATE_LIMIT_COOLDOWN_MS = 6 * 60 * 60 * 1000;
 
 // Cooldown durations (ms)
 const COOLDOWN = {

--- a/open-sse/utils/error.js
+++ b/open-sse/utils/error.js
@@ -50,6 +50,45 @@ export async function writeStreamError(writer, statusCode, message) {
 }
 
 /**
+ * Best-effort extraction of a precise rate-limit reset time from common
+ * provider error shapes. GLM/Z.AI: "Your limit will reset at 2026-08-17 02:56:15"
+ * (UTC). Also handles "retry in N seconds", "resets in Ns" and Retry-After.
+ * Returns epoch ms or null.
+ */
+export function extractResetsAtMs(response, message) {
+  if (!message) return null;
+  const text = typeof message === "string" ? message : JSON.stringify(message);
+
+  // GLM/Z.AI: "reset at 2026-08-17 02:56:15" (provider sends UTC without suffix)
+  const resetAt = text.match(/reset at\s+(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})/i);
+  if (resetAt) {
+    const ms = Date.parse(`${resetAt[1]}T${resetAt[2]}Z`);
+    if (Number.isFinite(ms) && ms > Date.now()) return ms;
+  }
+
+  // "retry in 300 seconds" / "resets in 5 minutes" / "try again in 1 hour"
+  const inTime = text.match(/(?:retry|try again|resets?)\s+(?:after|in)\s+(\d+(?:\.\d+)?)\s*(seconds?|minutes?|hours?)/i);
+  if (inTime) {
+    const n = Number(inTime[1]);
+    const unit = inTime[2][0].toLowerCase();
+    const mult = unit === "s" ? 1000 : unit === "m" ? 60000 : 3600000;
+    const ms = Date.now() + n * mult;
+    if (Number.isFinite(ms)) return ms;
+  }
+
+  // Retry-After header (seconds or HTTP-date)
+  const ra = response?.headers?.get?.("retry-after");
+  if (ra) {
+    const secs = Number(ra);
+    if (Number.isFinite(secs) && secs > 0) return Date.now() + secs * 1000;
+    const dateMs = Date.parse(ra);
+    if (Number.isFinite(dateMs) && dateMs > Date.now()) return dateMs;
+  }
+
+  return null;
+}
+
+/**
  * Parse upstream provider error response
  * @param {Response} response - Fetch response from provider
  * @param {object} [executor] - Optional executor with parseError() override for provider-specific parsing
@@ -84,6 +123,12 @@ export async function parseUpstreamError(response, executor = null) {
 
   const messageStr = typeof message === "string" ? message : JSON.stringify(message);
   const finalMessage = messageStr || DEFAULT_ERROR_MESSAGES[response.status] || `Upstream error: ${response.status}`;
+
+  // Generic reset-time extraction for rate limits (GLM "reset at ...", Retry-After, ...)
+  if (response.status === 429) {
+    const resetsAtMs = extractResetsAtMs(response, finalMessage);
+    if (resetsAtMs) return { statusCode: 429, message: finalMessage, resetsAtMs };
+  }
 
   return { statusCode: response.status, message: finalMessage };
 }

--- a/open-sse/utils/error.js
+++ b/open-sse/utils/error.js
@@ -108,7 +108,9 @@ export async function parseUpstreamError(response, executor = null) {
       const parsed = executor.parseError(response, bodyText);
       if (parsed && typeof parsed === "object") {
         const msg = parsed.message || DEFAULT_ERROR_MESSAGES[response.status] || `Upstream error: ${response.status}`;
-        return { statusCode: parsed.status || response.status, message: msg, resetsAtMs: parsed.resetsAtMs };
+        // Executor parse wins; fill resetsAtMs from generic patterns when absent
+        const resetsAtMs = parsed.resetsAtMs ?? (response.status === 429 ? extractResetsAtMs(response, msg) : null);
+        return { statusCode: parsed.status || response.status, message: msg, resetsAtMs };
       }
     } catch { /* fall through to default parsing */ }
   }


### PR DESCRIPTION
## Summary

Second of the promised one-concern PRs after #3456.

GLM/Z.AI 429s say "Usage limit reached for 5 hour. Your limit will reset at 2026-08-17 02:56:15" but the router fell back to ~1min transient backoff and kept hammering the same combo member every minute.

- `extractResetsAtMs()`: generic best-effort reset-time parser applied to 429s when the executor has no provider-specific parse:
  - "reset at <datetime>" (GLM/Z.AI, UTC)
  - "retry/resets in N seconds/minutes/hours"
  - `Retry-After` header (seconds or HTTP-date)
- `MAX_RATE_LIMIT_COOLDOWN_MS` 30m → 6h: the cap contradicted its own comment ("codex resets_at can be 5-6h") and truncated every provider-reported reset to 30m.
- Follow-up commit fills `resetsAtMs` via the generic parser when an executor's own parse didn't produce one.

## Testing

- vitest suite in a clean environment: identical to the pristine master baseline (54 failed / 1031 passed / 94 skipped — pre-existing on master in a clean env).
- Live-verified on our production deployment: GLM Coding Plan 5h-window lock now produces a precise ~5h cooldown instead of 30m, combo fallback stops re-picking the locked member.