### PR TITLE
fix(models): expose only configured custom-compatible models

### DIFF
--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -124,14 +124,6 @@ const LIVE_MODEL_RESOLVERS = {
   },
 };
 
-const parseOpenAIStyleModels = (data) => {
-  if (Array.isArray(data)) return data;
-  return data?.data || data?.models || data?.results || [];
-};
-
-// Header sent by fetchCompatibleModelIds to detect cross-instance /models fetches
-// and break recursive loops between 9router instances connected to each other.
-const INTERNAL_MODELS_FETCH_HEADER = "x-9r-internal-models-fetch";
 
 // LLM kind sentinel — combos/models with no explicit kind default to LLM
 const LLM_KIND = "llm";
@@ -163,62 +155,6 @@ function inferKindFromUnknownModelId(modelId) {
   return LLM_KIND;
 }
 
-async function fetchCompatibleModelIds(connection) {
-  if (!connection?.apiKey) return [];
-
-  const baseUrl = typeof connection?.providerSpecificData?.baseUrl === "string"
-    ? connection.providerSpecificData.baseUrl.trim().replace(/\/$/, "")
-    : "";
-
-  if (!baseUrl) return [];
-
-  let url = `${baseUrl}/models`;
-  const headers = {
-    "Content-Type": "application/json",
-  };
-
-  if (isOpenAICompatibleProvider(connection.provider)) {
-    headers.Authorization = `Bearer ${connection.apiKey}`;
-  } else if (isAnthropicCompatibleProvider(connection.provider)) {
-    if (url.endsWith("/messages/models")) {
-      url = url.slice(0, -9);
-    } else if (url.endsWith("/messages")) {
-      url = `${url.slice(0, -9)}/models`;
-    }
-    headers["x-api-key"] = connection.apiKey;
-    headers["anthropic-version"] = "2023-06-01";
-    headers.Authorization = `Bearer ${connection.apiKey}`;
-  } else {
-    return [];
-  }
-
-  try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 5000);
-    const response = await fetch(url, {
-      method: "GET",
-      headers: { ...headers, [INTERNAL_MODELS_FETCH_HEADER]: "1" },
-      cache: "no-store",
-      signal: controller.signal,
-    });
-    clearTimeout(timeoutId);
-
-    if (!response.ok) return [];
-
-    const data = await response.json();
-    const rawModels = parseOpenAIStyleModels(data);
-
-    return Array.from(
-      new Set(
-        rawModels
-          .map((model) => model?.id || model?.name || model?.model)
-          .filter((modelId) => typeof modelId === "string" && modelId.trim() !== "")
-      )
-    );
-  } catch {
-    return [];
-  }
-}
 
 // Provider matches kindFilter when its serviceKinds intersect the requested kinds.
 // LLM is the default kind for providers missing serviceKinds.
@@ -241,11 +177,7 @@ function comboMatchesKinds(combo, kindFilter) {
  * Build OpenAI-format models list filtered by service kinds.
  * @param {string[]} kindFilter - List of service kinds to include (e.g. ["llm"], ["webSearch","webFetch"]).
  */
-export async function buildModelsList(kindFilter, options = {}) {
-  // When this header is present, the /v1/models request came from another
-  // 9router instance's fetchCompatibleModelIds — skip dynamic fetch to break
-  // cross-instance recursive loops.
-  const skipDynamicFetch = options.skipDynamicFetch === true;
+export async function buildModelsList(kindFilter) {
   let connections = [];
   try {
     connections = await getProviderConnections();
@@ -556,11 +488,9 @@ export async function OPTIONS() {
  * GET /v1/models - OpenAI compatible models list (LLM/chat models only by default).
  * For other capabilities use /v1/models/{kind} (image, tts, stt, embedding, image-to-text, web).
  */
-export async function GET(request) {
+export async function GET() {
   try {
-    // Detect cross-instance recursive /models fetch (another 9router fetching our /models)
-    const skipDynamicFetch = request?.headers?.get(INTERNAL_MODELS_FETCH_HEADER) === "1";
-    const data = await buildModelsList([LLM_KIND], { skipDynamicFetch });
+    const data = await buildModelsList([LLM_KIND]);
     return Response.json({ object: "list", data }, {
       headers: { "Access-Control-Allow-Origin": "*" },
     });

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -365,19 +365,17 @@ export async function buildModelsList(kindFilter, options = {}) {
       let liveModelKindById = new Map();
       let liveCapabilitiesById = new Map();
 
-      let rawModelIds = hasExplicitEnabledModels
-        ? Array.from(
-            new Set(
-              enabledModels.filter(
-                (modelId) => typeof modelId === "string" && modelId.trim() !== "",
-              ),
-            ),
-          )
-        : providerModels.map((model) => model.id);
-
-      if (isCompatibleProvider && rawModelIds.length === 0 && !skipDynamicFetch) {
-        rawModelIds = await fetchCompatibleModelIds(conn);
-      }
+      let rawModelIds = isCompatibleProvider
+        ? []
+        : (hasExplicitEnabledModels
+            ? Array.from(
+                new Set(
+                  enabledModels.filter(
+                    (modelId) => typeof modelId === "string" && modelId.trim() !== "",
+                  ),
+                ),
+              )
+            : providerModels.map((model) => model.id));
 
       // Config-driven live catalog override (e.g. Kiro returns dynamic
       // -thinking/-agentic variants per account). On failure, fall back to

--- a/tests/unit/models-compatible-allowlist.test.js
+++ b/tests/unit/models-compatible-allowlist.test.js
@@ -37,7 +37,7 @@ describe("buildModelsList - Custom Compatible Provider Allowlist", () => {
     global.fetch = vi.fn();
   });
 
-  it("TEST A: OpenAI-compatible provider with explicit custom model exposes only that model, ignoring upstream /models", async () => {
+  it("TEST A: OpenAI-compatible provider with explicit custom model stored under providerId exposes only that model, ignoring upstream /models", async () => {
     getProviderConnections.mockResolvedValue([
       {
         id: "conn-stepfun",
@@ -51,11 +51,12 @@ describe("buildModelsList - Custom Compatible Provider Allowlist", () => {
       },
     ]);
 
+    // Dashboard persists with providerStorageAlias = isCompatible ? providerId : providerAlias
     getCustomModels.mockResolvedValue([
       {
         id: "step-3.7-flash",
         name: "Step 3.7 Flash",
-        providerAlias: "stepplan",
+        providerAlias: "openai-compatible-stepfun",
         type: "llm",
       },
     ]);
@@ -109,7 +110,7 @@ describe("buildModelsList - Custom Compatible Provider Allowlist", () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it("TEST C: Anthropic-compatible provider exposes only explicitly configured custom models", async () => {
+  it("TEST C: Anthropic-compatible provider exposes only explicitly configured custom models stored under providerId", async () => {
     getProviderConnections.mockResolvedValue([
       {
         id: "conn-anthropic-custom",
@@ -126,7 +127,7 @@ describe("buildModelsList - Custom Compatible Provider Allowlist", () => {
     getCustomModels.mockResolvedValue([
       {
         id: "MiniMax-Text-01",
-        providerAlias: "minimax-custom",
+        providerAlias: "anthropic-compatible-minimax",
         type: "llm",
       },
     ]);
@@ -145,7 +146,7 @@ describe("buildModelsList - Custom Compatible Provider Allowlist", () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it("TEST D: Legacy model aliases displayed as Available Models remain exposed", async () => {
+  it("TEST D: Legacy model aliases using providerId target remain exposed under output prefix", async () => {
     getProviderConnections.mockResolvedValue([
       {
         id: "conn-legacy",
@@ -161,13 +162,42 @@ describe("buildModelsList - Custom Compatible Provider Allowlist", () => {
 
     getCustomModels.mockResolvedValue([]);
     getModelAliases.mockResolvedValue({
-      "my-alias": "legacyprov/legacy-model-v1",
+      "my-alias": "openai-compatible-legacy/legacy-model-v1",
     });
 
     const models = await buildModelsList(["llm"]);
     const modelIds = models.map((m) => m.id);
 
     expect(modelIds).toEqual(["legacyprov/legacy-model-v1"]);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("TEST D2 (Backwards compatibility): Older custom models stored under display prefix remain supported", async () => {
+    getProviderConnections.mockResolvedValue([
+      {
+        id: "conn-prefix-storage",
+        provider: "openai-compatible-old",
+        apiKey: "sk-test",
+        isActive: true,
+        providerSpecificData: {
+          baseUrl: "https://api.old.com/v1",
+          prefix: "oldprefix",
+        },
+      },
+    ]);
+
+    getCustomModels.mockResolvedValue([
+      {
+        id: "old-custom-model",
+        providerAlias: "oldprefix",
+        type: "llm",
+      },
+    ]);
+
+    const models = await buildModelsList(["llm"]);
+    const modelIds = models.map((m) => m.id);
+
+    expect(modelIds).toEqual(["oldprefix/old-custom-model"]);
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
@@ -211,7 +241,7 @@ describe("buildModelsList - Custom Compatible Provider Allowlist", () => {
     );
   });
 
-  it("TEST F: Old connection enabledModels do NOT leak unrepresented models for custom compatible providers", async () => {
+  it("TEST F: Old connection enabledModels do NOT leak unrepresented models for custom compatible providers with providerId storage", async () => {
     getProviderConnections.mockResolvedValue([
       {
         id: "conn-stepfun",
@@ -230,7 +260,7 @@ describe("buildModelsList - Custom Compatible Provider Allowlist", () => {
       {
         id: "step-3.7-flash",
         name: "Step 3.7 Flash",
-        providerAlias: "stepplan",
+        providerAlias: "openai-compatible-stepfun",
         type: "llm",
       },
     ]);

--- a/tests/unit/models-compatible-allowlist.test.js
+++ b/tests/unit/models-compatible-allowlist.test.js
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: vi.fn(),
+  getCombos: vi.fn().mockResolvedValue([]),
+  getCustomModels: vi.fn().mockResolvedValue([]),
+  getModelAliases: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("@/lib/disabledModelsDb", () => ({
+  getDisabledModels: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("open-sse/services/kiroModels.js", () => ({ resolveKiroModels: vi.fn() }));
+vi.mock("open-sse/services/kimchiModels.js", () => ({ resolveKimchiModels: vi.fn() }));
+vi.mock("open-sse/services/qoderModels.js", () => ({ resolveQoderModels: vi.fn() }));
+vi.mock("open-sse/services/copilotModels.js", () => ({ resolveCopilotModels: vi.fn() }));
+vi.mock("open-sse/services/clinepassModels.js", () => ({ resolveClinepassModels: vi.fn() }));
+vi.mock("open-sse/services/grokCliModels.js", () => ({ resolveGrokCliModels: vi.fn() }));
+vi.mock("open-sse/services/cursorModels.js", () => ({ resolveCursorModels: vi.fn() }));
+vi.mock("open-sse/shared/zedAuth.js", () => ({ resolveZedModels: vi.fn() }));
+vi.mock("@/sse/services/tokenRefresh", () => ({ updateProviderCredentials: vi.fn() }));
+vi.mock("@/lib/network/connectionProxy", () => ({ resolveConnectionProxyConfig: vi.fn().mockResolvedValue({}) }));
+
+vi.mock("@/models", () => ({
+  getProviderConnectionById: vi.fn(),
+}));
+
+import { buildModelsList } from "@/app/api/v1/models/route.js";
+import { GET as getProviderModels } from "@/app/api/providers/[id]/models/route.js";
+import { getProviderConnections, getCustomModels, getModelAliases } from "@/lib/localDb";
+import { getProviderConnectionById } from "@/models";
+
+describe("buildModelsList - Custom Compatible Provider Allowlist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it("TEST A: OpenAI-compatible provider with explicit custom model exposes only that model, ignoring upstream /models", async () => {
+    getProviderConnections.mockResolvedValue([
+      {
+        id: "conn-stepfun",
+        provider: "openai-compatible-stepfun",
+        apiKey: "sk-test",
+        isActive: true,
+        providerSpecificData: {
+          baseUrl: "https://api.stepfun.com/v1",
+          prefix: "stepplan",
+        },
+      },
+    ]);
+
+    getCustomModels.mockResolvedValue([
+      {
+        id: "step-3.7-flash",
+        name: "Step 3.7 Flash",
+        providerAlias: "stepplan",
+        type: "llm",
+      },
+    ]);
+
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: "step-3.5-flash" },
+          { id: "step-3.5-flash-2603" },
+          { id: "step-3.7-flash" },
+        ],
+      }),
+    });
+
+    const models = await buildModelsList(["llm"]);
+    const modelIds = models.map((m) => m.id);
+
+    expect(modelIds).toEqual(["stepplan/step-3.7-flash"]);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("TEST B: OpenAI-compatible provider with no Available Models returns ZERO models and does not fetch upstream", async () => {
+    getProviderConnections.mockResolvedValue([
+      {
+        id: "conn-empty",
+        provider: "openai-compatible-empty",
+        apiKey: "sk-test",
+        isActive: true,
+        providerSpecificData: {
+          baseUrl: "https://api.empty.com/v1",
+          prefix: "emptyprov",
+        },
+      },
+    ]);
+
+    getCustomModels.mockResolvedValue([]);
+    getModelAliases.mockResolvedValue({});
+
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "unwanted-model-1" }, { id: "unwanted-model-2" }],
+      }),
+    });
+
+    const models = await buildModelsList(["llm"]);
+    const compatibleModels = models.filter((m) => m.id.startsWith("emptyprov/"));
+
+    expect(compatibleModels).toEqual([]);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("TEST C: Anthropic-compatible provider exposes only explicitly configured custom models", async () => {
+    getProviderConnections.mockResolvedValue([
+      {
+        id: "conn-anthropic-custom",
+        provider: "anthropic-compatible-minimax",
+        apiKey: "sk-test",
+        isActive: true,
+        providerSpecificData: {
+          baseUrl: "https://api.minimax.chat/v1",
+          prefix: "minimax-custom",
+        },
+      },
+    ]);
+
+    getCustomModels.mockResolvedValue([
+      {
+        id: "MiniMax-Text-01",
+        providerAlias: "minimax-custom",
+        type: "llm",
+      },
+    ]);
+
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "MiniMax-Text-01" }, { id: "MiniMax-VL-01" }, { id: "MiniMax-Speech" }],
+      }),
+    });
+
+    const models = await buildModelsList(["llm"]);
+    const modelIds = models.map((m) => m.id);
+
+    expect(modelIds).toEqual(["minimax-custom/MiniMax-Text-01"]);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("TEST D: Legacy model aliases displayed as Available Models remain exposed", async () => {
+    getProviderConnections.mockResolvedValue([
+      {
+        id: "conn-legacy",
+        provider: "openai-compatible-legacy",
+        apiKey: "sk-test",
+        isActive: true,
+        providerSpecificData: {
+          baseUrl: "https://api.legacy.com/v1",
+          prefix: "legacyprov",
+        },
+      },
+    ]);
+
+    getCustomModels.mockResolvedValue([]);
+    getModelAliases.mockResolvedValue({
+      "my-alias": "legacyprov/legacy-model-v1",
+    });
+
+    const models = await buildModelsList(["llm"]);
+    const modelIds = models.map((m) => m.id);
+
+    expect(modelIds).toEqual(["legacyprov/legacy-model-v1"]);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("TEST E: Import discovery endpoint /api/providers/[id]/models continues to query upstream /models for custom providers", async () => {
+    getProviderConnectionById.mockResolvedValue({
+      id: "conn-stepfun-import",
+      provider: "openai-compatible-stepfun",
+      apiKey: "sk-test-stepfun",
+      providerSpecificData: {
+        baseUrl: "https://api.stepfun.com/v1",
+        prefix: "stepplan",
+      },
+    });
+
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: "step-3.5-flash", name: "Step 3.5 Flash" },
+          { id: "step-3.7-flash", name: "Step 3.7 Flash" },
+        ],
+      }),
+    });
+
+    const req = new Request("http://localhost/api/providers/conn-stepfun-import/models");
+    const res = await getProviderModels(req, { params: Promise.resolve({ id: "conn-stepfun-import" }) });
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.models).toHaveLength(2);
+    expect(json.models[0].id).toBe("step-3.5-flash");
+    expect(json.models[1].id).toBe("step-3.7-flash");
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.stepfun.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer sk-test-stepfun",
+        }),
+      })
+    );
+  });
+
+  it("TEST F: Old connection enabledModels do NOT leak unrepresented models for custom compatible providers", async () => {
+    getProviderConnections.mockResolvedValue([
+      {
+        id: "conn-stepfun",
+        provider: "openai-compatible-stepfun",
+        apiKey: "sk-test",
+        isActive: true,
+        providerSpecificData: {
+          baseUrl: "https://api.stepfun.com/v1",
+          prefix: "stepplan",
+          enabledModels: ["step-3.5-flash", "step-3.5-flash-2603"],
+        },
+      },
+    ]);
+
+    getCustomModels.mockResolvedValue([
+      {
+        id: "step-3.7-flash",
+        name: "Step 3.7 Flash",
+        providerAlias: "stepplan",
+        type: "llm",
+      },
+    ]);
+
+    const models = await buildModelsList(["llm"]);
+    const modelIds = models.map((m) => m.id);
+
+    expect(modelIds).toEqual(["stepplan/step-3.7-flash"]);
+  });
+});


### PR DESCRIPTION
## Summary

Custom OpenAI-Compatible and Anthropic-Compatible providers were automatically populating public `/v1/models` from their upstream `/models` endpoint.

This caused 9Router to advertise models that the user had never added under **Available Models**.

This fix makes the Dashboard-configured Available Models authoritative for custom-compatible providers.

## Behavior after this change

- `/v1/models` exposes only models explicitly configured under Available Models.
- An empty Available Models list exposes zero models for that provider.
- Custom models stored using the compatible provider ID are supported.
- Older custom models stored under the display prefix remain supported.
- Legacy model aliases remain supported.
- Old connection `enabledModels` values cannot leak unconfigured models.
- `Import from /models` continues to query the upstream provider for explicit discovery/import.
- Built-in provider behavior is unchanged.
- Model Catalog Sync behavior is unchanged.

## Implementation

Removed automatic compatible-provider `/models` discovery from public `/v1/models`, including the now-unused recursive-fetch/header handling.

Upstream model discovery remains available exclusively through the dedicated provider models endpoint used by the Dashboard import flow.

## Regression coverage

7 regression tests cover:

- OpenAI-compatible provider with one configured model
- OpenAI-compatible provider with an empty Available Models list
- Anthropic-compatible provider allowlisting
- Legacy alias mapping
- Backward compatibility with models stored under the display prefix
- Explicit `/models` discovery through the import endpoint
- Protection against stale connection `enabledModels`

## Production verification

This was reproduced and validated on a real 9Router installation:

- StepFun: 3 advertised models → 1 configured model
- SeekAi: 11 advertised models → 3 configured models
- Total `/v1/models`: 29 → 19
- Allowed models continued routing successfully
- Model Catalog Sync remained enabled