### PR TITLE
feat(cline): live model catalog for free Cline connections

### DIFF
--- a/open-sse/providers/registry/cline.js
+++ b/open-sse/providers/registry/cline.js
@@ -40,6 +40,7 @@ export default {
     { id: "google/gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview" },
     { id: "google/gemini-3.1-flash-lite-preview", name: "Gemini 3.1 Flash Lite Preview" },
     { id: "kwaipilot/kat-coder-pro", name: "KAT Coder Pro" },
+    { id: "z-ai/glm-5.3-flash", name: "GLM 5.3 Flash (Free)" },
   ],
   oauth: {
     appBaseUrl: "https://app.cline.bot",

--- a/open-sse/services/clineModels.js
+++ b/open-sse/services/clineModels.js
@@ -1,0 +1,57 @@
+import { buildClineHeaders } from "../shared/clineAuth.js";
+
+const CLINE_MODELS_ENDPOINT = "https://api.cline.bot/api/v1/models";
+const FETCH_TIMEOUT_MS = 5000;
+
+/**
+ * Build request headers for the free Cline /models endpoint (Cline's upstream API).
+ * Free Cline connections authenticate with the WorkOS-prefixed OAuth token
+ * (handled by buildClineHeaders).
+ */
+function buildModelListHeaders(token) {
+  return buildClineHeaders(token, { Accept: "application/json" });
+}
+
+/**
+ * Fetch the live model catalog from Cline's /models endpoint for a free
+ * (OAuth) Cline connection. ClinePass models are served from the same
+ * endpoint but belong to the separate `clinepass` provider, so anything
+ * under the `cline-pass/` prefix is filtered out here.
+ *
+ * @param {object} credentials - Connection credentials ({ accessToken })
+ * @returns {Promise<{ models: { id: string, name: string }[] } | null>}
+ */
+export async function resolveClineModels(credentials) {
+  const token = credentials?.accessToken;
+  if (!token) return null;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(CLINE_MODELS_ENDPOINT, {
+      method: "GET",
+      headers: buildModelListHeaders(token),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) return null;
+
+    const json = await response.json();
+    const rawList = Array.isArray(json) ? json : json?.data;
+    if (!Array.isArray(rawList)) return null;
+
+    const models = rawList
+      .filter((m) => typeof m?.id === "string" && m.id !== "" && !m.id.startsWith("cline-pass/"))
+      .map((m) => ({
+        id: m.id,
+        name: m.name || m.id,
+      }));
+
+    return models.length ? { models } : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -12,6 +12,7 @@ import { resolveKimchiModels } from "open-sse/services/kimchiModels.js";
 import { resolveQoderModels } from "open-sse/services/qoderModels.js";
 import { resolveCopilotModels } from "open-sse/services/copilotModels.js";
 import { resolveClinepassModels } from "open-sse/services/clinepassModels.js";
+import { resolveClineModels } from "open-sse/services/clineModels.js";
 import { resolveGrokCliModels } from "open-sse/services/grokCliModels.js";
 import { resolveCursorModels } from "open-sse/services/cursorModels.js";
 import { resolveZedModels } from "open-sse/shared/zedAuth.js";
@@ -73,6 +74,12 @@ const LIVE_MODEL_RESOLVERS = {
     const result = await resolveClinepassModels({
       accessToken: conn.accessToken,
       apiKey: conn.apiKey,
+    });
+    return result?.models?.length ? { models: result.models } : null;
+  },
+  cline: async (conn) => {
+    const result = await resolveClineModels({
+      accessToken: conn.accessToken,
     });
     return result?.models?.length ? { models: result.models } : null;
   },


### PR DESCRIPTION
## What
- Add `resolveClineModels`: free (OAuth) Cline connections now fetch the live model
  catalog from Cline's `/models` endpoint instead of relying on the hardcoded list.
  ClinePass models (`cline-pass/` prefix) are filtered out — they belong to the
  separate `clinepass` provider.
- Register `cline` in the per-provider `LIVE_MODEL_RESOLVERS` map (same pattern as
  kiro/qoder/github/clinepass). The static list stays as fallback; live and static
  entries are merged.
- Add `z-ai/glm-5.3-flash` (Ox Alpha, now free in Cline) to the static fallback list.

## Why
Cline keeps adding models (e.g. GLM 5.3 Flash was just made free) but the registry
list is static, so new models are invisible until a manual registry update. With the
live catalog, `/v1/models` and the dashboard pick up new models automatically.

## Notes
- Live fetch failure falls back to the static list (5s timeout, silent null).
- Verified against the live endpoint: 396 models returned, `z-ai/glm-5.3-flash`
  present, no `cline-pass/` leakage.