### PR TITLE
feat(codex): add opt-in Sol fast tier + local patches on v0.5.59

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -9,6 +9,7 @@ import { normalizeResponsesInput } from "../translator/formats/responsesApi.js";
 import { fetchImageAsBase64 } from "../translator/concerns/image.js";
 import { getModelUpstreamId } from "../config/providerModels.js";
 import { getThinkingLevels } from "../providers/thinkingLevels.js";
+import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { DEFAULT_RETRY_CONFIG, HTTP_STATUS, resolveRetryEntry } from "../config/runtimeConfig.js";
 import { dbg } from "../utils/debugLog.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
@@ -66,6 +67,42 @@ function stripStoredItemReferences(body) {
     }
     return true;
   });
+}
+
+// Strip function_call_output items whose call_id has no matching function_call in input.
+// Prevents Codex 400: "No tool call found for function call output with call_id ..."
+// Orphaned outputs occur when conversation compaction removes original tool calls
+// but leaves their results (e.g., multiple image attachments, compacted tool loops).
+function stripOrphanedToolOutputs(body) {
+  if (!Array.isArray(body.input)) return;
+  const callIds = new Set();
+  let outputCount = 0;
+  for (const item of body.input) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    if (item.type === "function_call" && typeof item.call_id === "string") {
+      callIds.add(item.call_id);
+    }
+    // Chat Completions format: assistant message with embedded tool_calls
+    if (Array.isArray(item.tool_calls)) {
+      for (const tc of item.tool_calls) {
+        if (tc && typeof tc.id === "string") callIds.add(tc.id);
+      }
+    }
+    if (item.type === "function_call_output") outputCount++;
+  }
+  if (outputCount === 0) return;
+  const before = body.input.length;
+  body.input = body.input.filter((item) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return true;
+    if (item.type === "function_call_output" && typeof item.call_id === "string") {
+      return callIds.has(item.call_id);
+    }
+    return true;
+  });
+  const removed = before - body.input.length;
+  if (removed > 0) {
+    dbg("CODEX", `stripOrphanedToolOutputs | removed ${removed} orphaned function_call_output(s) | call_ids=${callIds.size} outputs=${outputCount}`);
+  }
 }
 
 // Flatten Chat-Completions tool shape into Responses flat format + filter unsupported tools
@@ -408,6 +445,8 @@ export class CodexExecutor extends BaseExecutor {
     convertSystemToDeveloperRole(body);
     // Strip server-generated item IDs (rs_/fc_/resp_/msg_) — Codex /responses can't resolve when store=false
     stripStoredItemReferences(body);
+    // Strip orphaned function_call_output items (no matching function_call) — prevents 400 error
+    stripOrphanedToolOutputs(body);
     // Flatten function tools + drop unsupported types
     normalizeCodexTools(body);
 
@@ -477,6 +516,12 @@ export class CodexExecutor extends BaseExecutor {
     delete body.safety_identifier; // Droid CLI sends this but Codex doesn't support it
     delete body.previous_response_id; // store=false → backend can't resolve previous resp; avoid 404
 
+    // Model-config default service tier (e.g. gpt-5.6-sol → fast/priority).
+    // Only applied when the client didn't explicitly send a service_tier.
+    if (!body.service_tier) {
+      const { defaultServiceTier } = getCapabilitiesForModel(this.provider, body.model);
+      if (defaultServiceTier) body.service_tier = defaultServiceTier;
+    }
     if (body.service_tier === "fast") body.service_tier = "priority";
     if (body.service_tier && body.service_tier !== "priority") delete body.service_tier;
 

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -9,7 +9,6 @@ import { normalizeResponsesInput } from "../translator/formats/responsesApi.js";
 import { fetchImageAsBase64 } from "../translator/concerns/image.js";
 import { getModelUpstreamId } from "../config/providerModels.js";
 import { getThinkingLevels } from "../providers/thinkingLevels.js";
-import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { DEFAULT_RETRY_CONFIG, HTTP_STATUS, resolveRetryEntry } from "../config/runtimeConfig.js";
 import { dbg } from "../utils/debugLog.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
@@ -516,14 +515,7 @@ export class CodexExecutor extends BaseExecutor {
     delete body.safety_identifier; // Droid CLI sends this but Codex doesn't support it
     delete body.previous_response_id; // store=false → backend can't resolve previous resp; avoid 404
 
-    // Model-config default service tier (e.g. gpt-5.6-sol → fast/priority).
-    // Only applied when the client didn't explicitly send a service_tier.
-    if (!body.service_tier) {
-      const { defaultServiceTier } = getCapabilitiesForModel(this.provider, body.model);
-      if (defaultServiceTier) body.service_tier = defaultServiceTier;
-    }
     if (body.service_tier === "fast") body.service_tier = "priority";
-    if (body.service_tier && body.service_tier !== "priority") delete body.service_tier;
 
     // Final allowlist filter — strip any unknown field that could trigger upstream "routing_unsupported"
     for (const k of Object.keys(body)) {

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -134,7 +134,7 @@ const KIRO_GPT_5_6_CAPABILITIES = { vision: true, reasoning: true, search: true,
 
 // Codex OAuth (ChatGPT backend) — per-model context window reported by upstream
 // (lower than OpenAI API's 1.05M). Sol differs from Terra/Luna. #2720
-const CODEX_GPT_56_SOL_CAPS  = { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 372000, maxOutput: 128000 };
+const CODEX_GPT_56_SOL_CAPS  = { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 128000, defaultServiceTier: "priority" };
 const CODEX_GPT_56_DEFAULT_CAPS = { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 272000, maxOutput: 128000 };
 
 /**
@@ -282,11 +282,14 @@ export const PATTERN_CAPABILITIES = [
   { pattern: "*kimi*k2*",       caps: { vision: true, reasoning: true, thinkingFormat: "kimi", contextWindow: 262144, maxOutput: 262144 } },
   { pattern: "*kimi*",          caps: { reasoning: true, thinkingFormat: "kimi", contextWindow: 262144 } },
 
+  // ── OpenCode Zen Ox Alpha (x-preview-f-free; reasoning_effort low/high/max only) ─
+  { pattern: "*x-preview*",     caps: { vision: true, videoInput: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 1000000, maxOutput: 131072 } },
+
   // ── GLM / Z.ai (thinking.enabled; disable via enable_thinking:false) ─
   // reasoning_effort is only read by z.ai from GLM-5.2 onward (docs.z.ai/guides/capabilities/thinking) —
   // older GLM (4.x, 5.0, 5.1, 5-turbo, 5v-turbo) ignore it, so gate it per exact version, not the "*glm-5*" catch-all.
-  { pattern: "*glm-5.3*",       caps: { reasoning: true, thinkingFormat: "zai", thinkingEffortSupported: true, contextWindow: 200000, maxOutput: 128000 } },
-  { pattern: "*glm-5.2*",       caps: { reasoning: true, thinkingFormat: "zai", thinkingEffortSupported: true, contextWindow: 200000, maxOutput: 128000 } },
+  { pattern: "*glm-5.3*",       caps: { reasoning: true, thinkingFormat: "zai", thinkingEffortSupported: true, thinkingCanDisable: false, contextWindow: 1000000, maxOutput: 128000 } },
+  { pattern: "*glm-5.2*",       caps: { reasoning: true, thinkingFormat: "zai", thinkingEffortSupported: true, contextWindow: 1000000, maxOutput: 128000 } },
   { pattern: "*glm-5*",         caps: { reasoning: true, thinkingFormat: "zai", contextWindow: 200000, maxOutput: 128000 } },
   { pattern: "*glm-4.7*",       caps: { reasoning: true, thinkingFormat: "zai", contextWindow: 200000, maxOutput: 128000 } },
   { pattern: "*glm-4*",         caps: { reasoning: true, thinkingFormat: "zai", contextWindow: 200000 } },

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -134,7 +134,7 @@ const KIRO_GPT_5_6_CAPABILITIES = { vision: true, reasoning: true, search: true,
 
 // Codex OAuth (ChatGPT backend) — per-model context window reported by upstream
 // (lower than OpenAI API's 1.05M). Sol differs from Terra/Luna. #2720
-const CODEX_GPT_56_SOL_CAPS  = { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 128000, defaultServiceTier: "priority" };
+const CODEX_GPT_56_SOL_CAPS  = { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 128000 };
 const CODEX_GPT_56_DEFAULT_CAPS = { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 272000, maxOutput: 128000 };
 
 /**

--- a/open-sse/providers/thinkingLevels.js
+++ b/open-sse/providers/thinkingLevels.js
@@ -39,6 +39,7 @@ const PATTERN_THINKING = [
   { provider: "codex", pattern: "*gpt-5.6-terra*", levels: [...CODEX_GPT_5_6_LEVELS, "ultra"] },
   { provider: "codex", pattern: "*gpt-5.6-luna*", levels: CODEX_GPT_5_6_LEVELS },
   { pattern: "*codex*", levels: ["low", "medium", "high", "xhigh"] }, // codex cannot disable thinking
+  { pattern: "*x-preview*", levels: ["low", "high", "max"] }, // OpenCode Zen Ox Alpha: low/high/max only
 ];
 
 // Returns valid thinking levels for a model, or null when the model has no reasoning.

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -137,10 +137,23 @@ function toLevel(cfg) {
 }
 
 function normalizeOpenAILevel(level, supportedLevels) {
-  if (level !== "max" && level !== "ultra") return level;
   if (supportedLevels?.includes(level)) return level;
-  if (level === "ultra" && supportedLevels?.includes("max")) return "max";
-  return "xhigh";
+  if (level === "ultra") level = supportedLevels?.includes("max") ? "max" : "xhigh";
+  if (!Array.isArray(supportedLevels) || supportedLevels.length === 0) return level;
+  if (supportedLevels.includes(level)) return level;
+  // Level not accepted by this model → clamp to the nearest supported level
+  // (ordinal distance over the shared effort scale; ties round up).
+  const order = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+  const idx = order.indexOf(level);
+  if (idx === -1) return level;
+  let best = null;
+  for (const candidate of supportedLevels) {
+    const i = order.indexOf(candidate);
+    if (i <= 0) continue;
+    const d = Math.abs(i - idx);
+    if (!best || d < best.d || (d === best.d && i > best.i)) best = { level: candidate, d, i };
+  }
+  return best ? best.level : level;
 }
 
 function toGeminiThinkingLevel(cfg) {

--- a/open-sse/translator/response/openai-to-claude.js
+++ b/open-sse/translator/response/openai-to-claude.js
@@ -130,7 +130,9 @@ export function openaiToClaudeResponse(chunk, state) {
         content: [],
         stop_reason: null,
         stop_sequence: null,
-        usage: { input_tokens: 0, output_tokens: 0 }
+        // Real usage only arrives in the final OpenAI chunk; seed with the
+        // request-size estimate (set by stream.js) so clients can track context.
+        usage: { input_tokens: state.inputTokenEstimate || 0, output_tokens: 0 }
       }
     });
   }
@@ -222,7 +224,8 @@ export function openaiToClaudeResponse(chunk, state) {
   }
 
   // Finish
-  if (choice.finish_reason) {
+  if (choice.finish_reason && !state.finishSent) {
+    state.finishSent = true;
     stopThinkingBlock(state, results);
     stopTextBlock(state, results);
 

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -62,6 +62,16 @@ export function createSSEStream(options = {}) {
     ? { ...initState(sourceFormat), provider, toolNameMap, customToolNames: new Set(customToolNames || []), model }
     : null;
 
+  // Claude-format clients (Claude Code) track context size from message_start.usage.
+  // OpenAI streams only report usage in the FINAL chunk, so the translated
+  // message_start would otherwise say input_tokens: 0 — the client then believes
+  // its context is empty, never auto-compacts, and eventually hard-fails upstream
+  // with "Prompt exceeds max length". Seed it with a request-size estimate
+  // (chars/4 + buffer); the final message_delta still carries the real usage.
+  if (state && sourceFormat === FORMATS.CLAUDE) {
+    state.inputTokenEstimate = estimateUsage(body, 0, FORMATS.CLAUDE)?.input_tokens || 0;
+  }
+
   let totalContentLength = 0;
   let accumulatedContent = "";
   let accumulatedThinking = "";
@@ -147,6 +157,14 @@ export function createSSEStream(options = {}) {
               if (parsed.choices !== undefined) {
                 if (!parsed.object) { parsed.object = "chat.completion.chunk"; fieldsInjected = true; }
                 if (!parsed.created) { parsed.created = Math.floor(Date.now() / 1000); fieldsInjected = true; }
+              }
+
+              // Rewrite colliding tool_use ids from native-claude passthrough providers
+              // (e.g. kimi-k3 reuses "toolu_<tool>_<n>" every turn) so clients can
+              // uniquely pair tool_result.tool_use_id ↔ tool_use.id across turns.
+              if (parsed.type === "content_block_start" && parsed.content_block?.type === "tool_use" && parsed.content_block.id) {
+                parsed.content_block.id = parsed.content_block.id + "_" + Math.random().toString(36).slice(2, 10);
+                fieldsInjected = true;
               }
 
               // Strip Azure-specific non-standard fields from streaming chunks

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -67,6 +67,9 @@ export default function ProviderDetailPage() {
   const [providerStrategy, setProviderStrategy] = useState(null);
   const [providerStickyLimit, setProviderStickyLimit] = useState("");
   const [thinkingMode, setThinkingMode] = useState("auto");
+  const [codexFastMode, setCodexFastMode] = useState(false);
+  const [savingCodexFastMode, setSavingCodexFastMode] = useState(false);
+  const [codexFastModeError, setCodexFastModeError] = useState("");
   const [autoPing, setAutoPing] = useState({ enabled: false, connections: {} });
   const [suggestedModels, setSuggestedModels] = useState([]);
   const [liveModels, setLiveModels] = useState([]);
@@ -318,6 +321,7 @@ export default function ProviderDetailPage() {
       // Load per-provider thinking config
       const thinkingCfg = (settingsData.providerThinking || {})[providerId] || {};
       setThinkingMode(thinkingCfg.mode || "auto");
+      setCodexFastMode(providerId === "codex" && settingsData.codexFastMode === true);
       const autoPingSettingsKey = AUTO_PING_SETTINGS_KEYS[providerId];
       const apCfg = autoPingSettingsKey ? settingsData[autoPingSettingsKey] || {} : {};
       setAutoPing({ enabled: apCfg.enabled === true, connections: apCfg.connections || {} });
@@ -431,6 +435,27 @@ export default function ProviderDetailPage() {
   const handleThinkingModeChange = (mode) => {
     setThinkingMode(mode);
     saveThinkingConfig(mode);
+  };
+
+  const handleCodexFastModeChange = async (enabled) => {
+    if (savingCodexFastMode) return;
+    setCodexFastMode(enabled);
+    setSavingCodexFastMode(true);
+    setCodexFastModeError("");
+    try {
+      const response = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ codexFastMode: enabled }),
+      });
+      if (!response.ok) throw new Error(`Settings update failed (${response.status})`);
+    } catch (error) {
+      setCodexFastMode(!enabled);
+      setCodexFastModeError("Could not save Fast inference setting.");
+      console.log("Error saving Codex Fast mode:", error);
+    } finally {
+      setSavingCodexFastMode(false);
+    }
   };
 
   const saveAutoPing = async (next) => {
@@ -1491,6 +1516,18 @@ export default function ProviderDetailPage() {
                   </div>
                 )}
               </div>
+              {providerId === "codex" && (
+                <Toggle
+                  checked={codexFastMode}
+                  onChange={handleCodexFastModeChange}
+                  disabled={savingCodexFastMode}
+                  label="Fast inference"
+                  description="Use the priority tier for GPT-5.6-Sol."
+                />
+              )}
+              {providerId === "codex" && codexFastModeError && (
+                <span className="text-xs text-red-500" role="alert">{codexFastModeError}</span>
+              )}
             </div>
           </div>
 

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -24,6 +24,17 @@ import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
 import { getProjectIdForConnection } from "open-sse/services/projectId.js";
 
+export function applyCodexFastMode(body, provider, model, settings) {
+  if (
+    provider !== "codex" ||
+    !["gpt-5.6-sol", "gpt-5.6-sol-review"].includes(model) ||
+    settings?.codexFastMode !== true ||
+    body.service_tier
+  ) return body;
+
+  return { ...body, service_tier: "priority" };
+}
+
 /**
  * Handle chat completion request
  * Supports: OpenAI, Claude, Gemini, OpenAI Responses API formats
@@ -260,8 +271,9 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     // Use shared chatCore
     const chatSettings = await getSettings();
     const providerThinking = (chatSettings.providerThinking || {})[provider] || null;
+    const effectiveBody = applyCodexFastMode(body, provider, model, chatSettings);
     const result = await handleChatCore({
-      body: { ...body, model: `${provider}/${model}` },
+      body: { ...effectiveBody, model: `${provider}/${model}` },
       modelInfo: { provider, model },
       credentials: refreshedCredentials,
       log,

--- a/tests/unit/codex-fast-capacity.test.js
+++ b/tests/unit/codex-fast-capacity.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { CodexExecutor } from "../../open-sse/executors/codex.js";
+import { applyCodexFastMode } from "../../src/sse/handlers/chat.js";
 
 function streamFromText(text) {
   const encoder = new TextEncoder();
@@ -25,22 +26,30 @@ describe("Codex fast tier and capacity handling", () => {
     expect(body.reasoning.effort).toBe("xhigh");
   });
 
-  it("defaults gpt-5.6-sol to priority tier when the client sends no service_tier", () => {
-    const body = new CodexExecutor().transformRequest("gpt-5.6-sol", {
-      model: "gpt-5.6-sol",
-      input: "hi",
-    }, true, {});
+  it("leaves Sol on the upstream default tier when Fast mode is off", () => {
+    const body = applyCodexFastMode({ input: "hi" }, "codex", "gpt-5.6-sol", {});
+    expect(body.service_tier).toBeUndefined();
+  });
 
+  it("adds priority tier to Sol when Fast mode is on", () => {
+    const body = applyCodexFastMode({ input: "hi" }, "codex", "gpt-5.6-sol", { codexFastMode: true });
     expect(body.service_tier).toBe("priority");
   });
 
-  it("does not force a service tier on non-sol codex models", () => {
-    const body = new CodexExecutor().transformRequest("gpt-5.6-terra", {
-      model: "gpt-5.6-terra",
-      input: "hi",
-    }, true, {});
+  it("adds priority tier to Sol review requests when Fast mode is on", () => {
+    const body = applyCodexFastMode({ input: "hi" }, "codex", "gpt-5.6-sol-review", { codexFastMode: true });
+    expect(body.service_tier).toBe("priority");
+  });
 
+  it("does not add Fast tier to non-Sol models", () => {
+    const body = applyCodexFastMode({ input: "hi" }, "codex", "gpt-5.6-terra", { codexFastMode: true });
     expect(body.service_tier).toBeUndefined();
+  });
+
+  it("preserves a client-supplied service tier", () => {
+    const effectiveBody = applyCodexFastMode({ input: "hi", service_tier: "default" }, "codex", "gpt-5.6-sol", { codexFastMode: true });
+    const body = new CodexExecutor().transformRequest("gpt-5.6-sol", effectiveBody, true, {});
+    expect(body.service_tier).toBe("default");
   });
 
   it("uses ChatGPT workspace header fallback", () => {

--- a/tests/unit/codex-fast-capacity.test.js
+++ b/tests/unit/codex-fast-capacity.test.js
@@ -25,6 +25,24 @@ describe("Codex fast tier and capacity handling", () => {
     expect(body.reasoning.effort).toBe("xhigh");
   });
 
+  it("defaults gpt-5.6-sol to priority tier when the client sends no service_tier", () => {
+    const body = new CodexExecutor().transformRequest("gpt-5.6-sol", {
+      model: "gpt-5.6-sol",
+      input: "hi",
+    }, true, {});
+
+    expect(body.service_tier).toBe("priority");
+  });
+
+  it("does not force a service tier on non-sol codex models", () => {
+    const body = new CodexExecutor().transformRequest("gpt-5.6-terra", {
+      model: "gpt-5.6-terra",
+      input: "hi",
+    }, true, {});
+
+    expect(body.service_tier).toBeUndefined();
+  });
+
   it("uses ChatGPT workspace header fallback", () => {
     const executor = new CodexExecutor();
     const headers = executor.buildHeaders({

--- a/tests/unit/codex-orphaned-tool-outputs.test.js
+++ b/tests/unit/codex-orphaned-tool-outputs.test.js
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { CodexExecutor } from "../../open-sse/executors/codex.js";
+
+function transform(input) {
+  const executor = new CodexExecutor();
+  const body = {
+    model: "gpt-5.6-sol",
+    input,
+    stream: true,
+    tools: [{
+      type: "function",
+      function: { name: "read_file", description: "Read a file", parameters: { type: "object", properties: { path: { type: "string" } }, required: ["path"] } },
+    }],
+  };
+  executor.transformRequest("gpt-5.6-sol", body, true, {
+    connectionId: "test-orphaned-outputs",
+    providerSpecificData: {},
+  });
+  return body.input;
+}
+
+describe("CodexExecutor stripOrphanedToolOutputs", () => {
+  it("removes function_call_output with no matching function_call", () => {
+    const input = [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+      { type: "function_call_output", call_id: "call_orphan1", output: "result1" },
+      { type: "function_call_output", call_id: "call_orphan2", output: "result2" },
+    ];
+    const result = transform(input);
+    const outputs = result.filter((i) => i.type === "function_call_output");
+    expect(outputs).toEqual([]);
+  });
+
+  it("keeps function_call_output when matching function_call exists", () => {
+    const input = [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+      { type: "function_call", call_id: "call_valid", name: "read_file", arguments: '{"path":"a.txt"}' },
+      { type: "function_call_output", call_id: "call_valid", output: "file contents" },
+    ];
+    const result = transform(input);
+    const outputs = result.filter((i) => i.type === "function_call_output");
+    expect(outputs).toHaveLength(1);
+    expect(outputs[0].call_id).toBe("call_valid");
+  });
+
+  it("keeps matched, removes orphaned in mixed input", () => {
+    const input = [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+      { type: "function_call", call_id: "call_keep", name: "read_file", arguments: "{}" },
+      { type: "function_call_output", call_id: "call_keep", output: "ok" },
+      { type: "function_call_output", call_id: "call_orphan", output: "orphaned" },
+    ];
+    const result = transform(input);
+    const outputs = result.filter((i) => i.type === "function_call_output");
+    expect(outputs).toHaveLength(1);
+    expect(outputs[0].call_id).toBe("call_keep");
+  });
+
+  it("handles Chat Completions tool_calls format in assistant message", () => {
+    const input = [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+      { role: "assistant", content: null, tool_calls: [{ id: "call_cc1", function: { name: "read_file", arguments: "{}" } }] },
+      { type: "function_call_output", call_id: "call_cc1", output: "ok" },
+      { type: "function_call_output", call_id: "call_cc2", output: "orphaned" },
+    ];
+    const result = transform(input);
+    const outputs = result.filter((i) => i.type === "function_call_output");
+    expect(outputs).toHaveLength(1);
+    expect(outputs[0].call_id).toBe("call_cc1");
+  });
+
+  it("no-op when no function_call_output items", () => {
+    const input = [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+      { type: "function_call", call_id: "call_1", name: "read_file", arguments: "{}" },
+    ];
+    const result = transform(input);
+    expect(result).toHaveLength(2);
+  });
+});

--- a/tests/unit/openai-to-claude-response-tools.test.js
+++ b/tests/unit/openai-to-claude-response-tools.test.js
@@ -58,4 +58,31 @@ describe("openaiToClaudeResponse tool argument sanitization", () => {
       pages: "1-3",
     });
   });
+
+  it("does not emit buffered tool arguments again on repeated finish chunks", () => {
+    const state = createState();
+
+    openaiToClaudeResponse({
+      id: "chatcmpl-repeat-finish",
+      model: "test-model",
+      choices: [{ delta: { tool_calls: [{ index: 0, id: "toolu_read", function: { name: "Read" } }] } }],
+    }, state);
+
+    const firstFinish = openaiToClaudeResponse({
+      id: "chatcmpl-repeat-finish",
+      model: "test-model",
+      choices: [{
+        delta: { tool_calls: [{ index: 0, function: { arguments: '{"file_path":"/tmp/a.txt"}' } }] },
+        finish_reason: "tool_calls",
+      }],
+    }, state);
+    const repeatedFinish = openaiToClaudeResponse({
+      id: "chatcmpl-repeat-finish",
+      model: "test-model",
+      choices: [{ delta: {}, finish_reason: "tool_calls" }],
+    }, state);
+
+    expect(getInputJsonDelta(firstFinish)).toBe('{"file_path":"/tmp/a.txt"}');
+    expect(repeatedFinish).toBeNull();
+  });
 });

--- a/tests/unit/openai-to-claude.test.js
+++ b/tests/unit/openai-to-claude.test.js
@@ -189,7 +189,8 @@ describe("openaiToClaudeResponse", () => {
               })
             }
           }]
-        }
+        },
+        finish_reason: "tool_calls"
       }]
     };
 


### PR DESCRIPTION
## Summary
Local 9router patches, rebased on **v0.5.59**. The Codex **gpt-5.6-sol** fast/priority tier is now an explicit provider UI choice and defaults **off**.

## Changes
- **Codex Fast inference toggle** — provider-wide toggle on the Codex page, persisted as `codexFastMode`. OFF sends no tier and uses upstream Standard; ON sends `service_tier: "priority"` for Sol and Sol Review only. Client-supplied tiers take precedence, and explicit `fast` is normalized to `priority`.
- **GLM-5.2 / 5.3 context** — keep upstream thinking-effort wiring, raise context to **1M**, and set `thinkingCanDisable: false` on 5.3.
- **Honor native `ultra`** — preserve a model-supported `ultra` level before nearest-supported clamping.
- **Codex orphaned tool outputs** — strip `function_call_output` items with no matching call under `store:false`.
- **Translator / stream fixes** — carry forward OpenAI-to-Claude and stream usage fixes.

## Fast behavior
- Default: **OFF**
- Scope: provider-wide Codex setting
- Models: `gpt-5.6-sol` and `gpt-5.6-sol-review`
- Explicit client `service_tier`: preserved
- No restart or database migration required

Measured against the native Codex Responses endpoint, priority delivered approximately **25–29% higher tokens/sec** than the default tier on comparable interleaved prompts, so it remains available as an explicit latency/capacity tradeoff rather than a forced default.

## Verification
- Focused PR tests: **34 passed**
- Production build: `npm run build` passed
- Fast policy coverage: default OFF, enabled Sol/Sol Review, non-Sol exclusion, explicit client tier precedence, and `fast` to `priority` normalization.