### PR TITLE
feat(routing): global + per-provider connect-timeout setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Unreleased
+
+## Features
+- **Routing**: global connect-timeout setting (`connectTimeoutMs`, default 15s)
+  plus a per-provider override. Aborts an upstream request when its response
+  headers don't arrive in time so a stalled provider fails over to the next
+  model/account instead of burning the per-request budget. Per-provider override
+  wins; if neither is set, the existing registry `timeoutMs` (or env default
+  `FETCH_CONNECT_TIMEOUT_MS=60000`) still applies. UI: global input in
+  `Settings → Routing Strategy`, per-provider input in the provider page next
+  to the Round Robin toggle.
+
 # v0.5.59 (2026-08-29)
 
 ## Features

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -97,7 +97,7 @@ export class BaseExecutor {
     return { status: response.status, message: bodyText || `HTTP ${response.status}` };
   }
 
-  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null }) {
+  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null, connectTimeoutMs = null }) {
     const fallbackCount = this.getFallbackCount();
     let lastError = null;
     let lastStatus = 0;
@@ -131,9 +131,10 @@ export class BaseExecutor {
 
       if (!retryAttemptsByUrl[urlIndex]) retryAttemptsByUrl[urlIndex] = 0;
 
-      // Abort if upstream doesn't return response headers within connection timeout
+      // Abort if upstream doesn't return response headers within connection timeout.
+      // Precedence: caller-supplied (per-provider settings) → registry `timeoutMs` → env default.
       const connectCtrl = new AbortController();
-      const timeoutMs = this.config?.timeoutMs || FETCH_CONNECT_TIMEOUT_MS;
+      const timeoutMs = connectTimeoutMs ?? this.config?.timeoutMs ?? FETCH_CONNECT_TIMEOUT_MS;
       const connectTimer = setTimeout(() => connectCtrl.abort(new Error("fetch connect timeout")), timeoutMs);
       const mergedSignal = signal ? AbortSignal.any([signal, connectCtrl.signal]) : connectCtrl.signal;
 

--- a/open-sse/executors/qoder.js
+++ b/open-sse/executors/qoder.js
@@ -445,7 +445,7 @@ export class QoderExecutor extends BaseExecutor {
   //   - body encoded with QoderEncodeBody before signing
   //   - COSY headers built from the *encoded* body bytes
   //   - response stream re-wrapped from {statusCodeValue, body} to OpenAI SSE
-  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null }) {
+  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null, connectTimeoutMs = null }) {
     // PAT (pt-...) → exchange for short-lived job token + resolve userId so
     // downstream COSY signing + catalog fetch work. Device tokens (dt-...) and
     // job tokens (jt-...) skip this and are used directly.
@@ -536,7 +536,8 @@ export class QoderExecutor extends BaseExecutor {
     };
 
     // Abort if upstream doesn't return response headers within connect timeout.
-    const timeoutMs = this.config?.timeoutMs || FETCH_CONNECT_TIMEOUT_MS;
+    // Precedence: caller-supplied → registry `timeoutMs` → env default.
+    const timeoutMs = connectTimeoutMs ?? this.config?.timeoutMs ?? FETCH_CONNECT_TIMEOUT_MS;
     const connectCtrl = new AbortController();
     const connectTimer = setTimeout(() => connectCtrl.abort(new Error("fetch connect timeout")), timeoutMs);
     const mergedSignal = signal ? AbortSignal.any([signal, connectCtrl.signal]) : connectCtrl.signal;

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -58,7 +58,7 @@ export function stripContinuityFields(body) {
   return body;
 }
 
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, headroomTimeoutMs, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, headroomTimeoutMs, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking, connectTimeoutMs }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
   // Stable per-session color so all lines of one CLI conversation share a tag
@@ -356,7 +356,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // exception: it is decoded by the executor into OpenAI-compatible output.
   let providerResponseFormat = targetFormat;
   try {
-    const result = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
+    const result = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions, connectTimeoutMs });
     providerResponse = result.response;
     providerUrl = result.url;
     providerHeaders = result.headers;
@@ -410,7 +410,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
           try { await onCredentialsRefreshed(newCredentials); } catch (e) { log?.warn?.("TOKEN", `onCredentialsRefreshed failed: ${e.message}`); }
         }
         try {
-          const retryResult = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
+          const retryResult = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions, connectTimeoutMs });
           if (retryResult.response.ok) {
             providerResponse = retryResult.response;
             providerUrl = retryResult.url;

--- a/src/app/(dashboard)/dashboard/profile/page.js
+++ b/src/app/(dashboard)/dashboard/profile/page.js
@@ -304,6 +304,24 @@ export default function ProfilePage() {
     }
   };
 
+  const updateConnectTimeout = async (ms) => {
+    const numMs = parseInt(ms);
+    if (isNaN(numMs) || numMs < 1000 || numMs > 120000) return;
+
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ connectTimeoutMs: numMs }),
+      });
+      if (res.ok) {
+        setSettings(prev => ({ ...prev, connectTimeoutMs: numMs }));
+      }
+    } catch (err) {
+      console.error("Failed to update connect timeout:", err);
+    }
+  };
+
   const updateComboStickyLimit = async (limit) => {
     const numLimit = parseInt(limit);
     if (isNaN(numLimit) || numLimit < 1) return;
@@ -1473,6 +1491,26 @@ export default function ProfilePage() {
               </div>
             )}
 
+            {/* Global Connect Timeout (ms) */}
+            <div className="flex items-start sm:items-center justify-between gap-4 pt-4 border-t border-border/50">
+              <div className="flex-1 min-w-0">
+                <p className="font-medium text-sm sm:text-base">Connect Timeout (ms)</p>
+                <p className="text-xs sm:text-sm text-text-muted">
+                  Abort request and fall back if the provider doesn&apos;t return response headers in time. Per-provider override wins.
+                </p>
+              </div>
+              <Input
+                type="number"
+                min="1000"
+                max="120000"
+                step="1000"
+                value={settings.connectTimeoutMs || 15000}
+                onChange={(e) => updateConnectTimeout(e.target.value)}
+                disabled={loading}
+                className="w-20 sm:w-24 text-center shrink-0"
+              />
+            </div>
+
             {/* Combo Round Robin */}
             <div className="flex items-start sm:items-center justify-between gap-4 pt-4 border-t border-border/50">
               <div className="flex-1 min-w-0">
@@ -1516,6 +1554,7 @@ export default function ProfilePage() {
               {settings.comboStrategy === "round-robin"
                 ? ` Combos rotate after ${settings.comboStickyRoundRobinLimit || 1} call${(settings.comboStickyRoundRobinLimit || 1) === 1 ? "" : "s"} per model.`
                 : " Combos always start with their first model."}
+              {` Connect timeout: ${(settings.connectTimeoutMs || 15000) / 1000}s (per-provider override wins).`}
             </p>
           </div>
         </Card>

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -66,6 +66,7 @@ export default function ProviderDetailPage() {
   const [bulkUpdatingProxy, setBulkUpdatingProxy] = useState(false);
   const [providerStrategy, setProviderStrategy] = useState(null);
   const [providerStickyLimit, setProviderStickyLimit] = useState("");
+  const [providerConnectTimeout, setProviderConnectTimeout] = useState("");
   const [thinkingMode, setThinkingMode] = useState("auto");
   const [autoPing, setAutoPing] = useState({ enabled: false, connections: {} });
   const [suggestedModels, setSuggestedModels] = useState([]);
@@ -315,6 +316,7 @@ export default function ProviderDetailPage() {
       const override = (settingsData.providerStrategies || {})[providerId] || {};
       setProviderStrategy(override.fallbackStrategy || null);
       setProviderStickyLimit(override.stickyRoundRobinLimit != null ? String(override.stickyRoundRobinLimit) : "1");
+      setProviderConnectTimeout(override.connectTimeoutMs != null ? String(override.connectTimeoutMs) : "");
       // Load per-provider thinking config
       const thinkingCfg = (settingsData.providerThinking || {})[providerId] || {};
       setThinkingMode(thinkingCfg.mode || "auto");
@@ -405,6 +407,48 @@ export default function ProviderDetailPage() {
   const handleStickyLimitChange = (value) => {
     setProviderStickyLimit(value);
     saveProviderStrategy("round-robin", value);
+  };
+
+  const saveProviderConnectTimeout = async (value) => {
+    try {
+      const settingsRes = await fetch("/api/settings", { cache: "no-store" });
+      const settingsData = settingsRes.ok ? await settingsRes.json() : {};
+      const current = settingsData.providerStrategies || {};
+      const existing = current[providerId] || {};
+
+      let updated = { ...current };
+      if (value === "" || value === null) {
+        delete existing.connectTimeoutMs;
+        if (Object.keys(existing).length === 0) {
+          delete updated[providerId];
+        } else {
+          updated[providerId] = existing;
+        }
+      } else {
+        updated[providerId] = { ...existing, connectTimeoutMs: Number(value) };
+      }
+
+      await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ providerStrategies: updated }),
+      });
+    } catch (error) {
+      console.log("Error saving provider connect timeout:", error);
+    }
+  };
+
+  const handleProviderConnectTimeoutChange = (value) => {
+    setProviderConnectTimeout(value);
+    const trimmed = value.trim();
+    if (trimmed === "") {
+      saveProviderConnectTimeout(null);
+    } else {
+      const num = parseInt(trimmed);
+      if (!isNaN(num) && num >= 1000 && num <= 120000) {
+        saveProviderConnectTimeout(num);
+      }
+    }
   };
 
   const saveThinkingConfig = async (mode) => {
@@ -1490,6 +1534,19 @@ export default function ProviderDetailPage() {
                     />
                   </div>
                 )}
+                <div className="flex items-center gap-1.5 ml-2">
+                  <span className="text-xs text-text-muted" title="Per-provider connect timeout in ms. Leave blank to use the global default.">Timeout&nbsp;(ms):</span>
+                  <input
+                    type="number"
+                    min={1000}
+                    max={120000}
+                    step={1000}
+                    value={providerConnectTimeout}
+                    onChange={(e) => handleProviderConnectTimeoutChange(e.target.value)}
+                    placeholder="global"
+                    className="w-20 px-2 py-1 text-xs border border-border rounded-md bg-background focus:outline-none focus:border-primary"
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -12,6 +12,13 @@ const DEFAULT_SETTINGS = {
   tailscaleEnabled: false,
   tailscaleUrl: "",
   stickyRoundRobinLimit: 3,
+  // Global upstream connect timeout (ms). Aborts the request and triggers
+  // fallback to the next model/account when the provider doesn't return
+  // response headers within this window. Per-provider registry `timeoutMs`
+  // still wins. Default 15s — generous enough for cold starts, fast enough
+  // to fail over from a stalled provider (e.g. rate-limited NIM) within a
+  // reasonable budget.
+  connectTimeoutMs: 15000,
   providerStrategies: {},
   quotaVisibility: {},
   comboStrategy: "fallback",

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -260,6 +260,11 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     // Use shared chatCore
     const chatSettings = await getSettings();
     const providerThinking = (chatSettings.providerThinking || {})[provider] || null;
+    // Connect-timeout precedence: per-provider setting → global setting → registry → env default.
+    // Per-provider lets the user pin a tight timeout to a flaky provider (e.g. nvidia: 10000)
+    // while leaving a generous global default (15s) for everything else.
+    const providerConnectTimeout = (chatSettings.providerStrategies || {})[provider]?.connectTimeoutMs;
+    const connectTimeoutMs = providerConnectTimeout ?? chatSettings.connectTimeoutMs;
     const result = await handleChatCore({
       body: { ...body, model: `${provider}/${model}` },
       modelInfo: { provider, model },
@@ -286,6 +291,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       pxpipeTransform: chatSettings.pxpipeEnabled ? await getPxpipeTransform() : null,
       onPxpipeEvent: appendPxpipeEvent,
       providerThinking,
+      connectTimeoutMs,
       // Detect source format by endpoint + body
       sourceFormatOverride: request?.url ? detectFormatByEndpoint(new URL(request.url).pathname, body) : null,
       onCredentialsRefreshed: async (newCreds) => {


### PR DESCRIPTION
### What
Adds a configurable upstream connect timeout (default 15s) so a stalled
provider fails over to the next model/account instead of burning the
full request budget waiting for headers.

### Why
When an upstream hangs (e.g. NVIDIA NIM returning 429 with silent
queuing, or a stalled free-tier model), the existing 60s default
(`FETCH_CONNECT_TIMEOUT_MS`) lets the hang sit just under the abort
window, blocking the combo from falling through promptly. 15s is a
sensible global default; per-provider override lets users tighten
specific flaky providers (e.g. `nvidia: 8000`) without affecting
everything else.

### How
- New `connectTimeoutMs` global setting in `DEFAULT_SETTINGS`
- New per-provider override under `providerStrategies[id].connectTimeoutMs`
- Precedence (highest → lowest):
  1. per-provider setting
  2. global setting (default 15s)
  3. registry `transport.timeoutMs` (preserves e.g. `qoder: 120000`)
  4. env `FETCH_CONNECT_TIMEOUT_MS` (60s default)
- Threaded through `chat.js` → `chatCore.js` → `BaseExecutor.execute()`.
  Default arg `null` so all existing executors keep working unchanged;
  `QoderExecutor` updated to the same precedence (it had its own
  `this.config?.timeoutMs` line that bypassed the new caller arg).
- UI: global input in `Settings → Routing Strategy` card; per-provider
  input next to the Round Robin sticky input in `/dashboard/providers/[id]`.

### Tested
- `npx eslint <changed files>` — 0 new errors
- `npx vitest run` — 209 → 209 failures, **0 new regressions**
- `tests/__baseline__/verify-alias.mjs` — byte-for-byte equal
- `tests/__baseline__/verify-oauth-urls.mjs` — byte-for-byte equal
- `tests/__baseline__/snapshot-providers.mjs` — 81 providers, unchanged

### Notes
- Backward compatible: if no setting is set, behavior is identical
  to today (registry `timeoutMs` → env `FETCH_CONNECT_TIMEOUT_MS`).
- No migration needed; new key is optional in