### PR TITLE
fix(codex): label quota windows by duration

### DIFF
--- a/open-sse/services/usage/codex.js
+++ b/open-sse/services/usage/codex.js
@@ -52,7 +52,8 @@ function appendCodexQuotaWindows(quotas, prefix, snapshot) {
   let added = false;
 
   if (primary) {
-    quotas[prefix ? `${prefix}_session` : "session"] = formatCodexWindow(primary);
+    const windowType = toFiniteNumber(primary.limit_window_seconds, 0) >= 604800 ? "weekly" : "session";
+    quotas[prefix ? `${prefix}_${windowType}` : windowType] = formatCodexWindow(primary);
     added = true;
   }
   if (secondary) {
@@ -61,6 +62,27 @@ function appendCodexQuotaWindows(quotas, prefix, snapshot) {
   }
 
   return added;
+}
+
+export function normalizeCodexUsage(data) {
+  const normalRateLimit = data.rate_limit || data.rate_limits || data.rate_limits_by_limit_id?.codex || {};
+  const reviewRateLimit = getCodexReviewRateLimit(data);
+  const sparkRateLimit = getCodexSparkRateLimit(data);
+  const availableResetCredits = Math.max(0, toFiniteNumber(data.rate_limit_reset_credits?.available_count, 0));
+  const quotas = {};
+
+  appendCodexQuotaWindows(quotas, "", normalRateLimit);
+  appendCodexQuotaWindows(quotas, "review", reviewRateLimit);
+  appendCodexQuotaWindows(quotas, "spark", sparkRateLimit);
+
+  return {
+    plan: data.plan_type || data.summary?.plan || "unknown",
+    limitReached: getCodexRateLimitBody(normalRateLimit)?.limit_reached || false,
+    reviewLimitReached: getCodexRateLimitBody(reviewRateLimit)?.limit_reached || false,
+    sparkLimitReached: getCodexRateLimitBody(sparkRateLimit)?.limit_reached || false,
+    resetCredits: { availableCount: availableResetCredits },
+    quotas,
+  };
 }
 
 function getCodexReviewRateLimit(data) {
@@ -112,24 +134,7 @@ export async function getCodexUsage(accessToken, proxyOptions = null) {
     }
 
     const data = await response.json();
-    const normalRateLimit = data.rate_limit || data.rate_limits || data.rate_limits_by_limit_id?.codex || {};
-    const reviewRateLimit = getCodexReviewRateLimit(data);
-    const sparkRateLimit = getCodexSparkRateLimit(data);
-    const availableResetCredits = Math.max(0, toFiniteNumber(data.rate_limit_reset_credits?.available_count, 0));
-    const quotas = {};
-
-    appendCodexQuotaWindows(quotas, "", normalRateLimit);
-    appendCodexQuotaWindows(quotas, "review", reviewRateLimit);
-    appendCodexQuotaWindows(quotas, "spark", sparkRateLimit);
-
-    return {
-      plan: data.plan_type || data.summary?.plan || "unknown",
-      limitReached: getCodexRateLimitBody(normalRateLimit)?.limit_reached || false,
-      reviewLimitReached: getCodexRateLimitBody(reviewRateLimit)?.limit_reached || false,
-      sparkLimitReached: getCodexRateLimitBody(sparkRateLimit)?.limit_reached || false,
-      resetCredits: { availableCount: availableResetCredits },
-      quotas,
-    };
+    return normalizeCodexUsage(data);
   } catch (error) {
     throw new Error(`Failed to fetch Codex usage: ${error.message}`);
   }

--- a/tests/unit/codex-spark-quota-tracking.test.js
+++ b/tests/unit/codex-spark-quota-tracking.test.js
@@ -1,7 +1,27 @@
 import { describe, it, expect } from "vitest";
 import { parseQuotaData } from "@/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js";
+import { normalizeCodexUsage } from "../../open-sse/services/usage/codex.js";
 
 describe("Codex Spark Quota Tracking (#3431)", () => {
+  it("labels a Pro account's single seven-day primary window as weekly", () => {
+    const usage = normalizeCodexUsage({
+      plan_type: "pro",
+      rate_limit: {
+        primary_window: {
+          used_percent: 1,
+          limit_window_seconds: 604800,
+          reset_at: 1788654857,
+        },
+        secondary_window: null,
+      },
+    });
+
+    expect(usage.plan).toBe("pro");
+    expect(usage.quotas.session).toBeUndefined();
+    expect(usage.quotas.weekly).toMatchObject({ used: 1, remaining: 99 });
+    expect(parseQuotaData("codex", usage)[0].name).toBe("Weekly");
+  });
+
   it("correctly normalizes spark_session and spark_weekly quotas with display labels", () => {
     const mockCodexUsage = {
       plan: "team",


### PR DESCRIPTION
## Summary
- classify Codex quota windows using `limit_window_seconds` instead of assuming every primary window is 5 hours
- keep the existing primary/secondary fallback when upstream omits window duration
- add a regression case for ChatGPT Pro accounts whose normal Codex quota is a single 7-day primary window

## Reproduction
The Codex usage API can return a Pro account normal limit as:

```json
{
  "plan_type": "pro",
  "rate_limit": {
    "primary_window": {
      "used_percent": 1,
      "limit_window_seconds": 604800
    },
    "secondary_window": null
  }
}
```

The existing positional mapping renders this as `5h` even though `604800` seconds is 7 days. Spark still correctly exposes separate 5-hour (`18000`) and weekly (`604800`) windows.

## Test
- `cd tests && npx vitest run unit/codex-spark-quota-tracking.test.js`