### PR TITLE
Adding a link to verify antigravity account

### DIFF
--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -2,11 +2,13 @@ import crypto from "crypto";
 import { BaseExecutor } from "./base.js";
 import { PROVIDERS } from "../config/providers.js";
 import { OAUTH_ENDPOINTS, ANTIGRAVITY_HEADERS, AG_DEFAULT_TOOLS, AG_TOOL_SUFFIX, ANTIGRAVITY_PROMPT_REWRITES } from "../config/appConstants.js";
+import { ANTIGRAVITY_IDE_USER_AGENT } from "../providers/shared.js";
 import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { cleanJSONSchemaForAntigravity } from "../translator/formats/gemini.js";
 import { DEFAULT_THINKING_AG_SIGNATURE } from "../config/defaultThinkingSignature.js";
+import { extractVerificationUrl } from "../services/projectId.js";
 
 // Sanitize function name: Gemini requires [a-zA-Z_][a-zA-Z0-9_.:\-]{0,63}
 function sanitizeFunctionName(name) {
@@ -129,7 +131,9 @@ export class AntigravityExecutor extends BaseExecutor {
     return {
       "Content-Type": "application/json",
       "Authorization": `Bearer ${credentials.accessToken}`,
-      "User-Agent": this.config.headers?.["User-Agent"] || ANTIGRAVITY_HEADERS["User-Agent"],
+      "User-Agent": this.config.headers?.["User-Agent"] || ANTIGRAVITY_IDE_USER_AGENT,
+      "X-Goog-Api-Client": "google-cloud-sdk vscode_cloudshelleditor/0.1",
+      "Client-Metadata": JSON.stringify({ ideType: "ANTIGRAVITY", platform: "MACOS", pluginType: "GEMINI" }),
     };
   }
 
@@ -521,6 +525,27 @@ export class AntigravityExecutor extends BaseExecutor {
       },
       toolNameMap
     };
+  }
+
+  parseError(response, bodyText) {
+    const base = super.parseError(response, bodyText);
+    if (!bodyText) return base;
+
+    try {
+      const json = JSON.parse(bodyText);
+      const err = json.error || json;
+      const message = err.message || base.message;
+      const verificationUrl = extractVerificationUrl(json) || extractVerificationUrl(bodyText);
+
+      return {
+        status: response.status,
+        message,
+        verificationUrl: verificationUrl || undefined
+      };
+    } catch {
+      const verificationUrl = extractVerificationUrl(bodyText);
+      return verificationUrl ? { ...base, verificationUrl } : base;
+    }
   }
 }
 

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -11,7 +11,7 @@ import { PROVIDERS } from "../config/providers.js";
 import { createErrorResult, parseUpstreamError, formatProviderError } from "../utils/error.js";
 import { HTTP_STATUS, TOKEN_SAVER_HEADER } from "../config/runtimeConfig.js";
 import { handleBypassRequest } from "../utils/bypassHandler.js";
-import { trackPendingRequest, appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
+import { trackPendingRequest, appendRequestLog, saveRequestDetail, setAntigravityVerification, clearAntigravityVerification } from "@/lib/usageDb.js";
 import { getExecutor } from "../executors/index.js";
 import { supportsGrokCliReasoningEffort } from "../config/grokCli.js";
 import { buildRequestDetail, extractRequestConfig } from "./chatCore/requestDetail.js";
@@ -411,11 +411,11 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
         }
         try {
           const retryResult = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
-          if (retryResult.response.ok) {
-            providerResponse = retryResult.response;
-            providerUrl = retryResult.url;
-            providerResponseFormat = retryResult.responseFormat || targetFormat;
-          }
+          providerResponse = retryResult.response;
+          providerUrl = retryResult.url;
+          providerHeaders = retryResult.headers;
+          finalBody = retryResult.transformedBody;
+          providerResponseFormat = retryResult.responseFormat || targetFormat;
         } catch { log?.warn?.("TOKEN", `${provider.toUpperCase()} | retry after refresh failed`); }
       } else {
         log?.warn?.("TOKEN", `${provider.toUpperCase()} | refresh failed`);
@@ -428,8 +428,15 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // Provider returned error
   if (!providerResponse.ok) {
     trackPendingRequest(model, provider, connectionId, false, true);
-    const { statusCode, message, resetsAtMs } = await parseUpstreamError(providerResponse, executor);
-    appendRequestLog({ model, provider, connectionId, status: `FAILED ${statusCode}` }).catch(() => { });
+    const { statusCode, message, resetsAtMs, verificationUrl } = await parseUpstreamError(providerResponse, executor);
+    if (verificationUrl && provider === "antigravity") {
+      setAntigravityVerification({
+        url: verificationUrl,
+        connectionId,
+        account: credentials?.email || credentials?.name || connectionId,
+        createdAt: Date.now()
+      });
+    }
     saveRequestDetail(buildRequestDetail({
       provider, model, connectionId,
       latency: { ttft: 0, total: Date.now() - requestStartTime },
@@ -447,7 +454,11 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
       log.errorLine(reqTag, "✗", `ERROR ${statusCode} · ${provider}/${model} · ${Date.now() - requestStartTime}ms${urlStr}\n    ${errMsg}`);
     }
     reqLogger.logError(new Error(message), finalBody || translatedBody);
-    return createErrorResult(statusCode, errMsg, resetsAtMs);
+    return createErrorResult(statusCode, errMsg, resetsAtMs, verificationUrl);
+  }
+
+  if (provider === "antigravity" && connectionId) {
+    clearAntigravityVerification(connectionId);
   }
 
   const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary, reqTag, log };

--- a/open-sse/services/projectId.js
+++ b/open-sse/services/projectId.js
@@ -8,6 +8,7 @@
  */
 
 import { CLOUD_CODE_API, LOAD_CODE_ASSIST_HEADERS, ANTIGRAVITY_LOAD_CODE_ASSIST_HEADERS, LOAD_CODE_ASSIST_METADATA } from "../config/appConstants.js";
+import { setAntigravityVerification } from "@/lib/usageDb.js";
 
 // ─── Cache ────────────────────────────────────────────────────────────────────
 // connectionId -> { projectId: string, fetchedAt: number }
@@ -102,7 +103,7 @@ export async function getProjectIdForConnection(connectionId, accessToken, provi
 
     const promise = (async () => {
         try {
-            const projectId = await fetchProjectId(accessToken, controller.signal, provider);
+            const projectId = await fetchProjectId(accessToken, controller.signal, provider, connectionId);
             if (projectId) {
                 projectIdCache.set(connectionId, {projectId, fetchedAt: Date.now()});
                 return projectId;
@@ -155,7 +156,7 @@ export function removeConnection(connectionId) {
  * @param {AbortSignal} signal
  * @returns {Promise<string|null>}
  */
-async function fetchProjectId(accessToken, signal, provider) {
+async function fetchProjectId(accessToken, signal, provider, connectionId) {
     const endpoints = CLOUD_CODE_API[provider] || CLOUD_CODE_API["gemini-cli"];
     const headers = provider === "antigravity" ? ANTIGRAVITY_LOAD_CODE_ASSIST_HEADERS : LOAD_CODE_ASSIST_HEADERS;
     const response = await fetch(endpoints.loadCodeAssist, {
@@ -166,11 +167,17 @@ async function fetchProjectId(accessToken, signal, provider) {
     });
 
     if (!response.ok) {
-        const errorText = await response.text().catch(() => "");
-        throw new Error(`loadCodeAssist failed: HTTP ${response.status} ${errorText.slice(0, 200)}`);
+        const rawText = await response.text().catch(() => "");
+        if (provider === "antigravity") {
+            inspectAndPublishVerification(rawText, connectionId);
+        }
+        throw new Error(`loadCodeAssist failed: HTTP ${response.status}`);
     }
 
     const data = await response.json();
+    if (provider === "antigravity") {
+        inspectAndPublishVerification(data, connectionId);
+    }
     const projectId = extractProjectId(data);
     if (projectId) return projectId;
 
@@ -187,7 +194,7 @@ async function fetchProjectId(accessToken, signal, provider) {
         }
     }
 
-    return onboardUser(accessToken, tierID, signal, endpoints, provider);
+    return onboardUser(accessToken, tierID, signal, endpoints, provider, connectionId);
 }
 
 /**
@@ -198,7 +205,7 @@ async function fetchProjectId(accessToken, signal, provider) {
  * @param {AbortSignal} externalSignal  – propagated from the connection's AbortController
  * @returns {Promise<string|null>}
  */
-async function onboardUser(accessToken, tierID, externalSignal, endpoints, provider) {
+async function onboardUser(accessToken, tierID, externalSignal, endpoints, provider, connectionId = null) {
     console.log(`[ProjectId] Onboarding user with tier: ${tierID}`);
 
     const reqBody = { tierId: tierID, metadata: LOAD_CODE_ASSIST_METADATA };
@@ -226,11 +233,17 @@ async function onboardUser(accessToken, tierID, externalSignal, endpoints, provi
             clearTimeout(timeoutId);
 
             if (!response.ok) {
-                const errorText = await response.text().catch(() => "");
-                throw new Error(`onboardUser HTTP ${response.status}: ${errorText.slice(0, 200)}`);
+                const rawText = await response.text().catch(() => "");
+                if (provider === "antigravity") {
+                    inspectAndPublishVerification(rawText, connectionId);
+                }
+                throw new Error(`onboardUser HTTP ${response.status}`);
             }
 
             const data = await response.json();
+            if (provider === "antigravity") {
+                inspectAndPublishVerification(data, connectionId);
+            }
 
             if (data.done === true) {
                 const projectId = extractProjectIdFromOnboard(data);
@@ -303,6 +316,112 @@ function extractProjectIdFromOnboard(data) {
     if (project && typeof project === "object") {
         const id = project.id;
         if (typeof id === "string" && id.trim()) return id.trim();
+    }
+
+    return null;
+}
+
+/**
+ * Inspect data / error payloads for Antigravity verification challenge URLs
+ * and publish to usageDb if valid HTTPS accounts.google.com with verification wording.
+ * Does not log raw bodies or sensitive URLs.
+ */
+export function inspectAndPublishVerification(payload, connectionId) {
+    const url = extractVerificationUrl(payload);
+    if (!url) return null;
+
+    try {
+        setAntigravityVerification({
+            url,
+            connectionId: connectionId || undefined,
+            createdAt: Date.now()
+        });
+    } catch {
+        // ignore verification recording failures
+    }
+    return url;
+}
+
+function isGoogleVerificationUrl(candidate) {
+    if (!candidate || typeof candidate !== "string") return false;
+    try {
+        const parsed = new URL(candidate);
+        return parsed.protocol === "https:" && parsed.hostname === "accounts.google.com";
+    } catch {
+        return false;
+    }
+}
+
+export function extractVerificationUrl(payload) {
+    if (!payload) return null;
+
+    let json = null;
+    let text = "";
+    if (typeof payload === "string") {
+        text = payload;
+        try { json = JSON.parse(payload); } catch { json = null; }
+    } else if (typeof payload === "object") {
+        json = payload;
+    }
+
+    const candidates = [];
+
+    if (json) {
+        // 1. Successful loadCodeAssist with ineligibleTiers
+        if (Array.isArray(json.ineligibleTiers)) {
+            for (const tier of json.ineligibleTiers) {
+                const reason = tier?.validationErrorMessage || tier?.reason || "";
+                const url = tier?.validationUrl || tier?.validation_url || tier?.appeal_url;
+                if (url && (/validation|verify|verification|appeal/i.test(reason) || !reason || /validation|appeal/i.test(url))) {
+                    candidates.push(url);
+                }
+            }
+        }
+
+        // 2. Direct properties on root
+        if (json.validationUrl) candidates.push(json.validationUrl);
+        if (json.validation_url) candidates.push(json.validation_url);
+        if (json.appeal_url) candidates.push(json.appeal_url);
+
+        // 3. Error structure details (ErrorInfo, Help, etc.)
+        const err = json.error || json;
+        const errMsg = typeof err?.message === "string" ? err.message : "";
+        const details = Array.isArray(err?.details) ? err.details : [];
+
+        for (const d of details) {
+            const metaUrl = d?.metadata?.validation_url || d?.metadata?.validationUrl || d?.metadata?.appeal_url || d?.metadata?.appealUrl;
+            if (metaUrl) candidates.push(metaUrl);
+        }
+
+        const hasValidationReason = details.some(d =>
+            (d["@type"]?.includes("ErrorInfo") || d.reason) &&
+            (d.reason === "VALIDATION_REQUIRED" || /validation|verify|verification|appeal/i.test(String(d.reason)))
+        ) || /validation\s+required|verification|verify\s+your\s+account/i.test(errMsg);
+
+        if (hasValidationReason) {
+            for (const d of details) {
+                if (Array.isArray(d?.links)) {
+                    for (const link of d.links) {
+                        if (link?.url) candidates.push(link.url);
+                    }
+                }
+            }
+        }
+    }
+
+    if (text && /validation|verification|verify/i.test(text)) {
+        const match = text.match(/https:\/\/accounts\.google\.com\/signin\/continue\?[^\s"'\\]+/);
+        if (match) candidates.push(match[0]);
+    }
+
+    for (const cand of candidates) {
+        if (isGoogleVerificationUrl(cand)) {
+            try {
+                return new URL(cand).href;
+            } catch {
+                return cand;
+            }
+        }
     }
 
     return null;

--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -33,7 +33,7 @@ import {
 const USAGE_HANDLERS = {
   github: (c) => getGitHubUsage(c.accessToken, c.providerSpecificData, c.proxyOptions),
   "gemini-cli": (c) => getGeminiUsage(c.accessToken, c.providerDataWithProjectId, c.proxyOptions),
-  antigravity: (c) => getAntigravityUsage(c.accessToken, c.providerSpecificData, c.proxyOptions),
+  antigravity: (c) => getAntigravityUsage(c.accessToken, c.providerSpecificData, c.proxyOptions, c.connectionId),
   claude: (c) => getClaudeUsage(c.accessToken, c.proxyOptions, { force: c.force }),
   codex: (c) => getCodexUsage(c.accessToken, c.proxyOptions),
   kiro: (c) => getKiroUsage(c.accessToken, c.providerSpecificData, c.proxyOptions),
@@ -59,7 +59,7 @@ const USAGE_HANDLERS = {
 };
 
 export async function getUsageForProvider(connection, proxyOptions = null, options = {}) {
-  const { provider, accessToken, apiKey, providerSpecificData, projectId } = connection;
+  const { provider, accessToken, apiKey, providerSpecificData, projectId, connectionId } = connection;
   const providerDataWithProjectId = {
     ...(providerSpecificData || {}),
     ...(projectId ? { projectId } : {}),
@@ -74,6 +74,7 @@ export async function getUsageForProvider(connection, proxyOptions = null, optio
     providerSpecificData,
     providerDataWithProjectId,
     proxyOptions,
-    force: options.force === true,
+    connectionId,
+    ...options,
   });
 }

--- a/open-sse/services/usage/google.js
+++ b/open-sse/services/usage/google.js
@@ -2,6 +2,7 @@
  * Google usage handlers (Gemini CLI + Antigravity)
  */
 
+import { inspectAndPublishVerification } from "../projectId.js";
 import { CLIENT_METADATA } from "../../config/appConstants.js";
 import { ANTIGRAVITY_IDE_USER_AGENT, ANTIGRAVITY_IDE_VERSION, ANTIGRAVITY_OAUTH_CLIENT } from "../../providers/shared.js";
 import { U, parseResetTime, normalizeCloudCodeProjectId, fetchWithTimeout } from "./shared.js";
@@ -116,10 +117,10 @@ async function getGeminiSubscriptionInfo(accessToken, proxyOptions = null) {
 /**
  * Antigravity Usage - Fetch quota from Google Cloud Code API
  */
-export async function getAntigravityUsage(accessToken, providerSpecificData, proxyOptions = null) {
+export async function getAntigravityUsage(accessToken, providerSpecificData, proxyOptions = null, connectionId = null) {
   try {
     // Fetch subscription info once — reuse for both projectId and plan
-    const subscriptionInfo = await getAntigravitySubscriptionInfo(accessToken, proxyOptions);
+    const subscriptionInfo = await getAntigravitySubscriptionInfo(accessToken, proxyOptions, connectionId);
     const projectId = subscriptionInfo?.cloudaicompanionProject || null;
 
     const response = await fetchWithTimeout(ANTIGRAVITY_CONFIG.quotaApiUrl, {
@@ -135,26 +136,28 @@ export async function getAntigravityUsage(accessToken, providerSpecificData, pro
         ...(projectId ? { project: projectId } : {})
       }),
     }, 10000, proxyOptions);
-
-    if (response.status === 403) {
-      return {
-        message: "Antigravity quota API access forbidden. Chat may still work.",
-        quotas: {}
-      };
-    }
-
-    if (response.status === 401) {
-      return {
-        message: "Antigravity quota API authentication expired. Chat may still work.",
-        quotas: {}
-      };
-    }
-
     if (!response.ok) {
+      const errorText = await response.text().catch(() => "");
+      inspectAndPublishVerification(errorText, connectionId);
+      if (response.status === 403) {
+        return {
+          message: "Antigravity quota API access forbidden. Chat may still work.",
+          quotas: {}
+        };
+      }
+
+      if (response.status === 401) {
+        return {
+          message: "Antigravity quota API authentication expired. Chat may still work.",
+          quotas: {}
+        };
+      }
+
       throw new Error(`Antigravity API error: ${response.status}`);
     }
 
     const data = await response.json();
+    inspectAndPublishVerification(data, connectionId);
     const quotas = {};
 
     // Parse model quotas (inspired by vscode-antigravity-cockpit)
@@ -223,7 +226,7 @@ export async function getAntigravityUsage(accessToken, providerSpecificData, pro
 /**
  * Get Antigravity subscription info
  */
-async function getAntigravitySubscriptionInfo(accessToken, proxyOptions = null) {
+async function getAntigravitySubscriptionInfo(accessToken, proxyOptions = null, connectionId = null) {
   try {
     const response = await fetchWithTimeout(ANTIGRAVITY_CONFIG.loadProjectApiUrl, {
       method: "POST",
@@ -234,9 +237,14 @@ async function getAntigravitySubscriptionInfo(accessToken, proxyOptions = null) 
       },
       body: JSON.stringify({ metadata: CLIENT_METADATA, mode: 1 }),
     }, 10000, proxyOptions);
-
-    if (!response.ok) return null;
-    return await response.json();
+    const rawText = await response.text().catch(() => "");
+    if (!response.ok) {
+      inspectAndPublishVerification(rawText, connectionId);
+      return null;
+    }
+    const data = rawText ? JSON.parse(rawText) : null;
+    inspectAndPublishVerification(data, connectionId);
+    return data;
   } catch (error) {
     console.error("[Antigravity Subscription] Error:", error.message);
     return null;

--- a/open-sse/utils/error.js
+++ b/open-sse/utils/error.js
@@ -53,7 +53,7 @@ export async function writeStreamError(writer, statusCode, message) {
  * Parse upstream provider error response
  * @param {Response} response - Fetch response from provider
  * @param {object} [executor] - Optional executor with parseError() override for provider-specific parsing
- * @returns {Promise<{statusCode: number, message: string, resetsAtMs?: number}>}
+ * @returns {Promise<{statusCode: number, message: string, resetsAtMs?: number, verificationUrl?: string}>}
  */
 export async function parseUpstreamError(response, executor = null) {
   let bodyText = "";
@@ -63,13 +63,18 @@ export async function parseUpstreamError(response, executor = null) {
     bodyText = "";
   }
 
-  // Let executor-specific parser extract provider-specific fields (e.g. codex resetsAtMs)
+  // Let executor-specific parser extract provider-specific fields (e.g. codex resetsAtMs, antigravity verificationUrl)
   if (executor && typeof executor.parseError === "function") {
     try {
       const parsed = executor.parseError(response, bodyText);
       if (parsed && typeof parsed === "object") {
         const msg = parsed.message || DEFAULT_ERROR_MESSAGES[response.status] || `Upstream error: ${response.status}`;
-        return { statusCode: parsed.status || response.status, message: msg, resetsAtMs: parsed.resetsAtMs };
+        return {
+          statusCode: parsed.status || response.status,
+          message: msg,
+          resetsAtMs: parsed.resetsAtMs,
+          verificationUrl: parsed.verificationUrl
+        };
       }
     } catch { /* fall through to default parsing */ }
   }
@@ -93,14 +98,16 @@ export async function parseUpstreamError(response, executor = null) {
  * @param {number} statusCode - HTTP status code
  * @param {string} message - Error message
  * @param {number} [resetsAtMs] - Optional precise cooldown expiry (ms epoch) for provider-specific quota errors
- * @returns {{ success: false, status: number, error: string, response: Response, resetsAtMs?: number }}
+ * @param {string} [verificationUrl] - Optional verification URL for antigravity authentication challenge
+ * @returns {{ success: false, status: number, error: string, response: Response, resetsAtMs?: number, verificationUrl?: string }}
  */
-export function createErrorResult(statusCode, message, resetsAtMs) {
+export function createErrorResult(statusCode, message, resetsAtMs, verificationUrl) {
   return {
     success: false,
     status: statusCode,
     error: message,
     resetsAtMs,
+    verificationUrl,
     response: errorResponse(statusCode, message)
   };
 }

--- a/src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js
@@ -6,7 +6,7 @@ import PropTypes from "prop-types";
 import { Badge, Toggle, Tooltip } from "@/shared/components";
 import CooldownTimer from "./CooldownTimer";
 
-export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst, isLast, onMoveUp, onMoveDown, onToggleActive, onUpdateProxy, onEdit, onDelete, oneByOneStatus = null, autoPing = null }) {
+export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst, isLast, onMoveUp, onMoveDown, onToggleActive, onUpdateProxy, onEdit, onDelete, oneByOneStatus = null, autoPing = null, verification = null }) {
   const [showProxyDropdown, setShowProxyDropdown] = useState(false);
   const [updatingProxy, setUpdatingProxy] = useState(false);
   const proxyDropdownRef = useRef(null);
@@ -211,7 +211,7 @@ export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst
         </div>
       </div>
       <div className="flex w-full items-center justify-between gap-2 sm:w-auto sm:justify-end">
-        <div className="grid flex-1 grid-cols-3 gap-1 sm:flex sm:flex-none">
+        <div className="grid flex-1 grid-cols-4 gap-1 sm:flex sm:flex-none">
           {/* Proxy button with inline dropdown */}
           {(proxyPools || []).length > 0 && (
             <div className="relative" ref={proxyDropdownRef}>
@@ -256,6 +256,26 @@ export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst
                 <span className="text-[10px] leading-tight">Auto-ping</span>
               </button>
             </Tooltip>
+          )}
+          {verification && typeof verification.url === "string" && (
+            <button
+              onClick={() => {
+                try {
+                  const parsed = new URL(verification.url);
+                  if (parsed.protocol === "https:" && parsed.hostname === "accounts.google.com") {
+                    window.open(verification.url, "_blank", "noopener,noreferrer");
+                  }
+                } catch {
+                  // invalid url
+                }
+              }}
+              className="flex flex-col items-center rounded px-2 py-1 text-amber-600 hover:bg-amber-500/10 dark:text-amber-400"
+              title="Verify account"
+              aria-label="Verify account"
+            >
+              <span className="material-symbols-outlined text-[18px]">verified_user</span>
+              <span className="text-[10px] leading-tight font-medium">Verify</span>
+            </button>
           )}
           <button onClick={onEdit} className="flex flex-col items-center rounded px-2 py-1 text-text-muted hover:bg-black/5 hover:text-primary dark:hover:bg-white/5">
             <span className="material-symbols-outlined text-[18px]">edit</span>
@@ -314,5 +334,11 @@ ConnectionRow.propTypes = {
     on: PropTypes.bool,
     onToggle: PropTypes.func,
     provider: PropTypes.string,
+  }),
+  verification: PropTypes.shape({
+    url: PropTypes.string,
+    connectionId: PropTypes.string,
+    account: PropTypes.string,
+    createdAt: PropTypes.number,
   }),
 };

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -23,6 +23,7 @@ import EditCompatibleNodeModal from "./EditCompatibleNodeModal";
 import AddCustomModelModal from "./AddCustomModelModal";
 import BulkImportCodexModal from "./BulkImportCodexModal";
 import BulkImportGrokCliModal from "./BulkImportGrokCliModal";
+import { useVerificationStore } from "@/store/verificationStore";
 
 const ONE_BY_ONE_DELAY_MS = 1000;
 
@@ -73,6 +74,8 @@ export default function ProviderDetailPage() {
   const [kiloFreeModels, setKiloFreeModels] = useState([]);
   const [disabledModelIds, setDisabledModelIds] = useState([]);
   const [confirmState, setConfirmState] = useState(null);
+  const verificationsMap = useVerificationStore((state) => state.verifications);
+  const latestVerification = useVerificationStore((state) => state.latestVerification);
   const [showAgRiskModal, setShowAgRiskModal] = useState(false);
   const [oneByOneRunning, setOneByOneRunning] = useState(false);
   const [oneByOneStopping, setOneByOneStopping] = useState(false);
@@ -345,6 +348,7 @@ export default function ProviderDetailPage() {
       setLoading(false);
     }
   }, [providerId, isCompatible]);
+
 
   const handleUpdateNode = async (formData) => {
     try {
@@ -988,6 +992,11 @@ export default function ProviderDetailPage() {
                     console.log("Error updating proxy:", error);
                   }
                 }}
+                verification={
+                  providerId === "antigravity"
+                    ? (verificationsMap[conn.id] || (latestVerification?.connectionId === conn.id ? latestVerification : null))
+                    : null
+                }
                 onEdit={() => {
                   setSelectedConnection(conn);
                   setShowEditModal(true);

--- a/src/app/api/usage/stream/route.js
+++ b/src/app/api/usage/stream/route.js
@@ -14,8 +14,8 @@ export async function GET() {
         try {
           // Push lightweight update immediately so UI reflects changes fast
           if (state.cachedStats) {
-            const { activeRequests, recentRequests, errorProvider } = await getActiveRequests();
-            const quickStats = { ...state.cachedStats, activeRequests, recentRequests, errorProvider };
+            const { activeRequests, recentRequests, errorProvider, antigravityVerification, antigravityVerifications } = await getActiveRequests();
+            const quickStats = { ...state.cachedStats, activeRequests, recentRequests, errorProvider, antigravityVerification, antigravityVerifications };
             controller.enqueue(encoder.encode(`data: ${JSON.stringify(quickStats)}\n\n`));
           }
           // Then do full recalc and update cache
@@ -34,8 +34,8 @@ export async function GET() {
       state.sendPending = async () => {
         if (state.closed || !state.cachedStats) return;
         try {
-          const { activeRequests, recentRequests, errorProvider } = await getActiveRequests();
-          const stats = { ...state.cachedStats, activeRequests, recentRequests, errorProvider };
+          const { activeRequests, recentRequests, errorProvider, antigravityVerification, antigravityVerifications } = await getActiveRequests();
+          const stats = { ...state.cachedStats, activeRequests, recentRequests, errorProvider, antigravityVerification, antigravityVerifications };
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(stats)}\n\n`));
         } catch {
           state.closed = true;

--- a/src/lib/db/index.js
+++ b/src/lib/db/index.js
@@ -60,6 +60,7 @@ export {
   statsEmitter, trackPendingRequest, getActiveRequests,
   saveRequestUsage, getUsageHistory, getUsageStats, getChartData,
   appendRequestLog, getRecentLogs,
+  setAntigravityVerification, clearAntigravityVerification, getAntigravityVerification, getAllAntigravityVerifications,
 } from "./repos/usageRepo.js";
 
 // Request details

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -25,6 +25,7 @@ if (!global._pendingTimers) global._pendingTimers = {};
 if (!global._recentRing) global._recentRing = { items: [], initialized: false };
 if (!global._connectionMapCache) global._connectionMapCache = { map: {}, ts: 0 };
 if (!global._statsEmitTimers) global._statsEmitTimers = { pending: null, update: null };
+if (!global._antigravityVerification) global._antigravityVerification = {};
 
 const pendingRequests = global._pendingRequests;
 const lastErrorProvider = global._lastErrorProvider;
@@ -32,6 +33,7 @@ const pendingTimers = global._pendingTimers;
 const recentRing = global._recentRing;
 const connCache = global._connectionMapCache;
 const statsEmitTimers = global._statsEmitTimers;
+const antigravityVerification = global._antigravityVerification;
 
 export const statsEmitter = global._statsEmitter;
 
@@ -188,9 +190,46 @@ export function trackPendingRequest(model, provider, connectionId, started, erro
     lastErrorProvider.provider = provider.toLowerCase();
     lastErrorProvider.ts = Date.now();
   }
-
-  // [PENDING] console line removed; lifecycle is visible via "▶" and "📊 done" lines
   scheduleStatsEvent("pending");
+}
+export function setAntigravityVerification(verification) {
+  if (!verification || !verification.url) return;
+  try {
+    const parsed = new URL(verification.url);
+    if (parsed.protocol !== "https:" || parsed.hostname !== "accounts.google.com") return;
+  } catch {
+    return;
+  }
+  const connectionId = verification.connectionId || "default";
+  antigravityVerification[connectionId] = {
+    url: verification.url,
+    connectionId: verification.connectionId || undefined,
+    account: verification.account || undefined,
+    createdAt: verification.createdAt || Date.now()
+  };
+  scheduleStatsEvent("update");
+}
+
+export function clearAntigravityVerification(connectionId) {
+  const key = connectionId || "default";
+  if (antigravityVerification[key]) {
+    delete antigravityVerification[key];
+    scheduleStatsEvent("update");
+  }
+}
+
+export function getAllAntigravityVerifications() {
+  return { ...antigravityVerification };
+}
+
+export function getAntigravityVerification(connectionId = null) {
+  if (connectionId) {
+    return antigravityVerification[connectionId] || null;
+  }
+  const entries = Object.values(antigravityVerification);
+  if (!entries.length) return null;
+  // Return the most recent verification challenge
+  return entries.sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0))[0] || null;
 }
 
 export async function getActiveRequests() {
@@ -235,7 +274,15 @@ export async function getActiveRequests() {
     .slice(0, 20);
 
   const errorProvider = (Date.now() - lastErrorProvider.ts < 10000) ? lastErrorProvider.provider : "";
-  return { activeRequests, recentRequests, errorProvider };
+  const verification = getAntigravityVerification();
+  const verifications = getAllAntigravityVerifications();
+  return {
+    activeRequests,
+    recentRequests,
+    errorProvider,
+    antigravityVerification: verification,
+    antigravityVerifications: verifications,
+  };
 }
 
 export async function saveRequestUsage(entry) {
@@ -655,6 +702,8 @@ export async function getUsageStats(period = "all") {
   }
 
   stats.totalRequests = Object.values(stats.byProvider).reduce((sum, p) => sum + (p.requests || 0), 0);
+  stats.antigravityVerification = getAntigravityVerification();
+  stats.antigravityVerifications = getAllAntigravityVerifications();
   return stats;
 }
 

--- a/src/lib/usageDb.js
+++ b/src/lib/usageDb.js
@@ -4,4 +4,5 @@ export {
   saveRequestUsage, getUsageHistory, getUsageStats, getChartData,
   appendRequestLog, getRecentLogs,
   saveRequestDetail, getRequestDetails, getRequestDetailById,
+  setAntigravityVerification, clearAntigravityVerification, getAntigravityVerification, getAllAntigravityVerifications,
 } from "@/lib/db/index.js";

--- a/src/shared/components/layouts/DashboardLayout.js
+++ b/src/shared/components/layouts/DashboardLayout.js
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { usePathname } from "next/navigation";
 import { useNotificationStore } from "@/store/notificationStore";
+import { useVerificationStore, isValidVerificationUrl } from "@/store/verificationStore";
 import Sidebar from "../Sidebar";
 import Header from "../Header";
-
+import Button from "../Button";
 function getToastStyle(type) {
   if (type === "success") {
     return {
@@ -33,13 +34,104 @@ function getToastStyle(type) {
 
 export default function DashboardLayout({ children }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const verificationData = useVerificationStore((state) => state.latestVerification);
+  const setFromPayload = useVerificationStore((state) => state.setFromPayload);
+  const [dismissedKey, setDismissedKey] = useState(null);
   const pathname = usePathname();
   const notifications = useNotificationStore((state) => state.notifications);
   const removeNotification = useNotificationStore((state) => state.removeNotification);
 
+  useEffect(() => {
+    let es;
+    try {
+      es = new EventSource("/api/usage/stream");
+      es.onmessage = (e) => {
+        try {
+          const data = JSON.parse(e.data);
+          setFromPayload(data);
+          if (!data.antigravityVerification && !data.antigravityVerifications) {
+            setDismissedKey(null);
+          }
+        } catch {
+          // ignore json parse error
+        }
+      };
+      es.onerror = () => {
+        // EventSource auto-reconnects
+      };
+    } catch {
+      // EventSource not supported or initialization failed
+    }
+
+    return () => {
+      if (es) {
+        es.close();
+      }
+    };
+  }, []);
+
+  const currentVerificationKey = verificationData
+    ? `${verificationData.connectionId || ""}-${verificationData.url}`
+    : null;
+  const showVerification =
+    verificationData &&
+    isValidVerificationUrl(verificationData.url) &&
+    dismissedKey !== currentVerificationKey;
+
+  const handleOpenVerification = () => {
+    if (verificationData && isValidVerificationUrl(verificationData.url)) {
+      window.open(verificationData.url, "_blank", "noopener,noreferrer");
+    }
+  };
   return (
     <div className="flex h-screen w-full overflow-hidden bg-bg">
       <div className="fixed top-4 right-4 z-[80] flex w-[min(92vw,380px)] flex-col gap-2">
+        {showVerification && (
+          <div
+            role="alert"
+            aria-live="assertive"
+            className="rounded-lg border px-3.5 py-3 shadow-lg backdrop-blur-sm border-amber-500/40 bg-amber-500/10 text-amber-900 dark:text-amber-200"
+          >
+            <div className="flex items-start gap-2.5">
+              <span className="material-symbols-outlined text-[20px] leading-5 text-amber-600 dark:text-amber-400 shrink-0">
+                verified_user
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5 mb-1">
+                  <span className="text-xs font-bold uppercase tracking-wider text-amber-700 dark:text-amber-300">
+                    Antigravity
+                  </span>
+                  {verificationData.account ? (
+                    <span className="text-[11px] px-1.5 py-0.2 rounded bg-amber-500/20 text-amber-800 dark:text-amber-200 truncate max-w-[180px]">
+                      {verificationData.account}
+                    </span>
+                  ) : null}
+                </div>
+                <p className="text-xs text-amber-800/90 dark:text-amber-200/90 mb-2.5">
+                  Google account verification required to proceed.
+                </p>
+                <div>
+                  <Button
+                    size="sm"
+                    variant="primary"
+                    className="w-full text-xs font-medium !bg-amber-600 hover:!bg-amber-700 !text-white"
+                    onClick={handleOpenVerification}
+                  >
+                    Verify account
+                  </Button>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setDismissedKey(currentVerificationKey)}
+                className="text-amber-800/70 hover:text-amber-900 dark:text-amber-200/70 dark:hover:text-amber-100 p-0.5"
+                aria-label="Dismiss verification alert"
+              >
+                <span className="material-symbols-outlined text-[16px]">close</span>
+              </button>
+            </div>
+          </div>
+        )}
         {notifications.map((n) => {
           const style = getToastStyle(n.type);
           return (

--- a/src/sse/services/antigravityQuota.js
+++ b/src/sse/services/antigravityQuota.js
@@ -63,7 +63,7 @@ async function _doRefresh(connectionId, accessToken, providerSpecificData, now) 
       strictProxy: proxyCfg.strictProxy === true,
     };
 
-    const usage = await getAntigravityUsage(accessToken, providerSpecificData, proxyOptions);
+    const usage = await getAntigravityUsage(accessToken, providerSpecificData, proxyOptions, connectionId);
     // 401/403 usage responses can contain an empty quotas object plus message.
     // Preserve known cache instead of replacing it with an upstream error response.
     if (!usage?.quotas || usage.message) return null;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,4 +3,5 @@ export { default as useThemeStore } from "./themeStore";
 export { default as useUserStore } from "./userStore";
 export { default as useProviderStore } from "./providerStore";
 export { useNotificationStore } from "./notificationStore";
+export { useVerificationStore, isValidVerificationUrl } from "./verificationStore";
 

--- a/src/store/verificationStore.js
+++ b/src/store/verificationStore.js
@@ -1,0 +1,68 @@
+"use client";
+
+import { create } from "zustand";
+
+export function isValidVerificationUrl(rawUrl) {
+  if (typeof rawUrl !== "string") return false;
+  try {
+    const parsed = new URL(rawUrl);
+    return (
+      parsed.protocol === "https:" &&
+      parsed.hostname === "accounts.google.com"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function sanitizeRecord(rec) {
+  if (!rec || typeof rec.url !== "string" || !isValidVerificationUrl(rec.url)) {
+    return null;
+  }
+  return rec;
+}
+
+export const useVerificationStore = create((set, get) => ({
+  latestVerification: null,
+  verifications: {},
+
+  setFromPayload: (data) => {
+    if (!data || typeof data !== "object") return;
+
+    let latest = null;
+    if ("antigravityVerification" in data) {
+      latest = sanitizeRecord(data.antigravityVerification);
+    }
+
+    const map = {};
+    if (data.antigravityVerifications && typeof data.antigravityVerifications === "object") {
+      for (const [key, val] of Object.entries(data.antigravityVerifications)) {
+        const sanitized = sanitizeRecord(val);
+        if (sanitized) {
+          map[key] = sanitized;
+        }
+      }
+    } else if (latest) {
+      const k = latest.connectionId || "default";
+      map[k] = latest;
+    }
+
+    set({
+      latestVerification: latest,
+      verifications: map,
+    });
+  },
+
+  getForConnection: (connectionId) => {
+    const { verifications, latestVerification } = get();
+    if (connectionId && verifications[connectionId]) {
+      return verifications[connectionId];
+    }
+    if (latestVerification && latestVerification.connectionId === connectionId) {
+      return latestVerification;
+    }
+    return null;
+  },
+
+  clearAll: () => set({ latestVerification: null, verifications: {} }),
+}));

--- a/tests/unit/antigravity-quota-routing.test.js
+++ b/tests/unit/antigravity-quota-routing.test.js
@@ -140,7 +140,7 @@ describe("Antigravity quota-aware routing", () => {
 
     expect(mocks.getAntigravityUsage).toHaveBeenCalledWith("token", {}, expect.objectContaining({
       strictProxy: true,
-    }));
+    }), "ag-strict-proxy");
   });
 
   it("keeps known cache when quota endpoint returns an error payload", async () => {

--- a/tests/unit/antigravity-verification-flow.test.js
+++ b/tests/unit/antigravity-verification-flow.test.js
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { AntigravityExecutor } from "../../open-sse/executors/antigravity.js";
+import { parseUpstreamError, createErrorResult } from "../../open-sse/utils/error.js";
+import {
+  setAntigravityVerification,
+  clearAntigravityVerification,
+  getAntigravityVerification,
+  getAllAntigravityVerifications,
+  getActiveRequests,
+} from "../../src/lib/db/repos/usageRepo.js";
+
+describe("Antigravity Verification Parser and Flow", () => {
+  const executor = new AntigravityExecutor();
+
+  beforeEach(() => {
+    clearAntigravityVerification("conn_1");
+    clearAntigravityVerification("conn_2");
+    clearAntigravityVerification("default");
+  });
+
+  it("extracts verification_url from ErrorInfo metadata", async () => {
+    const rawBody = JSON.stringify({
+      error: {
+        code: 403,
+        message: "PERMISSION_DENIED: Validation required to continue using the service",
+        status: "PERMISSION_DENIED",
+        details: [
+          {
+            "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+            reason: "VALIDATION_REQUIRED",
+            domain: "googleapis.com",
+            metadata: {
+              validation_url: "https://accounts.google.com/signin/continue?sarp=1&continue=https://console.cloud.google.com"
+            }
+          },
+          {
+            "@type": "type.googleapis.com/google.rpc.Help",
+            links: [
+              {
+                description: "Google support",
+                url: "https://support.google.com/a/answer/123456"
+              }
+            ]
+          }
+        ]
+      }
+    });
+
+    const mockResponse = {
+      status: 403,
+      text: async () => rawBody
+    };
+
+    const parsed = await parseUpstreamError(mockResponse, executor);
+    expect(parsed.statusCode).toBe(403);
+    expect(parsed.verificationUrl).toBe("https://accounts.google.com/signin/continue?sarp=1&continue=https://console.cloud.google.com");
+
+    const errorResult = createErrorResult(parsed.statusCode, parsed.message, parsed.resetsAtMs, parsed.verificationUrl);
+    expect(errorResult.verificationUrl).toBe("https://accounts.google.com/signin/continue?sarp=1&continue=https://console.cloud.google.com");
+  });
+
+  it("extracts Help link if ErrorInfo metadata is absent but validation reason present", async () => {
+    const rawBody = JSON.stringify({
+      error: {
+        code: 403,
+        message: "Validation required for account",
+        status: "PERMISSION_DENIED",
+        details: [
+          {
+            "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+            reason: "VALIDATION_REQUIRED",
+            domain: "googleapis.com"
+          },
+          {
+            "@type": "type.googleapis.com/google.rpc.Help",
+            links: [
+              {
+                description: "Continue sign in",
+                url: "https://accounts.google.com/signin/continue?flowName=GlifWebSignIn"
+              }
+            ]
+          }
+        ]
+      }
+    });
+
+    const mockResponse = {
+      status: 403,
+      text: async () => rawBody
+    };
+
+    const parsed = await parseUpstreamError(mockResponse, executor);
+    expect(parsed.verificationUrl).toBe("https://accounts.google.com/signin/continue?flowName=GlifWebSignIn");
+  });
+
+  it("falls back to bounded regex only when validation wording is present", async () => {
+    const rawBody = JSON.stringify({
+      error: {
+        code: 403,
+        message: "Validation required: visit https://accounts.google.com/signin/continue?flowEntry=ServiceLogin to unlock",
+        status: "PERMISSION_DENIED"
+      }
+    });
+
+    const mockResponse = {
+      status: 403,
+      text: async () => rawBody
+    };
+
+    const parsed = await parseUpstreamError(mockResponse, executor);
+    expect(parsed.verificationUrl).toBe("https://accounts.google.com/signin/continue?flowEntry=ServiceLogin");
+  });
+
+  it("rejects non-Google or malformed URLs and does not extract support links as verification", async () => {
+    const rawBody = JSON.stringify({
+      error: {
+        code: 403,
+        message: "Validation required",
+        status: "PERMISSION_DENIED",
+        details: [
+          {
+            reason: "VALIDATION_REQUIRED",
+            metadata: {
+              validation_url: "http://malicious.com/signin/continue"
+            }
+          },
+          {
+            "@type": "type.googleapis.com/google.rpc.Help",
+            links: [
+              {
+                description: "Support URL",
+                url: "https://support.google.com/cloud/answer/123"
+              }
+            ]
+          }
+        ]
+      }
+    });
+
+    const mockResponse = {
+      status: 403,
+      text: async () => rawBody
+    };
+
+    const parsed = await parseUpstreamError(mockResponse, executor);
+    expect(parsed.verificationUrl).toBeUndefined();
+  });
+
+  it("returns null/undefined verification for ordinary 403/429 quota errors", async () => {
+    const rawBody = JSON.stringify({
+      error: {
+        code: 429,
+        message: "Resource has been exhausted (e.g. check quota)",
+        status: "RESOURCE_EXHAUSTED"
+      }
+    });
+
+    const mockResponse = {
+      status: 429,
+      text: async () => rawBody
+    };
+
+    const parsed = await parseUpstreamError(mockResponse, executor);
+    expect(parsed.verificationUrl).toBeUndefined();
+  });
+
+  it("tracks in-memory verification state per connectionId and clears on matching connection", async () => {
+    setAntigravityVerification({
+      url: "https://accounts.google.com/signin/continue?id=1",
+      connectionId: "conn_1",
+      account: "user1@example.com"
+    });
+
+    setAntigravityVerification({
+      url: "https://accounts.google.com/signin/continue?id=2",
+      connectionId: "conn_2",
+      account: "user2@example.com"
+    });
+
+    expect(getAntigravityVerification("conn_1")?.url).toBe("https://accounts.google.com/signin/continue?id=1");
+    expect(getAntigravityVerification("conn_2")?.url).toBe("https://accounts.google.com/signin/continue?id=2");
+
+    const all = getAllAntigravityVerifications();
+    expect(all["conn_1"]?.url).toBe("https://accounts.google.com/signin/continue?id=1");
+    expect(all["conn_2"]?.url).toBe("https://accounts.google.com/signin/continue?id=2");
+
+    const active = await getActiveRequests();
+    expect(active.antigravityVerifications["conn_1"]?.url).toBe("https://accounts.google.com/signin/continue?id=1");
+    expect(active.antigravityVerifications["conn_2"]?.url).toBe("https://accounts.google.com/signin/continue?id=2");
+
+    clearAntigravityVerification("conn_1");
+    expect(getAntigravityVerification("conn_1")).toBeNull();
+    expect(getAntigravityVerification("conn_2")?.url).toBe("https://accounts.google.com/signin/continue?id=2");
+    expect(getAllAntigravityVerifications()["conn_1"]).toBeUndefined();
+    expect(getAllAntigravityVerifications()["conn_2"]?.url).toBe("https://accounts.google.com/signin/continue?id=2");
+
+    clearAntigravityVerification("conn_2");
+    expect(getAntigravityVerification()).toBeNull();
+    expect(Object.keys(getAllAntigravityVerifications()).length).toBe(0);
+  });
+
+  it("ignores setAntigravityVerification with non-https or non-accounts.google.com URLs", () => {
+    setAntigravityVerification({
+      url: "https://evil.com/signin/continue",
+      connectionId: "conn_evil"
+    });
+    expect(getAntigravityVerification("conn_evil")).toBeNull();
+
+    setAntigravityVerification({
+      url: "http://accounts.google.com/signin/continue",
+      connectionId: "conn_http"
+    });
+    expect(getAntigravityVerification("conn_http")).toBeNull();
+  });
+
+  it("does not let invalid first candidate suppress subsequent valid Google verification URL", async () => {
+    const rawBody = JSON.stringify({
+      error: {
+        code: 403,
+        message: "Validation required for account",
+        status: "PERMISSION_DENIED",
+        details: [
+          {
+            "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+            reason: "VALIDATION_REQUIRED",
+            metadata: {
+              validation_url: "https://support.google.com/cloud/answer/123"
+            }
+          },
+          {
+            "@type": "type.googleapis.com/google.rpc.Help",
+            links: [
+              {
+                description: "Help invalid",
+                url: "http://accounts.google.com/signin/continue?id=insecure"
+              },
+              {
+                description: "Continue sign in",
+                url: "https://accounts.google.com/signin/continue?flowName=GlifWebSignIn"
+              }
+            ]
+          }
+        ]
+      }
+    });
+
+    const mockResponse = {
+      status: 403,
+      text: async () => rawBody
+    };
+
+    const parsed = await parseUpstreamError(mockResponse, executor);
+    expect(parsed.verificationUrl).toBe("https://accounts.google.com/signin/continue?flowName=GlifWebSignIn");
+  });
+});

--- a/tests/unit/dashboard-antigravity-verification.test.js
+++ b/tests/unit/dashboard-antigravity-verification.test.js
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { isValidVerificationUrl, useVerificationStore } from "../../src/store/verificationStore.js";
+
+test("DashboardLayout antigravity verification URL validation", async (t) => {
+  await t.test("allows valid accounts.google.com URL", () => {
+    assert.equal(
+      isValidVerificationUrl("https://accounts.google.com/signin/continue?sarp=1&continue=https://console.cloud.google.com"),
+      true
+    );
+  });
+
+  await t.test("rejects subdomain of accounts.google.com", () => {
+    assert.equal(
+      isValidVerificationUrl("https://sub.accounts.google.com/signin/continue"),
+      false
+    );
+  });
+
+  await t.test("rejects http url", () => {
+    assert.equal(
+      isValidVerificationUrl("http://accounts.google.com/signin/continue"),
+      false
+    );
+  });
+
+  await t.test("rejects untrusted domains", () => {
+    assert.equal(isValidVerificationUrl("https://evil.com/signin"), false);
+    assert.equal(isValidVerificationUrl("javascript:alert(1)"), false);
+    assert.equal(isValidVerificationUrl("https://accounts.google.com.evil.com/signin"), false);
+    assert.equal(isValidVerificationUrl(null), false);
+    assert.equal(isValidVerificationUrl(undefined), false);
+  });
+});
+
+test("verificationStore state mapping and connection lookup", async (t) => {
+  await t.test("parses single latest and multiple per-connection verifications", () => {
+    useVerificationStore.getState().clearAll();
+
+    useVerificationStore.getState().setFromPayload({
+      antigravityVerification: {
+        url: "https://accounts.google.com/v1",
+        connectionId: "conn-1",
+        account: "acc1@gmail.com",
+      },
+      antigravityVerifications: {
+        "conn-1": {
+          url: "https://accounts.google.com/v1",
+          connectionId: "conn-1",
+          account: "acc1@gmail.com",
+        },
+        "conn-2": {
+          url: "https://accounts.google.com/v2",
+          connectionId: "conn-2",
+          account: "acc2@gmail.com",
+        },
+        "conn-bad": {
+          url: "https://evil.com/v3",
+          connectionId: "conn-bad",
+        }
+      }
+    });
+
+    const rec1 = useVerificationStore.getState().getForConnection("conn-1");
+    assert.equal(rec1?.url, "https://accounts.google.com/v1");
+    assert.equal(rec1?.account, "acc1@gmail.com");
+
+    const rec2 = useVerificationStore.getState().getForConnection("conn-2");
+    assert.equal(rec2?.url, "https://accounts.google.com/v2");
+    assert.equal(rec2?.account, "acc2@gmail.com");
+
+    const recBad = useVerificationStore.getState().getForConnection("conn-bad");
+    assert.equal(recBad, null);
+
+    const recUnset = useVerificationStore.getState().getForConnection("conn-unset");
+    assert.equal(recUnset, null);
+  });
+});

--- a/tests/unit/project-id-verification.test.js
+++ b/tests/unit/project-id-verification.test.js
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  getProjectIdForConnection,
+  invalidateProjectId,
+  extractVerificationUrl,
+} from "../../open-sse/services/projectId.js";
+import {
+  getAntigravityVerification,
+  clearAntigravityVerification,
+} from "../../src/lib/db/repos/usageRepo.js";
+
+describe("ProjectId Antigravity Verification Extraction", () => {
+  beforeEach(() => {
+    clearAntigravityVerification("conn_ag_1");
+    clearAntigravityVerification("conn_ag_2");
+    clearAntigravityVerification("conn_cli_1");
+    clearAntigravityVerification("default");
+    invalidateProjectId("conn_ag_1");
+    invalidateProjectId("conn_ag_2");
+    invalidateProjectId("conn_cli_1");
+    vi.restoreAllMocks();
+  });
+
+  it("extracts validationUrl from successful loadCodeAssist ineligibleTiers", () => {
+    const data = {
+      ineligibleTiers: [
+        {
+          id: "standard-tier",
+          validationErrorMessage: "Validation required to use standard tier",
+          validationUrl: "https://accounts.google.com/signin/continue?sarp=1&continue=https://console.cloud.google.com"
+        }
+      ]
+    };
+
+    const url = extractVerificationUrl(data);
+    expect(url).toBe("https://accounts.google.com/signin/continue?sarp=1&continue=https://console.cloud.google.com");
+  });
+
+  it("extracts appeal_url from non-OK error response details", () => {
+    const errorBody = {
+      error: {
+        code: 403,
+        message: "PERMISSION_DENIED: User validation required",
+        status: "PERMISSION_DENIED",
+        details: [
+          {
+            "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+            reason: "VALIDATION_REQUIRED",
+            metadata: {
+              appeal_url: "https://accounts.google.com/signin/continue?flowName=GlifWebSignIn"
+            }
+          }
+        ]
+      }
+    };
+
+    const url = extractVerificationUrl(errorBody);
+    expect(url).toBe("https://accounts.google.com/signin/continue?flowName=GlifWebSignIn");
+  });
+
+  it("ignores non-HTTPS or non-accounts.google.com support URLs", () => {
+    const supportPayload = {
+      ineligibleTiers: [
+        {
+          id: "standard-tier",
+          validationErrorMessage: "Need help",
+          validationUrl: "https://support.google.com/a/answer/123456"
+        }
+      ],
+      error: {
+        message: "validation required",
+        details: [
+          {
+            "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+            reason: "VALIDATION_REQUIRED",
+            metadata: {
+              validation_url: "http://accounts.google.com/signin/continue?sarp=1"
+            }
+          }
+        ]
+      }
+    };
+
+    const url = extractVerificationUrl(supportPayload);
+    expect(url).toBeNull();
+  });
+
+  it("publishes verification to usageDb when getProjectIdForConnection hits ineligible tier", async () => {
+    const mockPayload = {
+      ineligibleTiers: [
+        {
+          validationErrorMessage: "Validation required",
+          validationUrl: "https://accounts.google.com/signin/continue?id=ag123"
+        }
+      ]
+    };
+
+    globalThis.fetch = vi.fn().mockImplementation(async (url) => {
+      if (typeof url === "string" && url.includes("loadCodeAssist")) {
+        return new Response(JSON.stringify(mockPayload), {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        });
+      }
+      if (typeof url === "string" && url.includes("onboardUser")) {
+        return new Response(JSON.stringify({ done: true, response: { cloudaicompanionProject: { id: "test-proj" } } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        });
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    const pid = await getProjectIdForConnection("conn_ag_1", "fake-token", "antigravity");
+    expect(pid).toBe("test-proj");
+
+    const verification = getAntigravityVerification("conn_ag_1");
+    expect(verification).not.toBeNull();
+    expect(verification.url).toBe("https://accounts.google.com/signin/continue?id=ag123");
+    expect(verification.connectionId).toBe("conn_ag_1");
+  });
+
+  it("publishes verification to usageDb when loadCodeAssist returns 403 with error validation URL without leaking body/url in logs", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mockError = {
+      error: {
+        code: 403,
+        message: "Validation required",
+        details: [
+          {
+            reason: "VALIDATION_REQUIRED",
+            metadata: {
+              validation_url: "https://accounts.google.com/signin/continue?sarp=403"
+            }
+          }
+        ]
+      }
+    };
+
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(mockError), {
+        status: 403,
+        headers: { "Content-Type": "application/json" }
+      })
+    );
+
+    const pid = await getProjectIdForConnection("conn_ag_2", "fake-token", "antigravity");
+    expect(pid).toBeNull();
+
+    const verification = getAntigravityVerification("conn_ag_2");
+    expect(verification).not.toBeNull();
+    expect(verification.url).toBe("https://accounts.google.com/signin/continue?sarp=403");
+    expect(verification.connectionId).toBe("conn_ag_2");
+
+    const loggedWarnings = warnSpy.mock.calls.map(call => call.join(" ")).join("\n");
+    expect(loggedWarnings).not.toContain("accounts.google.com/signin/continue");
+    expect(loggedWarnings).not.toContain("VALIDATION_REQUIRED");
+    expect(loggedWarnings).toContain("loadCodeAssist failed: HTTP 403");
+  });
+
+  it("does not publish verification for non-antigravity providers", async () => {
+    const mockPayload = {
+      ineligibleTiers: [
+        {
+          validationErrorMessage: "Validation required",
+          validationUrl: "https://accounts.google.com/signin/continue?id=gemini123"
+        }
+      ]
+    };
+
+    globalThis.fetch = vi.fn().mockImplementation(async (url) => {
+      if (typeof url === "string" && url.includes("loadCodeAssist")) {
+        return new Response(JSON.stringify(mockPayload), {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        });
+      }
+      if (typeof url === "string" && url.includes("onboardUser")) {
+        return new Response(JSON.stringify({ done: true, response: { cloudaicompanionProject: { id: "test-proj" } } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        });
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    await getProjectIdForConnection("conn_cli_1", "fake-token", "gemini-cli");
+    const verification = getAntigravityVerification("conn_cli_1");
+    expect(verification).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- preserve Antigravity validation responses through retry handling
- extract `VALIDATION_REQUIRED` verification URLs from project, quota, and model responses
- expose per-connection verification state through usage SSE
- add an accessible Verify button beside Edit on Antigravity provider rows
- accept only HTTPS `accounts.google.com` verification URLs

## Verification

- Fresh upstream base: `v0.5.59` (`90b52e0`)
- Build passed on Termux with SQLite WASM fallback
- Backend focused tests: 22/22
- UI tests: 7/7
- Syntax checks passed
- Live probe with `VALIDATION_REQUIRED` produced verification state for the target Antigravity connection