### PR TITLE
Fix: implement tool name compression to handle length limits in tool…

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -9,6 +9,7 @@ import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
+import { decloakOpenAIChunk } from "../../utils/toolCompressor.js";
 import { ROLE, RESPONSES_ITEM } from "../../translator/schema/index.js";
 
 function parseToolArguments(value) {
@@ -315,6 +316,8 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
 
   // Decloak tool_use names once on raw Claude body, before any translation (INPUT side)
   responseBody = decloakToolNames(responseBody, toolNameMap);
+  // Also decloak OpenAI format if target was OpenAI
+  responseBody = decloakOpenAIChunk(responseBody, toolNameMap);
 
   const usage = extractUsageFromResponse(responseBody);
   appendLog({ tokens: usage, status: "200 OK" });

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -2,6 +2,7 @@ import { FORMATS } from "./formats.js";
 import { ensureToolCallIds, fixMissingToolResponses } from "./concerns/toolCall.js";
 import { prepareClaudeRequest } from "./formats/claude.js";
 import { cloakClaudeTools, decloakStreamChunk } from "../utils/claudeCloaking.js";
+import { compressToolNames, decloakOpenAIChunk } from "../utils/toolCompressor.js";
 import { filterToOpenAIFormat } from "./formats/openai.js";
 import { normalizeThinkingConfig } from "../services/provider.js";
 import { applyThinking, captureThinking } from "./concerns/thinkingUnified.js";
@@ -52,6 +53,13 @@ function stripContentTypes(body, stripList = []) {
 export function translateRequest(sourceFormat, targetFormat, model, body, stream = true, credentials = null, provider = null, reqLogger = null, stripList = [], connectionId = null, clientTool = null) {
   ensureInitialized();
   let result = body;
+
+  // Compress overly long tool names globally
+  const { body: compressedBody, toolNameMap } = compressToolNames(sourceFormat, result);
+  result = compressedBody;
+  if (toolNameMap) {
+    result._toolNameMap = toolNameMap;
+  }
 
   // Strip explicit content types (opt-in via strip[] in PROVIDER_MODELS entry)
   stripContentTypes(result, stripList);
@@ -138,10 +146,19 @@ export function translateRequest(sourceFormat, targetFormat, model, body, stream
   if (PROVIDERS[provider]?.quirks?.cloakToolsOnOAuth) {
     const apiKey = credentials?.accessToken || credentials?.apiKey || null;
     if (apiKey?.includes("sk-ant-oat")) {
-      const { body: cloakedBody, toolNameMap } = cloakClaudeTools(result);
+      const { body: cloakedBody, toolNameMap: cloakMap } = cloakClaudeTools(result);
       result = cloakedBody;
-      if (toolNameMap?.size > 0) {
-        result._toolNameMap = toolNameMap;
+      if (cloakMap?.size > 0) {
+        if (result._toolNameMap) {
+          const mergedMap = new Map(result._toolNameMap);
+          for (const [suffixed, originalOrShortened] of cloakMap) {
+            const trueOriginal = result._toolNameMap.get(originalOrShortened) || originalOrShortened;
+            mergedMap.set(suffixed, trueOriginal);
+          }
+          result._toolNameMap = mergedMap;
+        } else {
+          result._toolNameMap = cloakMap;
+        }
       }
     }
   }
@@ -166,7 +183,12 @@ export function translateResponse(targetFormat, sourceFormat, chunk, state) {
   // even when no format conversion is needed, so streamed tool_use blocks must
   // be decloaked here or the client sees an unknown ("_ide"-suffixed) tool.
   if (sourceFormat === targetFormat) {
-    return [decloakStreamChunk(chunk, state?.toolNameMap)];
+    if (sourceFormat === FORMATS.CLAUDE) {
+      return [decloakStreamChunk(chunk, state?.toolNameMap)];
+    } else if (sourceFormat === FORMATS.OPENAI) {
+      return [decloakOpenAIChunk(chunk, state?.toolNameMap)];
+    }
+    return [chunk];
   }
 
   let results = [chunk];
@@ -213,6 +235,15 @@ export function translateResponse(targetFormat, sourceFormat, chunk, state) {
   // Attach OpenAI intermediate results for logging
   if (openaiResults && sourceFormat !== FORMATS.OPENAI && targetFormat !== FORMATS.OPENAI) {
     results._openaiIntermediate = openaiResults;
+  }
+
+  // Global decloak at the end for cross-format translation if toolNameMap exists
+  if (state?.toolNameMap?.size > 0) {
+    if (sourceFormat === FORMATS.CLAUDE) {
+      results = results.map(r => decloakStreamChunk(r, state.toolNameMap));
+    } else if (sourceFormat === FORMATS.OPENAI) {
+      results = results.map(r => decloakOpenAIChunk(r, state.toolNameMap));
+    }
   }
 
   return results;

--- a/open-sse/utils/toolCompressor.js
+++ b/open-sse/utils/toolCompressor.js
@@ -1,0 +1,107 @@
+import crypto from "crypto";
+
+export function compressToolNames(sourceFormat, body) {
+  const isClaude = sourceFormat === "claude";
+  const isOpenAI = sourceFormat === "openai";
+  
+  if (!isClaude && !isOpenAI) return { body, toolNameMap: null };
+
+  const tools = body.tools;
+  if (!tools || !Array.isArray(tools) || tools.length === 0) return { body, toolNameMap: null };
+
+  const toolNameMap = new Map();
+  let changed = false;
+
+  const getToolName = (t) => isClaude ? t.name : t.function?.name;
+  const setToolName = (t, name) => isClaude ? { ...t, name } : { ...t, function: { ...t.function, name } };
+
+  const compressName = (name) => {
+    if (!name || name.length <= 64) return name;
+    const hash = crypto.createHash("md5").update(name).digest("hex").substring(0, 8);
+    const shortName = name.substring(0, 55) + "_" + hash;
+    return shortName;
+  };
+
+  const newTools = tools.map(tool => {
+    const originalName = getToolName(tool);
+    if (!originalName) return tool;
+    const shortName = compressName(originalName);
+    if (shortName !== originalName) {
+      toolNameMap.set(shortName, originalName);
+      changed = true;
+      return setToolName(tool, shortName);
+    }
+    return tool;
+  });
+
+  if (!changed) return { body, toolNameMap: null };
+
+  const newMessages = body.messages?.map(msg => {
+    if (isClaude) {
+      if (!Array.isArray(msg.content)) return msg;
+      const newContent = msg.content.map(block => {
+        if (block.type === "tool_use" && toolNameMap.has(block.name)) {
+          return { ...block, name: toolNameMap.get(block.name) };
+        }
+        return block;
+      });
+      return { ...msg, content: newContent };
+    } else if (isOpenAI) {
+      if (msg.tool_calls && Array.isArray(msg.tool_calls)) {
+        const newToolCalls = msg.tool_calls.map(tc => {
+          if (tc.type === "function" && tc.function && toolNameMap.has(tc.function.name)) {
+            return { ...tc, function: { ...tc.function, name: toolNameMap.get(tc.function.name) } };
+          }
+          return tc;
+        });
+        return { ...msg, tool_calls: newToolCalls };
+      }
+      return msg;
+    }
+    return msg;
+  });
+
+  let newToolChoice = body.tool_choice;
+  if (isClaude && body.tool_choice?.type === "tool" && toolNameMap.has(body.tool_choice.name)) {
+    newToolChoice = { ...body.tool_choice, name: toolNameMap.get(body.tool_choice.name) };
+  } else if (isOpenAI && body.tool_choice?.type === "function" && toolNameMap.has(body.tool_choice.function?.name)) {
+    newToolChoice = { ...body.tool_choice, function: { ...body.tool_choice.function, name: toolNameMap.get(body.tool_choice.function.name) } };
+  }
+
+  const newBody = { ...body, tools: newTools };
+  if (newMessages) newBody.messages = newMessages;
+  if (newToolChoice) newBody.tool_choice = newToolChoice;
+
+  return { body: newBody, toolNameMap };
+}
+
+export function decloakOpenAIChunk(chunk, toolNameMap) {
+  if (!toolNameMap?.size || !chunk || !chunk.choices) return chunk;
+  
+  let changed = false;
+  const newChoices = chunk.choices.map(choice => {
+    if (choice.delta?.tool_calls) {
+      const newToolCalls = choice.delta.tool_calls.map(tc => {
+        if (tc.function?.name && toolNameMap.has(tc.function.name)) {
+          changed = true;
+          return { ...tc, function: { ...tc.function, name: toolNameMap.get(tc.function.name) } };
+        }
+        return tc;
+      });
+      return { ...choice, delta: { ...choice.delta, tool_calls: newToolCalls } };
+    } else if (choice.message?.tool_calls) {
+      const newToolCalls = choice.message.tool_calls.map(tc => {
+        if (tc.function?.name && toolNameMap.has(tc.function.name)) {
+          changed = true;
+          return { ...tc, function: { ...tc.function, name: toolNameMap.get(tc.function.name) } };
+        }
+        return tc;
+      });
+      return { ...choice, message: { ...choice.message, tool_calls: newToolCalls } };
+    }
+    return choice;
+  });
+
+  if (!changed) return chunk;
+  return { ...chunk, choices: newChoices };
+}


### PR DESCRIPTION
### Description
Fixes #3622

**Bug:** 
When routing Claude Code requests containing MCP tools with very long names through Gemini/Vertex or OpenAI-compatible (OpenCode) models, the API rejects the request due to a 64-character limit on function names. The previous truncation behavior (`.substring(0, 64)`) caused identically-prefixed tool names to collide, throwing `400 INVALID_ARGUMENT: Duplicate function declaration found`.

**Fix:**
- Added `compressToolNames()` to intercept incoming requests before translation. 
- It safely compresses tool names exceeding 64 characters by keeping the first 55 characters and appending a unique 8-character MD5 hash (e.g. `mcp_plugin_foo..._1a2b3c4d`), guaranteeing uniqueness and compliance with API limits.
- The original long names are preserved in a request-scoped `toolNameMap`.
- Updated both streaming (`translateResponse`) and non-streaming (`nonStreamingHandler.js`) output pipelines to seamlessly restore the shortened names back to their original long names when passing the response back to the client.

### Changes
- **`open-sse/utils/toolCompressor.js`**: Created new tool compression and OpenAI decloaking logic.
- **`open-sse/translator/index.js`**: Integrated `compressToolNames` globally in `translateRequest` and mapped original names back in `translateResponse`.
- **`open-sse/handlers/chatCore/nonStreamingHandler.js`**: Added OpenAI chunk decloaking for non-streaming formats.
