### PR TITLE
fix(model-test): allow internal auth without API keys

### DIFF
--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -1,23 +1,8 @@
 import { NextResponse } from "next/server";
 import { getSettings, validateApiKey } from "@/lib/localDb";
-import { getConsistentMachineId } from "@/shared/utils/machineId";
 import { verifyDashboardAuthToken } from "@/lib/auth/dashboardSession";
+import { hasValidCliToken } from "@/lib/auth/internalCliToken";
 import { hasTrustedPeerHeaders } from "@/lib/auth/trustedPeer";
-
-const CLI_TOKEN_HEADER = "x-9r-cli-token";
-const CLI_TOKEN_SALT = "9r-cli-auth";
-
-let cachedCliToken = null;
-async function getCliToken() {
-  if (!cachedCliToken) cachedCliToken = await getConsistentMachineId(CLI_TOKEN_SALT);
-  return cachedCliToken;
-}
-
-async function hasValidCliToken(request) {
-  const token = request.headers.get(CLI_TOKEN_HEADER);
-  if (!token) return false;
-  return token === await getCliToken();
-}
 
 // Public API paths — no auth required (LLM API has its own key auth inside handler).
 const PUBLIC_API_PATHS = [

--- a/src/lib/auth/internalCliToken.js
+++ b/src/lib/auth/internalCliToken.js
@@ -1,0 +1,17 @@
+import { getConsistentMachineId } from "@/shared/utils/machineId";
+
+const CLI_TOKEN_HEADER = "x-9r-cli-token";
+const CLI_TOKEN_SALT = "9r-cli-auth";
+
+let cachedCliToken = null;
+
+async function getCliToken() {
+  cachedCliToken ||= await getConsistentMachineId(CLI_TOKEN_SALT);
+  return cachedCliToken;
+}
+
+export async function hasValidCliToken(request) {
+  const suppliedToken = request.headers.get(CLI_TOKEN_HEADER);
+  if (!suppliedToken) return false;
+  return suppliedToken === await getCliToken();
+}

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -5,7 +5,7 @@ import {
   markAccountUnavailable,
   clearAccountError,
   extractApiKey,
-  isValidApiKey,
+  isApiRequestAuthorized,
 } from "../services/auth.js";
 import { handleAntigravityQuotaError } from "../services/antigravityQuota.js";
 import { getSettings } from "@/lib/localDb";
@@ -64,14 +64,11 @@ export async function handleChat(request, clientRawRequest = null) {
   // Enforce API key if enabled in settings
   const settings = await getSettings();
   if (settings.requireApiKey) {
-    if (!apiKey) {
-      log.warn("AUTH", "Missing API key (requireApiKey=true)");
-      return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
-    }
-    const valid = await isValidApiKey(apiKey);
-    if (!valid) {
-      log.warn("AUTH", "Invalid API key (requireApiKey=true)");
-      return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+    const authorized = await isApiRequestAuthorized(request);
+    if (!authorized) {
+      const message = apiKey ? "Invalid API key" : "Missing API key";
+      log.warn("AUTH", `${message} (requireApiKey=true)`);
+      return errorResponse(HTTP_STATUS.UNAUTHORIZED, message);
     }
   }
 

--- a/src/sse/handlers/embeddings.js
+++ b/src/sse/handlers/embeddings.js
@@ -3,7 +3,7 @@ import {
   markAccountUnavailable,
   clearAccountError,
   extractApiKey,
-  isValidApiKey,
+  isApiRequestAuthorized,
 } from "../services/auth.js";
 import { getSettings } from "@/lib/localDb";
 import { getModelInfo } from "../services/model.js";
@@ -54,14 +54,11 @@ export async function handleEmbeddings(request) {
   // Enforce API key if enabled in settings
   const settings = await getSettings();
   if (settings.requireApiKey) {
-    if (!apiKey) {
-      log.warn("AUTH", "Missing API key (requireApiKey=true)");
-      return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
-    }
-    const valid = await isValidApiKey(apiKey);
-    if (!valid) {
-      log.warn("AUTH", "Invalid API key (requireApiKey=true)");
-      return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+    const authorized = await isApiRequestAuthorized(request);
+    if (!authorized) {
+      const message = apiKey ? "Invalid API key" : "Missing API key";
+      log.warn("AUTH", `${message} (requireApiKey=true)`);
+      return errorResponse(HTTP_STATUS.UNAUTHORIZED, message);
     }
   }
 

--- a/src/sse/handlers/imageGeneration.js
+++ b/src/sse/handlers/imageGeneration.js
@@ -3,7 +3,7 @@ import {
   markAccountUnavailable,
   clearAccountError,
   extractApiKey,
-  isValidApiKey,
+  isApiRequestAuthorized,
 } from "../services/auth.js";
 import { getSettings } from "@/lib/localDb";
 import { getModelInfo, getComboModels } from "../services/model.js";
@@ -38,9 +38,8 @@ export async function handleImageGeneration(request) {
   const apiKey = extractApiKey(request);
   const settings = await getSettings();
   if (settings.requireApiKey) {
-    if (!apiKey) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
-    const valid = await isValidApiKey(apiKey);
-    if (!valid) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+    const authorized = await isApiRequestAuthorized(request);
+    if (!authorized) return errorResponse(HTTP_STATUS.UNAUTHORIZED, apiKey ? "Invalid API key" : "Missing API key");
   }
 
   if (!modelStr) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");

--- a/src/sse/handlers/stt.js
+++ b/src/sse/handlers/stt.js
@@ -1,5 +1,5 @@
 import {
-  extractApiKey, isValidApiKey,
+  extractApiKey, isApiRequestAuthorized,
   getProviderCredentials, markAccountUnavailable,
 } from "../services/auth.js";
 import { getSettings } from "@/lib/localDb";
@@ -31,9 +31,8 @@ export async function handleStt(request) {
   const settings = await getSettings();
   if (settings.requireApiKey) {
     const apiKey = extractApiKey(request);
-    if (!apiKey) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
-    const valid = await isValidApiKey(apiKey);
-    if (!valid) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+    const authorized = await isApiRequestAuthorized(request);
+    if (!authorized) return errorResponse(HTTP_STATUS.UNAUTHORIZED, apiKey ? "Invalid API key" : "Missing API key");
   }
 
   if (!modelStr) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -1,4 +1,5 @@
 import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings, getProxyPools } from "@/lib/localDb";
+import { hasValidCliToken } from "@/lib/auth/internalCliToken";
 import { resolveConnectionProxyConfig, pickProxyPoolId } from "@/lib/network/connectionProxy";
 import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
 import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
@@ -361,4 +362,9 @@ export function extractApiKey(request) {
 export async function isValidApiKey(apiKey) {
   if (!apiKey) return false;
   return await validateApiKey(apiKey);
+}
+
+export async function isApiRequestAuthorized(request) {
+  if (await hasValidCliToken(request)) return true;
+  return await isValidApiKey(extractApiKey(request));
 }

--- a/tests/unit/dashboard-guard.test.js
+++ b/tests/unit/dashboard-guard.test.js
@@ -149,6 +149,16 @@ describe("dashboard guard public LLM API access", () => {
     expect(mocks.validateApiKey).toHaveBeenCalledWith("sk-valid");
   });
 
+  it("allows internal model probes with a valid CLI token", async () => {
+    const response = await proxy(request("/api/v1/chat/completions", {
+      host: "router.example.com",
+      "x-9r-cli-token": "cli-token",
+    }));
+
+    expect(response).toBe(mocks.nextResponse);
+    expect(mocks.validateApiKey).not.toHaveBeenCalled();
+  });
+
   it("allows remote public LLM API with valid x-api-key", async () => {
     mocks.validateApiKey.mockResolvedValue(true);
 

--- a/tests/unit/internal-cli-token-auth.test.js
+++ b/tests/unit/internal-cli-token-auth.test.js
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getConsistentMachineId: vi.fn(),
+  validateApiKey: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: vi.fn(),
+  validateApiKey: mocks.validateApiKey,
+  updateProviderConnection: vi.fn(),
+  getSettings: vi.fn(),
+  getProxyPools: vi.fn(),
+}));
+
+vi.mock("@/shared/utils/machineId", () => ({
+  getConsistentMachineId: mocks.getConsistentMachineId,
+}));
+
+describe("internal CLI token API authentication", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getConsistentMachineId.mockResolvedValue("internal-cli-token");
+    mocks.validateApiKey.mockResolvedValue(false);
+  });
+
+  it("accepts the server-generated token used by hosted model probes", async () => {
+    const { hasValidCliToken } = await import("../../src/lib/auth/internalCliToken.js");
+    const request = new Request("http://127.0.0.1/api/v1/chat/completions", {
+      headers: { "x-9r-cli-token": "internal-cli-token" },
+    });
+
+    await expect(hasValidCliToken(request)).resolves.toBe(true);
+    expect(mocks.getConsistentMachineId).toHaveBeenCalledWith("9r-cli-auth");
+  });
+
+  it("rejects missing or incorrect internal tokens", async () => {
+    const { hasValidCliToken } = await import("../../src/lib/auth/internalCliToken.js");
+
+    await expect(hasValidCliToken(new Request("http://127.0.0.1"))).resolves.toBe(false);
+    await expect(hasValidCliToken(new Request("http://127.0.0.1", {
+      headers: { "x-9r-cli-token": "wrong" },
+    }))).resolves.toBe(false);
+  });
+
+  it("authorizes internal probes without accepting external keyless requests", async () => {
+    const { isApiRequestAuthorized } = await import("../../src/sse/services/auth.js");
+
+    await expect(isApiRequestAuthorized(new Request("http://127.0.0.1", {
+      headers: { "x-9r-cli-token": "internal-cli-token" },
+    }))).resolves.toBe(true);
+    await expect(isApiRequestAuthorized(new Request("https://router.example"))).resolves.toBe(false);
+  });
+
+  it("still validates supplied gateway API keys", async () => {
+    const { isApiRequestAuthorized } = await import("../../src/sse/services/auth.js");
+    mocks.validateApiKey.mockResolvedValueOnce(true);
+
+    const request = new Request("https://router.example", {
+      headers: { authorization: "Bearer sk-router" },
+    });
+    await expect(isApiRequestAuthorized(request)).resolves.toBe(true);
+    expect(mocks.validateApiKey).toHaveBeenCalledWith("sk-router");
+  });
+});

--- a/tests/unit/model-test-routing.test.js
+++ b/tests/unit/model-test-routing.test.js
@@ -107,6 +107,34 @@ describe("model test route kind routing", () => {
     );
   });
 
+  it("sends the internal CLI token when no gateway API key exists", async () => {
+    mocks.getApiKeys.mockResolvedValue([]);
+    global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      choices: [{ message: { role: "assistant", content: "ok" } }],
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+
+    const { POST } = await import("../../src/app/api/models/test/route.js");
+    const req = new Request("http://localhost/api/models/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "codex/gpt-5.3-codex", kind: "llm" }),
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/chat/completions"),
+      expect.objectContaining({
+        headers: expect.objectContaining({ "x-9r-cli-token": "cli-token" }),
+      })
+    );
+    expect(global.fetch.mock.calls[0][1].headers.Authorization).toBeUndefined();
+  });
+
   it("fails embedding model tests when provider returns no embedding data", async () => {
     global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
       data: [{ embedding: null }],


### PR DESCRIPTION
## Summary
- reuse 9Router's existing internal CLI-token validation in both the dashboard guard and model handlers
- allow dashboard model probes to run when `requireApiKey` is enabled but no gateway API key has been created
- preserve API-key enforcement for requests without the private internal token

## Problem
The model-test route already attaches `x-9r-cli-token`, and the dashboard guard accepts it. Chat, embeddings, image, and STT handlers then repeat an API-key-only check, so hosted model tests fail with “Missing API key” before reaching the configured provider.

## Security
This does not enable anonymous model access. Requests still need either a valid gateway API key or the same machine-bound CLI token already accepted by the dashboard guard.

## Tests
- 37 focused tests passed across dashboard guard, internal-token auth, model-test routing, and reasoning-model probes
- syntax checks passed for every changed JavaScript file
