### PR TITLE
fix(codex): use manual callback on hosted dashboards

### DIFF
--- a/src/shared/components/OAuthModal.js
+++ b/src/shared/components/OAuthModal.js
@@ -4,6 +4,11 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import PropTypes from "prop-types";
 import { Modal, Button, Input } from "@/shared/components";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
+import {
+  CODEX_LOOPBACK_REDIRECT_URI,
+  hasMatchingOAuthState,
+  isLoopbackBrowserHostname,
+} from "@/shared/utils/oauthBrowserFlow";
 
 // Providers using the dynamic-port local callback proxy.
 // Browser OAuth: popup → auto callback → auto exchange → poll-status.
@@ -52,20 +57,8 @@ export default function OAuthModal({ isOpen, provider, providerInfo, onSuccess, 
   const openedRef = useRef(false);
   const { copied, copy } = useCopyToClipboard();
 
-  // State for client-only values to avoid hydration mismatch
-  const [isLocalhost, setIsLocalhost] = useState(false);
   const [placeholderUrl, setPlaceholderUrl] = useState("/callback?code=...");
   const callbackProcessedRef = useRef(false);
-
-  // Detect if running on localhost (client-side only)
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      setIsLocalhost(
-        window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1"
-      );
-      setPlaceholderUrl(`${window.location.origin}/callback?code=...`);
-    }
-  }, []);
 
   // Define all useCallback hooks BEFORE the useEffects that reference them
 
@@ -73,6 +66,10 @@ export default function OAuthModal({ isOpen, provider, providerInfo, onSuccess, 
   const exchangeTokens = useCallback(async (code, state) => {
     if (!authData) return;
     try {
+      const isRawAccessToken = typeof code === "string" && code.startsWith("eyJ") && code.includes(".");
+      if (provider === "codex" && !isRawAccessToken && !hasMatchingOAuthState(authData.state, state)) {
+        throw new Error("OAuth state mismatch. Start the Codex connection again.");
+      }
       const res = await fetch(`/api/oauth/${provider}/exchange`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -215,6 +212,7 @@ export default function OAuthModal({ isOpen, provider, providerInfo, onSuccess, 
     if (!provider) return;
     try {
       setError(null);
+      setPlaceholderUrl(`${window.location.origin}/callback?code=...`);
 
       // Trae/Windsurf: proxy OAuth (browser mode) — handled by dedicated flow.
       // Paste-token mode is handled by handleManualSubmit (no /authorize call).
@@ -293,9 +291,10 @@ export default function OAuthModal({ isOpen, provider, providerInfo, onSuccess, 
 
       // Authorization code flow - build redirect URI (some providers require fixed ports)
       const appPort = window.location.port || (window.location.protocol === "https:" ? "443" : "80");
+      const browserIsLoopback = isLoopbackBrowserHostname(window.location.hostname);
       let redirectUri;
       if (provider === "codex") {
-        redirectUri = "http://localhost:1455/auth/callback";
+        redirectUri = CODEX_LOOPBACK_REDIRECT_URI;
       } else if (provider === "xai") {
         redirectUri = "http://127.0.0.1:56121/callback";
       } else {
@@ -315,7 +314,7 @@ export default function OAuthModal({ isOpen, provider, providerInfo, onSuccess, 
       // Codex: start proxy with server-side session (auto-exchange) + fallback to channels
       let codexProxyActive = false;
       let codexServerSide = false;
-      if (provider === "codex") {
+      if (provider === "codex" && browserIsLoopback) {
         try {
           const proxyUrl = new URL(`/api/oauth/codex/start-proxy`, window.location.origin);
           proxyUrl.searchParams.set("app_port", appPort);
@@ -380,10 +379,10 @@ export default function OAuthModal({ isOpen, provider, providerInfo, onSuccess, 
         if (!popupRef.current) {
           setStep("input");
         }
-      } else if (!isLocalhost || provider === "codex" || provider === "xai") {
+      } else if (!browserIsLoopback || provider === "codex" || provider === "xai") {
         // Non-localhost or proxy failed: manual input mode
         setStep("input");
-        window.open(data.authUrl, "_blank");
+        window.open(data.authUrl, "_blank", "noopener,noreferrer");
       } else {
         // Localhost (non-Codex/xAI): Open popup and wait for message
         setStep("waiting");
@@ -396,7 +395,7 @@ export default function OAuthModal({ isOpen, provider, providerInfo, onSuccess, 
       setError(err.message);
       setStep("error");
     }
-  }, [provider, isLocalhost, startPolling, oauthMeta, idcConfig, authMode, startProxyFlow]);
+  }, [provider, startPolling, oauthMeta, idcConfig, authMode, startProxyFlow]);
 
   // Reset state and start OAuth when modal opens
   useEffect(() => {
@@ -675,9 +674,11 @@ export default function OAuthModal({ isOpen, provider, providerInfo, onSuccess, 
   const modalTitle = isXaiProvider ? "Connect Grok Build OAuth" : `Connect ${providerInfo.name}`;
   const manualPlaceholder = isXaiProvider
     ? "http://127.0.0.1:56121/callback?code=... or copied code"
-    : isKimchiProvider
-      ? `${placeholderUrl.replace("code=...", "token=...")} or copied token`
-      : placeholderUrl;
+    : provider === "codex"
+      ? `${CODEX_LOOPBACK_REDIRECT_URI}?code=...&state=...`
+      : isKimchiProvider
+        ? `${placeholderUrl.replace("code=...", "token=...")} or copied token`
+        : placeholderUrl;
 
   return (
     <Modal isOpen={isOpen} title={modalTitle} onClose={handleClose} size="lg">
@@ -759,22 +760,26 @@ export default function OAuthModal({ isOpen, provider, providerInfo, onSuccess, 
         {/* Waiting + Manual Input combined (non-device-code, non-proxy) */}
         {(step === "waiting" || step === "input") && !isDeviceCode && !PROXY_OAUTH_PROVIDERS.has(provider) && (
           <>
-            {/* Option A: Auto via popup */}
-            <div className="flex items-center gap-2 px-3 py-2 border border-border rounded-lg bg-sidebar/50">
-              <span className="material-symbols-outlined text-base text-primary animate-spin">
-                progress_activity
-              </span>
-              <span className="text-sm">
-                {isXaiProvider ? "Waiting for Grok Build OAuth…" : "Waiting for popup authorization…"}
-              </span>
-            </div>
+            {step === "waiting" && (
+              <>
+                {/* Option A: Auto via popup */}
+                <div className="flex items-center gap-2 px-3 py-2 border border-border rounded-lg bg-sidebar/50">
+                  <span className="material-symbols-outlined text-base text-primary animate-spin">
+                    progress_activity
+                  </span>
+                  <span className="text-sm">
+                    {isXaiProvider ? "Waiting for Grok Build OAuth…" : "Waiting for popup authorization…"}
+                  </span>
+                </div>
 
-            {/* Divider */}
-            <div className="flex items-center gap-3 my-1">
-              <div className="flex-1 h-px bg-border" />
-              <span className="text-xs text-text-muted uppercase tracking-wider">Or paste callback URL manually</span>
-              <div className="flex-1 h-px bg-border" />
-            </div>
+                {/* Divider */}
+                <div className="flex items-center gap-3 my-1">
+                  <div className="flex-1 h-px bg-border" />
+                  <span className="text-xs text-text-muted uppercase tracking-wider">Or paste callback URL manually</span>
+                  <div className="flex-1 h-px bg-border" />
+                </div>
+              </>
+            )}
 
             {/* Option B: Manual paste */}
             <div className="space-y-4">

--- a/src/shared/utils/oauthBrowserFlow.js
+++ b/src/shared/utils/oauthBrowserFlow.js
@@ -1,0 +1,10 @@
+export const CODEX_LOOPBACK_REDIRECT_URI = "http://localhost:1455/auth/callback";
+
+export function isLoopbackBrowserHostname(hostname) {
+  const normalized = String(hostname || "").trim().toLowerCase().replace(/^\[|\]$/g, "");
+  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1";
+}
+
+export function hasMatchingOAuthState(expectedState, receivedState) {
+  return Boolean(expectedState && receivedState && expectedState === receivedState);
+}

--- a/tests/unit/oauth-browser-flow.test.js
+++ b/tests/unit/oauth-browser-flow.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CODEX_LOOPBACK_REDIRECT_URI,
+  hasMatchingOAuthState,
+  isLoopbackBrowserHostname,
+} from "../../src/shared/utils/oauthBrowserFlow.js";
+
+describe("hosted Codex browser OAuth flow", () => {
+  it("keeps the Codex CLI loopback redirect URI", () => {
+    expect(CODEX_LOOPBACK_REDIRECT_URI).toBe("http://localhost:1455/auth/callback");
+  });
+
+  it.each(["localhost", "127.0.0.1", "::1", "[::1]"])(
+    "allows the local callback proxy on %s",
+    (hostname) => {
+      expect(isLoopbackBrowserHostname(hostname)).toBe(true);
+    }
+  );
+
+  it.each(["router.example", "ninerouter-render-xvkc.onrender.com", "192.168.1.10", ""])(
+    "uses manual callback entry on remote host %s",
+    (hostname) => {
+      expect(isLoopbackBrowserHostname(hostname)).toBe(false);
+    }
+  );
+
+  it("requires an exact non-empty state match before exchange", () => {
+    expect(hasMatchingOAuthState("expected", "expected")).toBe(true);
+    expect(hasMatchingOAuthState("expected", "different")).toBe(false);
+    expect(hasMatchingOAuthState("expected", null)).toBe(false);
+    expect(hasMatchingOAuthState(null, null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- keep the automatic Codex callback proxy when the dashboard is opened on loopback
- send hosted dashboards directly to the existing manual callback-URL flow
- remove the misleading popup-waiting UI from manual mode
- reject mismatched Codex OAuth state before exchanging the authorization code

## Problem
Codex uses a fixed `http://localhost:1455/auth/callback` redirect. On a hosted 9Router dashboard, `/start-proxy` starts port 1455 on the remote server, not on the computer running the user's browser, so the automatic callback cannot arrive there. The manual copy/paste path already works, but the modal first presents a non-working automatic path.

## Behavior
- localhost / loopback dashboard: unchanged automatic proxy flow
- remote dashboard: open the authorize URL in a new tab, then paste the full localhost callback URL into 9Router
- no relay helper or additional service is introduced

## Tests
- 10/10 hosted OAuth flow tests passed
- OAuthModal JSX parsed successfully
- JavaScript syntax and diff checks passed
