### PR TITLE
feat(codebuddy-cn): refresh model catalog — add hy4-preview/hy3/glm-5.3/kimi-k3, drop EOL glm-5.0/glm-4.7

### DIFF
--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -190,6 +190,15 @@ export const PROVIDER_CAPABILITIES = {
     "kimi-k2.6":          { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 256000, maxOutput: 32000 },
     "kimi-k2.5":          { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 164000, maxOutput: 32000 },
     "hy3-preview":        { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 192000, maxOutput: 64000 },
+    // hy3/hy3-x: 256K official (192K conservative, matches hy3-preview); hy4-preview: 1M official.
+    // glm-5.3: 1M (GLM-5.x gen); glm-5.3-flash window unverified (200K conservative).
+    "hy3":                { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 192000, maxOutput: 64000 },
+    "hy3-x":              { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 192000, maxOutput: 64000 },
+    "hy4-preview":        { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 1000000, maxOutput: 64000 },
+    "hy4-preview-x":      { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 1000000, maxOutput: 64000 },
+    "glm-5.3":            { reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 1000000, maxOutput: 48000 },
+    "glm-5.3-flash":      { reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 200000, maxOutput: 48000 },
+    "kimi-k3-1":          { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 256000, maxOutput: 32000 },
     "deepseek-v4-pro":    { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 1000000, maxOutput: 50000 },
     "deepseek-v4-flash":  { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 1000000, maxOutput: 50000 },
     "deepseek-v3-2-volc": { reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 96000, maxOutput: 32000 },

--- a/open-sse/providers/registry/codebuddy-cn.js
+++ b/open-sse/providers/registry/codebuddy-cn.js
@@ -47,16 +47,24 @@ export default {
   models: [
     { id: "glm-5.2", name: "GLM-5.2" },
     { id: "glm-5.1", name: "GLM-5.1" },
-    { id: "glm-5.0", name: "GLM-5.0" },
     { id: "glm-5.0-turbo", name: "GLM-5.0-Turbo" },
     { id: "glm-5v-turbo", name: "GLM-5v-Turbo" },
-    { id: "glm-4.7", name: "GLM-4.7" },
     { id: "minimax-m3", name: "MiniMax-M3" },
     { id: "minimax-m2.7", name: "MiniMax-M2.7" },
     { id: "kimi-k2.7", name: "Kimi-K2.7-Code" },
     { id: "kimi-k2.6", name: "Kimi-K2.6" },
     { id: "kimi-k2.5", name: "Kimi-K2.5" },
+    // "-x" suffix = paid tier of the same model (free id rides the promo quota:
+    // hy3 free until 2026-08-31, hy4-preview until 2026-09-10). Server model table
+    // seen in client logs 2026-08-30; glm-5.0 / glm-4.7 removed (API 11102 dead).
     { id: "hy3-preview", name: "Hy3 Preview" },
+    { id: "hy3", name: "Hy3" },
+    { id: "hy3-x", name: "Hy3 (Paid)" },
+    { id: "hy4-preview", name: "Hy4-Preview" },
+    { id: "hy4-preview-x", name: "Hy4-Preview (Paid)" },
+    { id: "glm-5.3", name: "GLM-5.3" },
+    { id: "glm-5.3-flash", name: "GLM-5.3-Flash" },
+    { id: "kimi-k3-1", name: "Kimi-K3" },
     { id: "deepseek-v4-pro", name: "DeepSeek-V4-Pro" },
     { id: "deepseek-v4-flash", name: "DeepSeek-V4-Flash" },
     { id: "deepseek-v3-2-volc", name: "DeepSeek-V3.2" },

--- a/open-sse/providers/thinkingLevels.js
+++ b/open-sse/providers/thinkingLevels.js
@@ -39,6 +39,13 @@ const PATTERN_THINKING = [
   { provider: "codex", pattern: "*gpt-5.6-terra*", levels: [...CODEX_GPT_5_6_LEVELS, "ultra"] },
   { provider: "codex", pattern: "*gpt-5.6-luna*", levels: CODEX_GPT_5_6_LEVELS },
   { pattern: "*codex*", levels: ["low", "medium", "high", "xhigh"] }, // codex cannot disable thinking
+  // codebuddy-cn per-model effort sets — read off the client picker (server-
+  // delivered supportedEfforts), 2026-08-30. Gateway uses thinkingFormat "openai"
+  // but rejects levels outside each model's set.
+  { provider: "codebuddy-cn", pattern: "glm-5.3*",     levels: ["low", "high", "max"] },
+  { provider: "codebuddy-cn", pattern: "deepseek-v4*", levels: ["low", "high", "xhigh"] },
+  { provider: "codebuddy-cn", pattern: "hy3*",         levels: ["low", "high"] },
+  { provider: "codebuddy-cn", pattern: "hy4*",         levels: ["high"] },
 ];
 
 // Returns valid thinking levels for a model, or null when the model has no reasoning.


### PR DESCRIPTION
## Problem

The codebuddy-cn model catalog is stale against the live gateway (verified 2026-08-30):

**Dead models still advertised** — `glm-5.0` and `glm-4.7` answer `11102 service info not found` on every request. They show up in `/v1/models` and silently consume combo fallback slots.

**Missing models** — the gateway has shipped a new generation that 9router can't route:

| Model | Status | Notes |
|---|---|---|
| `hy4-preview` | live | Tencent's new flagship, 770B MoE, **1M context**, released 2026-08-28 |
| `hy4-preview-x` | live | paid twin of hy4-preview (see below) |
| `hy3` | live | Hy3 GA (preview graduated 2026-07-06) |
| `hy3-x` | live | paid twin of hy3 |
| `glm-5.3` | live | GLM-5.3, 1M context |
| `glm-5.3-flash` | live | GLM-5.3 flash tier |
| `kimi-k3-1` | live | canonical id per the client's server-delivered table (bare `kimi-k3` currently resolves but the client sends `-1`) |

**The `-x` suffix convention:** the official client's server-delivered model table (extracted from CodeBuddy IDE v4.11.2 logs) lists pairs like `hy4-preview` + `hy4-preview-x` with identical display names — the `-x` id bills credits directly while the plain id rides the limited-time free quota (hy3 free until 2026-08-31, hy4-preview until 2026-09-10). Routing both lets users pick free-vs-paid explicitly instead of silently burning promo quota.

## Change

**`open-sse/providers/registry/codebuddy-cn.js`**
- Add `hy3`, `hy3-x`, `hy4-preview`, `hy4-preview-x`, `glm-5.3`, `glm-5.3-flash`, `kimi-k3-1`
- Remove `glm-5.0`, `glm-4.7` (EOL, 11102)

**`open-sse/providers/capabilities.js`**
- Matching `PROVIDER_CAPABILITIES["codebuddy-cn"]` entries: `hy4-preview*` 1M context (official release notes), `glm-5.3` 1M, `glm-5.3-flash` conservative 200K (window unverified), `hy3` family 192K (matches existing `hy3-preview`), `kimi-k3-1` 256K

**`open-sse/providers/thinkingLevels.js`**
- Per-model effort sets, read off the official client's model picker (the server delivers `supportedEfforts` per model — same approach as the existing codex pattern entries):
  - `glm-5.3*` → low/high/max
  - `deepseek-v4*` → low/high/xhigh
  - `hy3*` → low/high
  - `hy4*` → high (single fixed level; the picker shows no alternatives)
- All patterns are scoped to `provider: "codebuddy-cn"`; no other provider is affected.

## Verification

- Every added free-tier id live-probed against `copilot.tencent.com/v2/chat/completions` with streaming (200 + real completions; `hy4-preview` returns `reasoning_content`, confirming thinking)
- Effort sets transcribed from the official client's model picker (server-delivered `supportedEfforts`), not guessed
- Context windows: hy4-preview 1M and hy3 256K from Tencent's release notes; glm-5.3 1M from Z.ai docs; glm-5.3-flash left conservative with an unverified comment
- `tests/unit/codebuddy-reasoning-optin.test.js` + thinking-levels/capabilities suites pass locally (the pre-existing `codebuddy-cn-bonus-recurring.test.js` vitest-alias failure reproduces on clean master, unrelated)