### PR TITLE
fix(usage): bucket usage by API key identity, not by its mask or the key

### DIFF
--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { EventEmitter } from "events";
 import { getAdapter } from "../driver.js";
 import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
@@ -7,6 +8,23 @@ function maskApiKey(key) {
   if (!key || typeof key !== "string") return null;
   if (key.length <= 8) return key.charAt(0) + "***";
   return key.slice(0, 8) + "***";
+}
+
+/**
+ * A stable, non-secret identity for one API key, used to bucket usage stats.
+ *
+ * The mask cannot serve: keys are minted as sk-{machineId}-{keyId}-{crc}, so
+ * every key on one install shares its first 8 characters and maskApiKey()
+ * folds all of them onto a single bucket (#3640). The key itself cannot serve
+ * either: these bucket names are returned to the dashboard, which is what
+ * AUDIT-002 forbids. The key's own id satisfies both; a deleted or unregistered
+ * key falls back to a digest, so it still gets its own bucket without the
+ * secret ever reaching the response.
+ */
+function apiKeyIdentity(apiKey, keyInfo) {
+  if (!apiKey || typeof apiKey !== "string") return "local-no-key";
+  if (keyInfo?.id) return keyInfo.id;
+  return "anon-" + createHash("sha256").update(apiKey).digest("hex").slice(0, 12);
 }
 
 const PENDING_TIMEOUT_MS = 60 * 1000;
@@ -500,7 +518,7 @@ export async function getUsageStats(period = "all") {
         if (dateKey > (stats.byAccount[accountKey].lastUsed || "")) stats.byAccount[accountKey].lastUsed = dateKey;
       }
 
-      for (const [akKey, ak] of Object.entries(day.byApiKey || {})) {
+      for (const [, ak] of Object.entries(day.byApiKey || {})) {
         const rawModel = ak.rawModel || "";
         const provider = ak.provider || "";
         const providerDisplayName = providerNodeNameMap[provider] || provider;
@@ -509,6 +527,10 @@ export async function getUsageStats(period = "all") {
         const keyName = keyInfo?.name || (apiKeyVal ? apiKeyVal.slice(0, 8) + "..." : "Local (No API Key)");
         const apiKeyMasked = maskApiKey(apiKeyVal);
         const apiKeyKey = apiKeyMasked || "local-no-key";
+        // The stored daily bucket is named by the raw key (aggregateEntryToDay
+        // writes `${apiKey}|${model}|${provider}`). Re-derive the response
+        // bucket so the secret stays in storage and never leaves in the payload.
+        const akKey = `${apiKeyIdentity(apiKeyVal, keyInfo)}|${rawModel}|${provider || "unknown"}`;
         if (!stats.byApiKey[akKey]) {
           stats.byApiKey[akKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cachedTokens: 0, cost: 0, rawModel, provider: providerDisplayName, apiKeyMasked, keyName, apiKeyKey, lastUsed: dateKey };
         }
@@ -555,7 +577,7 @@ export async function getUsageStats(period = "all") {
       }
 
       const apiKeyKey = (e.apiKey && typeof e.apiKey === "string")
-        ? `${e.apiKey}|${e.model}|${e.provider || "unknown"}`
+        ? `${apiKeyIdentity(e.apiKey, apiKeyMap[e.apiKey])}|${e.model}|${e.provider || "unknown"}`
         : "local-no-key";
       if (stats.byApiKey[apiKeyKey] && new Date(ts) > new Date(stats.byApiKey[apiKeyKey].lastUsed)) stats.byApiKey[apiKeyKey].lastUsed = ts;
 
@@ -627,7 +649,10 @@ export async function getUsageStats(period = "all") {
         const keyInfo = apiKeyMap[r.apiKey];
         const keyName = keyInfo?.name || r.apiKey.slice(0, 8) + "...";
         const apiKeyMasked = maskApiKey(r.apiKey);
-        const akKey = `${apiKeyMasked}|${r.model}|${r.provider || "unknown"}`;
+        // Not the mask: every key on one install shares its first 8 characters,
+        // so masking folded them all onto one bucket and the first key seen
+        // absorbed the rest of the install's requests, tokens and cost (#3640).
+        const akKey = `${apiKeyIdentity(r.apiKey, keyInfo)}|${r.model}|${r.provider || "unknown"}`;
         if (!stats.byApiKey[akKey]) {
           stats.byApiKey[akKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cachedTokens: 0, cost: 0, rawModel: r.model, provider: providerDisplayName, apiKeyMasked, keyName, apiKeyKey: apiKeyMasked, lastUsed: r.timestamp };
         }

--- a/tests/unit/security-audit.test.js
+++ b/tests/unit/security-audit.test.js
@@ -48,15 +48,17 @@ describe("AUDIT-002: API key masking", () => {
     expect(livePath.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("byApiKey object keys should use masked key, not raw key", () => {
+  it("byApiKey object keys should never contain the raw key", () => {
     const source = fs.readFileSync(
       path.resolve("src/lib/db/repos/usageRepo.js"),
       "utf-8"
     );
-    // The 24h path should use apiKeyMasked in the akKey template
-    expect(source).toContain("${apiKeyMasked}|${r.model}|${r.provider");
-    // Should NOT use raw r.apiKey in the key
+    // Neither aggregation path may name a response bucket after the secret.
     expect(source).not.toContain("${r.apiKey}|${r.model}|${r.provider");
+    expect(source).not.toContain("${e.apiKey}|${e.model}|${e.provider");
+    // Both derive the bucket name through the shared non-secret identity.
+    expect(source).toContain("function apiKeyIdentity(");
+    expect((source.match(/apiKeyIdentity\(/g) || []).length).toBeGreaterThanOrEqual(4);
   });
 });
 

--- a/tests/unit/usage-api-key-prefix-collision-3640.test.js
+++ b/tests/unit/usage-api-key-prefix-collision-3640.test.js
@@ -1,0 +1,113 @@
+// #3640 — "Usage by API Key" collapsed distinct keys that share an 8-char prefix.
+//
+// Keys are minted as sk-{machineId}-{keyId}-{crc}, so every key issued by one
+// install shares its first 8 characters. The 24h/today branch of getUsageStats
+// grouped on maskApiKey(key), which is exactly those 8 characters, so all keys
+// landed in one bucket: the first one seen kept its name and absorbed the rest
+// of the install's requests, tokens and cost.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { generateApiKeyWithMachine } from "../../src/shared/utils/apiKey.js";
+
+const originalDataDir = process.env.DATA_DIR;
+let tempDir;
+let db;
+
+beforeAll(async () => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-apikey-3640-"));
+  process.env.DATA_DIR = tempDir;
+  vi.resetModules();
+  db = await import("@/lib/db/index.js");
+  await db.initDb();
+});
+
+afterAll(() => {
+  // Best-effort: the adapter has no close(), so on Windows the open SQLite
+  // handle makes rmSync raise EPERM. The OS reclaims the temp dir either way,
+  // and failing teardown must not mask the assertions above.
+  try {
+    if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  } catch {}
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+});
+
+describe("usage by API key (#3640)", () => {
+  it("two keys from one install really do share their first 8 characters", () => {
+    const machineId = "00275ae3";
+    const first = generateApiKeyWithMachine(machineId).key;
+    const second = generateApiKeyWithMachine(machineId).key;
+
+    expect(first).not.toBe(second);
+    expect(first.slice(0, 8)).toBe(second.slice(0, 8));
+  });
+
+  it("keeps a separate bucket, name and totals for each key", async () => {
+    const machineId = "00275ae3";
+    const clientA = await db.createApiKey("Client-A", machineId);
+    const clientB = await db.createApiKey("Client-B", machineId);
+    expect(clientA.key.slice(0, 8)).toBe(clientB.key.slice(0, 8));
+
+    const record = (apiKey, promptTokens) =>
+      db.saveRequestUsage({
+        provider: "google",
+        model: "gemini-3.7-flash-high",
+        connectionId: "c-3640",
+        apiKey,
+        tokens: { prompt_tokens: promptTokens, completion_tokens: 1 },
+        endpoint: "/v1/chat/completions",
+        status: "ok",
+      });
+
+    await record(clientA.key, 10);
+    await record(clientB.key, 20);
+    await record(clientB.key, 30);
+
+    const stats = await db.getUsageStats("24h");
+    const buckets = Object.values(stats.byApiKey);
+    expect(buckets).toHaveLength(2);
+
+    const byName = Object.fromEntries(buckets.map((b) => [b.keyName, b]));
+    expect(Object.keys(byName).sort()).toEqual(["Client-A", "Client-B"]);
+    expect(byName["Client-A"].requests).toBe(1);
+    expect(byName["Client-A"].promptTokens).toBe(10);
+    expect(byName["Client-B"].requests).toBe(2);
+    expect(byName["Client-B"].promptTokens).toBe(50);
+  });
+
+  it("still reports the key masked, never in full", async () => {
+    const stats = await db.getUsageStats("24h");
+    for (const bucket of Object.values(stats.byApiKey)) {
+      expect(bucket.apiKeyMasked).toMatch(/\*\*\*$/);
+      expect(bucket.apiKeyMasked.length).toBeLessThanOrEqual(11);
+    }
+  });
+});
+
+describe("AUDIT-002 at runtime: the raw key must not reach the response", () => {
+  it("no period puts the raw key in a byApiKey bucket name or payload", async () => {
+    const secret = (await db.createApiKey("Audit-Probe", "00275ae3")).key;
+    await db.saveRequestUsage({
+      provider: "google",
+      model: "gemini-3.7-flash-high",
+      connectionId: "c-audit",
+      apiKey: secret,
+      tokens: { prompt_tokens: 5, completion_tokens: 5 },
+      endpoint: "/v1/chat/completions",
+      status: "ok",
+    });
+
+    // The daily-summary periods read usageDaily, whose stored bucket names are
+    // built from the raw key. Before this fix they were copied into the
+    // response verbatim, which is exactly what the source-text check missed.
+    for (const period of ["24h", "today", "7d", "30d", "all"]) {
+      const stats = await db.getUsageStats(period);
+      expect(JSON.stringify(stats.byApiKey), `period=${period}`).not.toContain(secret);
+      for (const name of Object.keys(stats.byApiKey)) {
+        expect(name, `period=${period}`).not.toContain(secret);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Fixes #3640.

## The collision is structural, not a coincidence

The report says keys "commonly share the same default prefix". It is stronger than that — **every key on one install always does**:

```js
// src/shared/utils/apiKey.js
const key = `sk-${machineId}-${keyId}-${crc}`;
```

`maskApiKey` returns `key.slice(0, 8)`, which is `sk-` plus the first five characters of the machine id. So the mask is identical for every key the install ever issues, and the 24h/today branch grouped on exactly that. The first key seen kept its `keyName` and absorbed the whole install's requests, tokens and cost. A test asserts the shared prefix from two freshly generated keys rather than taking my word for it.

Only 24h/today: `useDailySummary = period !== "24h" && period !== "today"`, and the daily branch keys off `day.byApiKey`, whose names come from the raw key. That matches the reported repro exactly.

## ⚠️ The suggested fix would have leaked the key — and probing that turned up a second bug

`AUDIT-002` in `tests/unit/security-audit.test.js` deliberately pins the mask, because `stats.byApiKey`'s **object keys are returned to the dashboard**. Grouping on the raw key, as the issue suggests, trips that guard for good reason.

Checking whether the other branch honours it, I found it does not. On unmodified `master`:

```
period=24h   buckets=1 rawKeyInObjectKey=false
period=today buckets=1 rawKeyInObjectKey=false
period=7d    buckets=1 rawKeyInObjectKey=true   <-- sk-00275ae3-w035te-1ddb4b0e|gemini-3.7-flash-high|google
period=30d   buckets=1 rawKeyInObjectKey=true
period=all   buckets=1 rawKeyInObjectKey=true
```

`aggregateEntryToDay` names its stored bucket `${apiKey}|${model}|${provider}`, and the daily branch copied that name straight into the response. AUDIT-002 checked the source text of the 24h template only, so it never saw the other path.

## The fix

One shared helper both branches derive their bucket name from:

```js
function apiKeyIdentity(apiKey, keyInfo) {
  if (!apiKey || typeof apiKey !== "string") return "local-no-key";
  if (keyInfo?.id) return keyInfo.id;
  return "anon-" + createHash("sha256").update(apiKey).digest("hex").slice(0, 12);
}
```

The key's own id is unique and not a secret. A key that has since been deleted is not in `apiKeyMap`, so it falls back to a digest — still its own bucket, still nothing sensitive in the payload. The stored `usageDaily` names are untouched; only the response is re-derived. `apiKeyMasked` and `apiKeyKey` stay masked, so the UI is unchanged.

The `lastUsed` patch a few lines up built its lookup from the raw key, so it moves to the same helper or it would stop matching its bucket.

## ⚠️ I changed a security test — please read this hunk

`AUDIT-002`'s "byApiKey object keys should use masked key, not raw key" asserted one exact template string. That form is what let the 7d leak through, so I replaced it with the property it was trying to express — neither branch may name a bucket after the secret, and both must go through the shared helper — and added a **runtime** check in the new test file that walks every period and asserts the key appears in neither the bucket names nor the serialized payload. That is the assertion that actually catches the bug the old one missed.

The other AUDIT-002 case (`apiKeyMasked` present in both paths, count ≥ 4) is untouched and still passes.

## Tests

Reverting each branch independently fails 2 tests each time:

| mutation | result |
|---|---|
| 24h path back to the mask | 2 failed |
| daily path back to the stored raw-key name | 2 failed |

```
vitest run --config tests/vitest.config.js \
  tests/unit/usage-api-key-prefix-collision-3640.test.js \
  tests/unit/security-audit.test.js                        25 passed, 0 failed
```

Neighbouring suites (`cached-token-e2e`, `cached-token-usage`, `db-sqlite-vs-lowdb`, `db-benchmark`, `security-audit`) report **59 passed / 5 skipped both before and after** this branch. The 3 files reported as "failed" in both runs fail only in `afterAll`, on `rmSync` raising `EPERM` against the still-open SQLite handle — a Windows-only teardown artifact, identical on a clean tree. My own test's teardown is wrapped for that reason, and says so.

I have not opened the dashboard; this is proven at the `getUsageStats` boundary, which is where both bugs live.
