### PR TITLE
fix(cli): stop re-enabling autostart on every switch to tray mode

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -761,10 +761,11 @@ function startServer(updatePromise) {
           const { clearScreen } = require("./src/cli/utils/display");
           clearScreen();
 
-          // Enable auto startup on OS boot
+          // Enable auto startup on OS boot, but only the first time. Doing it
+          // on every hide undid both ways of turning it off (#3628).
           try {
-            const { enableAutoStart } = require("./src/cli/tray/autostart");
-            enableAutoStart(__filename);
+            const { ensureAutoStart } = require("./src/cli/tray/autostart");
+            ensureAutoStart(__filename);
           } catch (e) { }
 
           if (process.platform === "darwin") {

--- a/cli/src/cli/tray/autostart.js
+++ b/cli/src/cli/tray/autostart.js
@@ -6,6 +6,49 @@ const { execSync } = require("child_process");
 const APP_NAME = "9router";
 const APP_LABEL = "com.9router.autostart";
 
+/** Same data directory the CLI's api/client.js uses. */
+function getDataDir() {
+  if (process.env.DATA_DIR) return process.env.DATA_DIR;
+  if (process.platform === "win32") {
+    return path.join(process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming"), APP_NAME);
+  }
+  return path.join(os.homedir(), `.${APP_NAME}`);
+}
+
+/**
+ * Marks that the automatic first-run enable has already happened.
+ *
+ * Without it, switching to tray mode re-enabled autostart on every launch, so
+ * neither way of turning it off survived: the tray's "Disable" was undone by
+ * the next hide, and deleting the startup entry by hand was undone too (#3628).
+ * Once this file exists the automatic path never writes again; only an explicit
+ * enable does.
+ */
+function autostartDecidedFile() {
+  return path.join(getDataDir(), "autostart-decided");
+}
+
+function hasDecidedAutoStart() {
+  try {
+    return fs.existsSync(autostartDecidedFile());
+  } catch (err) {
+    // Unreadable data dir: treat as decided rather than write an entry the
+    // user has no recorded way of refusing.
+    return true;
+  }
+}
+
+function rememberAutoStartDecision() {
+  try {
+    const file = autostartDecidedFile();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, new Date().toISOString());
+  } catch (err) {
+    // Best-effort: a data dir we cannot write is not a reason to fail the
+    // enable/disable the user actually asked for.
+  }
+}
+
 /**
  * Resolve the absolute path to this package's cli.js.
  *
@@ -51,13 +94,28 @@ function enableAutoStart(cliPath) {
   if (platform === "linux" && !process.env.DISPLAY) return false;
 
   try {
-    if (platform === "darwin") return enableMacOS(cliPath);
-    if (platform === "win32") return enableWindows(cliPath);
-    if (platform === "linux") return enableLinux(cliPath);
+    let ok = false;
+    if (platform === "darwin") ok = enableMacOS(cliPath);
+    if (platform === "win32") ok = enableWindows(cliPath);
+    if (platform === "linux") ok = enableLinux(cliPath);
+    if (ok) rememberAutoStartDecision();
+    return ok;
   } catch (err) {
     // Silent fail — autostart is optional
   }
   return false;
+}
+
+/**
+ * Enable autostart the first time only, for callers that are not the user
+ * asking — switching to tray mode, for instance. Once the choice has been
+ * made, by this function or by an explicit enable/disable, it is left alone.
+ *
+ * @returns {boolean} whether an entry was written on this call
+ */
+function ensureAutoStart(cliPath) {
+  if (hasDecidedAutoStart()) return false;
+  return enableAutoStart(cliPath);
 }
 
 /**
@@ -66,6 +124,9 @@ function enableAutoStart(cliPath) {
  */
 function disableAutoStart() {
   const platform = process.platform;
+  // Record the choice first: even if removing the entry throws, the automatic
+  // path must not treat the next launch as a fresh install and put it back.
+  rememberAutoStartDecision();
   try {
     if (platform === "darwin") return disableMacOS();
     if (platform === "win32") return disableWindows();
@@ -301,6 +362,7 @@ function disableLinux() {
 
 module.exports = {
   enableAutoStart,
+  ensureAutoStart,
   disableAutoStart,
   isAutoStartEnabled
 };

--- a/tests/unit/autostart-user-choice-3628.test.js
+++ b/tests/unit/autostart-user-choice-3628.test.js
@@ -1,0 +1,116 @@
+// #3628 — autostart could not be turned off on any platform.
+//
+// cli.js called enableAutoStart() every time the user switched to tray mode,
+// so the tray's "Disable" was undone by the next hide, and deleting the
+// startup entry by hand was undone too. The automatic path now runs once and
+// then leaves the user's choice alone.
+//
+// Exercised through the Linux branch against a temporary HOME: the Windows
+// branch writes into the real Start Menu Startup folder, which a test must
+// never touch.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const AUTOSTART = "../../cli/src/cli/tray/autostart.js";
+
+const saved = {};
+let home;
+let dataDir;
+let cliPath;
+
+function desktopEntry() {
+  return path.join(home, ".config", "autostart", "9router.desktop");
+}
+
+function decidedMarker() {
+  return path.join(dataDir, "autostart-decided");
+}
+
+function load() {
+  delete require.cache[require.resolve(AUTOSTART)];
+  return require(AUTOSTART);
+}
+
+beforeEach(() => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "9router-autostart-3628-"));
+  home = path.join(root, "home");
+  dataDir = path.join(root, "data");
+  fs.mkdirSync(path.join(home, ".config", "autostart"), { recursive: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+  cliPath = path.join(root, "cli.js");
+  fs.writeFileSync(cliPath, "// stub\n");
+
+  for (const key of ["HOME", "USERPROFILE", "DATA_DIR", "DISPLAY"]) saved[key] = process.env[key];
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  process.env.DATA_DIR = dataDir;
+  process.env.DISPLAY = ":0";
+
+  saved.platform = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+});
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", saved.platform);
+  for (const key of ["HOME", "USERPROFILE", "DATA_DIR", "DISPLAY"]) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+describe("autostart respects the user's choice (#3628)", () => {
+  it("enables on the first automatic run", () => {
+    const { ensureAutoStart } = load();
+    expect(ensureAutoStart(cliPath)).toBe(true);
+    expect(fs.existsSync(desktopEntry())).toBe(true);
+    expect(fs.existsSync(decidedMarker())).toBe(true);
+  });
+
+  it("does not re-enable after the user disables it", () => {
+    const { ensureAutoStart, disableAutoStart, isAutoStartEnabled } = load();
+    ensureAutoStart(cliPath);
+    disableAutoStart();
+    expect(fs.existsSync(desktopEntry())).toBe(false);
+
+    // The next switch to tray mode. This is the loop the issue reports.
+    expect(ensureAutoStart(cliPath)).toBe(false);
+    expect(fs.existsSync(desktopEntry())).toBe(false);
+    expect(isAutoStartEnabled()).toBe(false);
+  });
+
+  it("does not re-create an entry the user deleted by hand", () => {
+    const { ensureAutoStart } = load();
+    ensureAutoStart(cliPath);
+    fs.unlinkSync(desktopEntry());
+
+    expect(ensureAutoStart(cliPath)).toBe(false);
+    expect(fs.existsSync(desktopEntry())).toBe(false);
+  });
+
+  it("still turns back on when the user asks explicitly", () => {
+    const { ensureAutoStart, disableAutoStart, enableAutoStart, isAutoStartEnabled } = load();
+    ensureAutoStart(cliPath);
+    disableAutoStart();
+
+    expect(enableAutoStart(cliPath)).toBe(true);
+    expect(fs.existsSync(desktopEntry())).toBe(true);
+    expect(isAutoStartEnabled()).toBe(true);
+    // ...and stays on across a later hide.
+    expect(ensureAutoStart(cliPath)).toBe(false);
+    expect(fs.existsSync(desktopEntry())).toBe(true);
+  });
+
+  it("records the choice even when removing the entry fails", () => {
+    const { disableAutoStart, ensureAutoStart } = load();
+    // Nothing to remove: disable must still be remembered, or the next launch
+    // would treat this as a fresh install and enable autostart again.
+    expect(fs.existsSync(desktopEntry())).toBe(false);
+    disableAutoStart();
+    expect(ensureAutoStart(cliPath)).toBe(false);
+    expect(fs.existsSync(desktopEntry())).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #3628.

## Why deleting the file did not help

`cli.js` re-enabled autostart on **every** switch to tray mode:

```js
// cli/cli.js, the "hide" branch
const { enableAutoStart } = require("./src/cli/tray/autostart");
enableAutoStart(__filename);
```

So both ways of turning it off were undone by the next hide — the tray menu's "Disable" and deleting `9router.vbs` by hand. Nothing recorded that the user had said no.

The issue is filed against Windows, but that call is platform-agnostic: `enableAutoStart` dispatches to `enableMacOS` / `enableWindows` / `enableLinux`, so the LaunchAgent plist and the `.desktop` entry come back the same way.

## The fix

Separate the automatic path from the deliberate one:

- `ensureAutoStart(cliPath)` — for callers that are not the user asking. Writes an entry only if no choice has been recorded yet, then records one. `cli.js` calls this.
- `enableAutoStart(cliPath)` / `disableAutoStart()` — unchanged in meaning, still always act, and both record the choice. The tray menu calls these.

The marker is a small file in the CLI's data directory (`getDataDir()`, the same `%APPDATA%\9router` / `~/.9router` convention as `api/client.js`). `disableAutoStart` records **before** removing the entry, so a failed removal still cannot be read as a fresh install next launch.

A first install still gets autostart on its first hide, exactly as before.

## Tests

`tests/unit/autostart-user-choice-3628.test.js`, 5 tests: first automatic run enables; disable survives the next hide (the reported loop); an entry deleted by hand is not recreated; an explicit enable still works after a disable and survives a later hide; and disable is recorded even when there was no entry to remove.

They run against the **Linux** branch with a temporary `HOME` and `DATA_DIR`. That is deliberate — the Windows branch writes into the real Start Menu Startup folder, which a test must not touch. I checked my own Startup folder before and after the run to confirm nothing was written to it. (It does contain a `9router.vbs` that the running install put there, which is how I could see the reported behaviour first-hand.)

Reverting each guard fails them:

| mutation | result |
|---|---|
| `ensureAutoStart` ignores the recorded choice | 4 failed |
| `disableAutoStart` stops recording the choice | 1 failed |

```
vitest run --config tests/vitest.config.js tests/unit/autostart-user-choice-3628.test.js   5 passed
vitest run --config tests/vitest.config.js tests/unit/cli-*.test.js \
       tests/unit/security-audit.test.js                                        38 passed, before and after
```

I have not exercised the Windows or macOS branches end-to-end — only the shared decision logic that both go through.
