### PR TITLE
fix(rtk): treat a Responses input item with no type as a message

### DIFF
--- a/open-sse/rtk/systemInject.js
+++ b/open-sse/rtk/systemInject.js
@@ -149,6 +149,14 @@ function appendToChatMessage(msg, prompt) {
   } catch (_) {}
 }
 
+// A Responses input[] message item may omit `type`: the field defaults to
+// "message" and native clients leave it off. codex.js, grok-cli.js and
+// headroom.js already read an absent type as a message; this file did not, so a
+// system item written that way was skipped and a second one prepended beside it.
+function isMessageItem(item) {
+  return !!item && (!item.type || item.type === RESPONSES_ITEM.MESSAGE);
+}
+
 // ---- Responses input[] ----
 function injectResponsesInputSystem(body, prompt) {
   try {
@@ -156,10 +164,10 @@ function injectResponsesInputSystem(body, prompt) {
     if (!Array.isArray(arr)) return;
     // instructions already handled above
     if (containsPromptInResponsesInput(arr, prompt)) return;
-    // find system/developer message items only (type === message)
+    // find system/developer message items only (type absent or "message")
     let idx = -1;
     try {
-      idx = arr.findIndex(m => m && m.type === RESPONSES_ITEM.MESSAGE && (m.role === ROLE.SYSTEM || m.role === ROLE.DEVELOPER));
+      idx = arr.findIndex(m => isMessageItem(m) && (m.role === ROLE.SYSTEM || m.role === ROLE.DEVELOPER));
     } catch (_) { return; }
     if (idx >= 0) {
       appendToResponsesMessage(arr[idx], prompt);
@@ -173,7 +181,7 @@ function injectResponsesInputSystem(body, prompt) {
 function containsPromptInResponsesInput(arr, prompt) {
   try {
     for (const item of arr) {
-      if (!item || item.type !== RESPONSES_ITEM.MESSAGE) continue;
+      if (!isMessageItem(item)) continue;
       if (item.role !== ROLE.SYSTEM && item.role !== ROLE.DEVELOPER) continue;
       const c = item.content;
       if (typeof c === "string" && hasPrompt(c, prompt)) return true;

--- a/tests/unit/system-inject-untyped-item.test.js
+++ b/tests/unit/system-inject-untyped-item.test.js
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { injectSystemPrompt } from "../../open-sse/rtk/systemInject.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+const PROMPT = "speak like a caveman";
+
+// A Responses input[] message item may leave `type` off — the field defaults to
+// "message". The repo already reads it that way in three other places:
+//   open-sse/executors/codex.js:53      item.role === "system" && (!item.type || item.type === "message")
+//   open-sse/executors/grok-cli.js:79   item.role === "user"   && (!type || type === "message")
+//   open-sse/rtk/headroom.js:96         typeof item.type === "string" && item.type !== "message"
+// and tests/unit/continuity-strip.test.js builds its fixture without the field.
+describe("system injection into a Responses input[] whose items omit type", () => {
+  it("appends to an untyped system item instead of prepending a second one", () => {
+    const body = {
+      input: [
+        { role: "system", content: [{ type: "input_text", text: "you are a helper" }] },
+        { role: "user", content: [{ type: "input_text", text: "hi" }] },
+      ],
+    };
+
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, PROMPT);
+
+    expect(body.input).toHaveLength(2);
+    expect(body.input[0].content).toEqual([
+      { type: "input_text", text: "you are a helper" },
+      { type: "input_text", text: PROMPT },
+    ]);
+    expect(body.input.filter(i => i.role === "system")).toHaveLength(1);
+  });
+
+  it("treats an untyped developer item as the system channel too", () => {
+    const body = { input: [{ role: "developer", content: "rules" }] };
+
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, PROMPT);
+
+    expect(body.input).toHaveLength(1);
+    expect(body.input[0].content).toBe(`rules
+
+${PROMPT}`);
+  });
+
+  it("stays idempotent when the prompt already sits in an untyped item", () => {
+    const body = {
+      input: [{ role: "system", content: [{ type: "input_text", text: PROMPT }] }],
+    };
+
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, PROMPT);
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, PROMPT);
+
+    expect(body.input).toHaveLength(1);
+    expect(body.input[0].content).toEqual([{ type: "input_text", text: PROMPT }]);
+  });
+
+  it("still skips a non-message item that carries a role-like field", () => {
+    const body = {
+      input: [
+        { type: "function_call", call_id: "c1", name: "sh", arguments: "{}", role: "system" },
+        { type: "message", role: "system", content: [{ type: "input_text", text: "real" }] },
+      ],
+    };
+
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, PROMPT);
+
+    expect(body.input[0].type).toBe("function_call");
+    expect(body.input[0].content).toBeUndefined();
+    expect(body.input[1].content).toEqual([
+      { type: "input_text", text: "real" },
+      { type: "input_text", text: PROMPT },
+    ]);
+  });
+
+  // appendToResponsesMessage dedups on its own, so the scan below only decides the
+  // case where the prompt sits in a *different* system item than the one findIndex
+  // returns. Without the untyped item being scanned, the prompt lands twice.
+  it("does not duplicate a prompt already held by a later untyped system item", () => {
+    const body = {
+      input: [
+        { type: "message", role: "system", content: [{ type: "input_text", text: "house rules" }] },
+        { role: "system", content: [{ type: "input_text", text: PROMPT }] },
+      ],
+    };
+
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, PROMPT);
+
+    const occurrences = JSON.stringify(body.input).split(PROMPT).length - 1;
+    expect(occurrences).toBe(1);
+    expect(body.input[0].content).toEqual([{ type: "input_text", text: "house rules" }]);
+  });
+
+  it("keeps prepending when the input carries no system item at all", () => {
+    const body = { input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }] };
+
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, PROMPT);
+
+    expect(body.input).toHaveLength(2);
+    expect(body.input[0]).toEqual({
+      type: "message",
+      role: "system",
+      content: [{ type: "input_text", text: PROMPT }],
+    });
+  });
+});


### PR DESCRIPTION
`injectResponsesInputSystem` and `containsPromptInResponsesInput` both require `item.type === "message"` to recognise a message item in a Responses `input[]`. That field is optional — it defaults to `"message"` — and native clients leave it off. A system item written that way is invisible to the injector, so it falls through to the else branch and **prepends a second system message beside the one already there**.

Measured on `master` (`90b52e06`), running the injector directly:

```js
const body = { input: [
  { role: "system", content: [{ type: "input_text", text: "you are a helper" }] },
  { role: "user",   content: [{ type: "input_text", text: "hi" }] },
]};
injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, "speak like a caveman");
```

```json
items: 3
[{"type":"message","role":"system","content":[{"type":"input_text","text":"speak like a caveman"}]},
 {"role":"system","content":[{"type":"input_text","text":"you are a helper"}]},
 {"role":"user","content":[{"type":"input_text","text":"hi"}]}]
```

Two `role:"system"` items go upstream, and the caller's own system prompt is never appended to. This only reaches native-passthrough traffic: bodies this repo builds itself always stamp the field (`translator/request/openai-responses.js:369`), which is why nothing caught it.

### Why "no type means message" is this repo's existing reading

Three other call sites already treat an absent type that way:

| file | line | test |
| --- | --- | --- |
| `open-sse/executors/codex.js` | 53 | `item.role === "system" && (!item.type \|\| item.type === "message")` |
| `open-sse/executors/grok-cli.js` | 79 | `item.role === "user" && (!type \|\| type === "message")` |
| `open-sse/rtk/headroom.js` | 96 | `typeof item.type === "string" && item.type !== "message"` — an item with no type string is not excluded |

and `tests/unit/continuity-strip.test.js:21` builds its own fixture without the field. `systemInject.js` was the outlier, so the fix follows the existing idiom instead of inventing a new one.

### On the second half of the diff

I fixed the scan in `containsPromptInResponsesInput` alongside it, and it is narrower than it looks. `appendToResponsesMessage` already dedups (`c.some(b => b && b.text === prompt)`, and `dedupStringAppend` for the string case), so the scan only decides the case where the prompt sits in a **different** system item than the one `findIndex` returns. The fifth test covers exactly that case, and it is the only one that fails if that half is reverted. Saying so explicitly in case you would rather drop it — the first half stands on its own.

### Tests

Six tests in `tests/unit/system-inject-untyped-item.test.js`, including the two negatives that keep the change honest: a `function_call` item carrying a stray `role` field is still skipped, and a body with no system item at all still gets one prepended.

Mutation-checked in both directions:

| reverted | result |
| --- | --- |
| `findIndex` half | 2 failed |
| `containsPromptInResponsesInput` half | 1 failed |
| neither | 6 passed |

### Suite

`npx vitest run tests/unit --config tests/vitest.config.js`

| | tests | failed |
| --- | --- | --- |
| `master` (`90b52e06`) | 1673 | 75 |
| this branch | 1679 | 75 |

Same 75 by name, compared as a set rather than a count — no new failures, and the six added tests account for the delta. Those 75 are pre-existing on a clean `master` checkout on this host (Windows, Node 24); I have not touched them.
