### PR TITLE
fix(usage): read Responses-shape cached_tokens in extractUsageFromResponse

### DIFF
--- a/open-sse/handlers/chatCore/requestDetail.js
+++ b/open-sse/handlers/chatCore/requestDetail.js
@@ -25,10 +25,16 @@ export function extractUsageFromResponse(responseBody) {
   if (!responseBody || typeof responseBody !== "object") return null;
 
   // Claude format
+  // Note: OpenAI Responses usage ({input_tokens, input_tokens_details:{cached_tokens}})
+  // also matches this branch. Its prompt is cache-INCLUSIVE and its cache rides in
+  // input_tokens_details, so emit it as cached_tokens — the convention
+  // canonicalizeUsage() passes through without folding. Reading it here keeps
+  // cache accounting correct for /v1/responses and codex traffic.
   if (responseBody.usage?.input_tokens !== undefined) {
     return {
       prompt_tokens: responseBody.usage.input_tokens || 0,
       completion_tokens: responseBody.usage.output_tokens || 0,
+      cached_tokens: responseBody.usage.cached_tokens ?? responseBody.usage.input_tokens_details?.cached_tokens,
       cache_read_input_tokens: responseBody.usage.cache_read_input_tokens,
       cache_creation_input_tokens: responseBody.usage.cache_creation_input_tokens
     };
@@ -39,7 +45,7 @@ export function extractUsageFromResponse(responseBody) {
     return {
       prompt_tokens: responseBody.usage.prompt_tokens || 0,
       completion_tokens: responseBody.usage.completion_tokens || 0,
-      cached_tokens: responseBody.usage.prompt_tokens_details?.cached_tokens,
+      cached_tokens: responseBody.usage.cached_tokens ?? responseBody.usage.prompt_tokens_details?.cached_tokens,
       reasoning_tokens: responseBody.usage.completion_tokens_details?.reasoning_tokens
     };
   }

--- a/tests/unit/extract-usage-cache-shapes.test.js
+++ b/tests/unit/extract-usage-cache-shapes.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+
+// sever the DB import chain (usageDb -> @/lib/db/*) — not under test
+vi.mock("@/lib/usageDb.js", () => ({
+  saveRequestUsage: vi.fn(),
+  appendRequestLog: vi.fn(),
+  saveRequestDetail: vi.fn(),
+}));
+// and the stream/console-coloring utils that drag in the translator graph
+vi.mock("../../open-sse/utils/stream.js", () => ({
+  COLORS: {},
+  formatSSE: vi.fn(),
+}));
+
+import { extractUsageFromResponse } from "../../open-sse/handlers/chatCore/requestDetail.js";
+import { canonicalizeUsage } from "../../open-sse/utils/usageTracking.js";
+
+// The three real-world usage shapes and how extractUsageFromResponse() must
+// surface their cache-read count so canonicalizeUsage() produces a correct
+// cached_tokens. Regression for non-streaming codex/Responses traffic, where
+// cache reads were silently dropped and usage recorded cached_tokens: 0.
+describe("extractUsageFromResponse cache surfaces", () => {
+  it("surfaces OpenAI Responses input_tokens_details.cached_tokens", () => {
+    // codex / /v1/responses shape: prompt is cache-INCLUSIVE
+    const out = extractUsageFromResponse({
+      usage: { input_tokens: 25421, output_tokens: 5, total_tokens: 25426,
+               input_tokens_details: { cached_tokens: 24320 } },
+    });
+    expect(out.cached_tokens).toBe(24320);
+    expect(out.prompt_tokens).toBe(25421);
+    expect(out.cache_read_input_tokens).toBeUndefined();
+  });
+
+  it("canonicalizes Responses usage without double-counting the prompt", () => {
+    const extracted = extractUsageFromResponse({
+      usage: { input_tokens: 25421, output_tokens: 5,
+               input_tokens_details: { cached_tokens: 24320 } },
+    });
+    const out = canonicalizeUsage(extracted);
+    // inclusive prompt passes through unchanged; cache reported as subset
+    expect(out.prompt_tokens).toBe(25421);
+    expect(out.cached_tokens).toBe(24320);
+    expect(out.total_tokens).toBe(25426);
+    expect(out.cache_creation_input_tokens).toBe(0);
+  });
+
+  it("still folds genuine Claude exclusive cache (regression)", () => {
+    const extracted = extractUsageFromResponse({
+      usage: { input_tokens: 100, output_tokens: 50,
+               cache_read_input_tokens: 200, cache_creation_input_tokens: 30 },
+    });
+    expect(extracted.cached_tokens).toBeUndefined();
+    const out = canonicalizeUsage(extracted);
+    expect(out.prompt_tokens).toBe(330); // 100 + 200 + 30
+    expect(out.cached_tokens).toBe(200);
+    expect(out.cache_creation_input_tokens).toBe(30);
+  });
+
+  it("surfaces flat cached_tokens on the OpenAI branch (SSE-to-JSON shape)", () => {
+    const out = extractUsageFromResponse({
+      usage: { prompt_tokens: 300, completion_tokens: 10, cached_tokens: 240 },
+    });
+    expect(out.cached_tokens).toBe(240);
+  });
+
+  it("keeps nested prompt_tokens_details.cached_tokens working (regression)", () => {
+    const out = extractUsageFromResponse({
+      usage: { prompt_tokens: 300, completion_tokens: 10,
+               prompt_tokens_details: { cached_tokens: 240 } },
+    });
+    expect(out.cached_tokens).toBe(240);
+    expect(canonicalizeUsage(out).cached_tokens).toBe(240);
+  });
+});


### PR DESCRIPTION
## Summary

Non-streaming codex traffic records `cached_tokens: 0` in usage stats and cost even when upstream prompt caching is working. Identical back-to-back requests with the same ~4.2k-token prompt stored `cached_tokens: 0` seconds apart, while streaming clients on the same connection + model reported 94%+ hit rates. The cache was real; the accounting lost it.

## Root cause

`extractUsageFromResponse()` (open-sse/handlers/chatCore/requestDetail.js) claims to cover all three LLM usage shapes, but:

- The **Claude-format branch** (matched when `usage.input_tokens` is present) reads only `cache_read_input_tokens` / `cache_creation_input_tokens` — never `usage.input_tokens_details`. The **OpenAI Responses shape** `{input_tokens, input_tokens_details: {cached_tokens}}` (codex, /v1/responses) matches this branch, so its cache-read count is silently dropped.
- The **OpenAI-format branch** reads only `prompt_tokens_details.cached_tokens`, dropping a top-level flat `cached_tokens` — the shape `convertResponsesStreamToJson()` emits, and some providers emit natively.

## Fix

Read both nested details objects in both branches:

```js
// Claude-format branch (also matches OpenAI Responses usage)
cached_tokens: usage.cached_tokens ?? usage.input_tokens_details?.cached_tokens,
// OpenAI-format branch
cached_tokens: usage.cached_tokens ?? usage.prompt_tokens_details?.cached_tokens,
```

The Responses prompt is cache-INCLUSIVE, so its nested cache is emitted as `cached_tokens` — the convention `canonicalizeUsage()` passes through without folding — so prompt totals are untouched and there is no double-count. Claude's exclusive-cache folding is covered by regression tests.

## Scope note

This fixes the native-JSON non-streaming path. The forced SSE→JSON converter (`streamToJsonConverter.js`) drops the same field for the same symptom and is already covered by **#3481**; the two patches are complementary. PR #3449's hand-applied fix (`canonicalizeUsage` reading nested `prompt_tokens_details`) addressed the OpenAI Chat Completions shape but not the Responses shape — this closes that gap at the extractor layer.

## Reproduction evidence

9router 0.5.59, codex provider, OpenAI-compatible /v1/chat/completions client, `stream: false`:

| call | stored `cached_tokens` | client-visible cache |
|---|---|---|
| identical prompt, before fix | 0 | none |
| identical prompt, after local patch | 24320 | `prompt_tokens_details.cached_tokens: 24320` |

Client-visible usage on non-stream requests was also missing the cache field entirely (it rode on the same dropped value), so cost surfaced at full input price while upstream billed at the ~10x-cheaper cache-read rate.

## Tests

5 new cases in tests/unit/extract-usage-cache-shapes.test.js: Responses shape surfaced, canonicalize round-trip without double-count, Claude exclusive-cache fold regression, flat cached_tokens shape, and nested prompt_tokens_details regression.