### PR TITLE
feat: add selective provider and combo transfer

### DIFF
--- a/src/app/(dashboard)/dashboard/profile/page.js
+++ b/src/app/(dashboard)/dashboard/profile/page.js
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { Card, Button, Toggle, Input } from "@/shared/components";
 import Modal, { ConfirmModal } from "@/shared/components/Modal";
 import LanguageSwitcher from "@/shared/components/LanguageSwitcher";
+import ProviderComboTransferModal from "@/shared/components/ProviderComboTransferModal";
 import { useTheme } from "@/shared/hooks/useTheme";
 import { cn } from "@/shared/utils/cn";
 import { APP_CONFIG } from "@/shared/constants/config";
@@ -32,7 +33,9 @@ export default function ProfilePage() {
   const [passLoading, setPassLoading] = useState(false);
   const [dbLoading, setDbLoading] = useState(false);
   const [dbStatus, setDbStatus] = useState({ type: "", message: "" });
+  const [databaseLocation, setDatabaseLocation] = useState("9Router data directory");
   const [dbAuth, setDbAuth] = useState({ open: false, mode: "", password: "" });
+  const [transferMode, setTransferMode] = useState("");
   const pendingImportRef = useRef(null);
   const [oidcForm, setOidcForm] = useState({
     authMode: "password",
@@ -122,6 +125,15 @@ export default function ProfilePage() {
         console.error("Failed to fetch settings:", err);
         setLoading(false);
       });
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/settings/storage", { cache: "no-store" })
+      .then((res) => res.json())
+      .then((data) => {
+        if (data?.databaseLocation) setDatabaseLocation(data.databaseLocation);
+      })
+      .catch(() => {});
   }, []);
 
   const updateOutboundProxy = async (e) => {
@@ -760,7 +772,7 @@ export default function ProfilePage() {
   return (
     <div className="max-w-2xl mx-auto px-4 sm:px-0">
       <div className="flex flex-col gap-6">
-        {/* Local Mode Info */}
+        {/* Data storage and transfer */}
         <Card>
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
             <div className="flex items-center gap-3 sm:gap-4">
@@ -768,16 +780,92 @@ export default function ProfilePage() {
                 <span className="material-symbols-outlined text-xl sm:text-2xl">computer</span>
               </div>
               <div>
-                <h2 className="text-lg sm:text-xl font-semibold">Local Mode</h2>
-                <p className="text-sm text-text-muted">Running on your machine</p>
+                <h2 className="text-lg sm:text-xl font-semibold">Data & Transfer</h2>
+                <p className="text-sm text-text-muted">Back up or selectively move your 9Router configuration</p>
               </div>
             </div>
-            <div className="inline-flex p-1 rounded-lg bg-black/5 dark:bg-white/5 w-full sm:w-auto">
+          </div>
+          <div className="flex flex-col gap-3 pt-4 border-t border-border">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between p-3 rounded-lg bg-bg border border-border gap-2">
+              <div>
+                <p className="font-medium text-sm sm:text-base">Database Location</p>
+                <p className="text-xs sm:text-sm text-text-muted font-mono break-all">{databaseLocation}</p>
+              </div>
+            </div>
+            <div className="rounded-lg border border-border p-3">
+              <div className="mb-3">
+                <p className="font-medium text-sm sm:text-base">Full backup</p>
+                <p className="text-xs sm:text-sm text-text-muted">Download or restore the complete database. Restore replaces the current configuration.</p>
+              </div>
+              <div className="flex flex-col sm:flex-row gap-2">
+                <Button
+                  variant="secondary"
+                  icon="download"
+                  onClick={() => setDbAuth({ open: true, mode: "export", password: "" })}
+                  loading={dbLoading}
+                  className="w-full sm:w-auto"
+                >
+                  Download Backup
+                </Button>
+                <Button
+                  variant="outline"
+                  icon="upload"
+                  onClick={() => importFileRef.current?.click()}
+                  disabled={dbLoading}
+                  className="w-full sm:w-auto"
+                >
+                  Import Backup
+                </Button>
+                <input
+                  ref={importFileRef}
+                  type="file"
+                  accept="application/json,.json"
+                  className="hidden"
+                  onChange={handleImportDatabase}
+                />
+              </div>
+            </div>
+            <div className="rounded-lg border border-border p-3">
+              <div className="mb-3">
+                <p className="font-medium text-sm sm:text-base">Selective transfer</p>
+                <p className="text-xs sm:text-sm text-text-muted">Move provider accounts and combos without deleting unrelated destination data.</p>
+              </div>
+              <div className="flex flex-col sm:flex-row gap-2">
+                <Button variant="secondary" icon="file_export" onClick={() => setTransferMode("export")} className="w-full sm:w-auto">
+                  Export Selected
+                </Button>
+                <Button variant="outline" icon="upload_file" onClick={() => setTransferMode("import")} className="w-full sm:w-auto">
+                  Import Selected
+                </Button>
+              </div>
+            </div>
+            {dbStatus.message && (
+              <p className={`text-sm ${dbStatus.type === "error" ? "text-red-500" : "text-green-600 dark:text-green-400"}`}>
+                {dbStatus.message}
+              </p>
+            )}
+          </div>
+        </Card>
+
+        {/* Appearance */}
+        <Card>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-3">
+              <div className="size-10 rounded-lg bg-purple-500/10 text-purple-500 flex items-center justify-center shrink-0">
+                <span className="material-symbols-outlined text-[20px]">palette</span>
+              </div>
+              <div>
+                <h3 className="text-base sm:text-lg font-semibold">Appearance</h3>
+                <p className="text-xs sm:text-sm text-text-muted">Choose how the dashboard looks</p>
+              </div>
+            </div>
+            <div className="inline-flex p-1 rounded-lg bg-black/5 dark:bg-white/5 w-full sm:w-auto" aria-label="Theme">
               {["light", "dark", "system"].map((option) => (
                 <button
                   key={option}
                   type="button"
                   onClick={() => setTheme(option)}
+                  aria-pressed={theme === option}
                   className={cn(
                     "flex items-center justify-center gap-1 sm:gap-1.5 px-2 sm:px-3 py-1.5 rounded-md font-medium transition-all flex-1 sm:flex-initial",
                     theme === option
@@ -792,46 +880,6 @@ export default function ProfilePage() {
                 </button>
               ))}
             </div>
-          </div>
-          <div className="flex flex-col gap-3 pt-4 border-t border-border">
-            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between p-3 rounded-lg bg-bg border border-border gap-2">
-              <div>
-                <p className="font-medium text-sm sm:text-base">Database Location</p>
-                <p className="text-xs sm:text-sm text-text-muted font-mono break-all">~/.9router/db/data.sqlite</p>
-              </div>
-            </div>
-            <div className="flex flex-col sm:flex-row gap-2">
-              <Button
-                variant="secondary"
-                icon="download"
-                onClick={() => setDbAuth({ open: true, mode: "export", password: "" })}
-                loading={dbLoading}
-                className="w-full sm:w-auto"
-              >
-                Download Backup
-              </Button>
-              <Button
-                variant="outline"
-                icon="upload"
-                onClick={() => importFileRef.current?.click()}
-                disabled={dbLoading}
-                className="w-full sm:w-auto"
-              >
-                Import Backup
-              </Button>
-              <input
-                ref={importFileRef}
-                type="file"
-                accept="application/json,.json"
-                className="hidden"
-                onChange={handleImportDatabase}
-              />
-            </div>
-            {dbStatus.message && (
-              <p className={`text-sm ${dbStatus.type === "error" ? "text-red-500" : "text-green-600 dark:text-green-400"}`}>
-                {dbStatus.message}
-              </p>
-            )}
           </div>
         </Card>
 
@@ -1639,7 +1687,7 @@ export default function ProfilePage() {
         {/* App Info */}
         <div className="text-center text-xs sm:text-sm text-text-muted py-4">
           <p>{APP_CONFIG.name} v{APP_CONFIG.version}</p>
-          <p className="mt-1">Local Mode - All data stored on your machine</p>
+          <p className="mt-1">Configuration stored in the 9Router data directory</p>
         </div>
       </div>
 
@@ -1682,6 +1730,11 @@ export default function ProfilePage() {
         <p className="text-text-muted mb-3 text-sm">
           Enter your current password to {dbAuth.mode === "export" ? "export" : "import"} the database.
         </p>
+        {dbAuth.mode === "import" && (
+          <p className="mb-3 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-600 dark:text-red-400">
+            Full restore replaces current providers, combos, keys, and settings. Use Selective Transfer to preserve unrelated destination data.
+          </p>
+        )}
         <Input
           type="password"
           value={dbAuth.password}
@@ -1691,6 +1744,15 @@ export default function ProfilePage() {
           autoFocus
         />
       </Modal>
+      {transferMode && (
+        <ProviderComboTransferModal
+          key={transferMode}
+          isOpen
+          mode={transferMode}
+          onClose={() => setTransferMode("")}
+          onComplete={(message) => setDbStatus({ type: "success", message })}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/api/auth/status/route.js
+++ b/src/app/api/auth/status/route.js
@@ -35,7 +35,7 @@ export async function GET() {
       oidcLoginLabel: (settings.oidcLoginLabel || "Sign in with OIDC").trim() || "Sign in with OIDC",
       samlConfigured: isSamlConfigured(settings),
       samlLoginLabel: (settings.samlLoginLabel || "Sign in with SAML SSO").trim() || "Sign in with SAML SSO",
-      hasPassword: !!settings.password,
+      hasPassword: !!(settings.password || process.env.INITIAL_PASSWORD),
       displayName,
       loginMethod,
       authenticated: !!session,

--- a/src/app/api/settings/route.js
+++ b/src/app/api/settings/route.js
@@ -27,7 +27,7 @@ export async function GET() {
       ...safeSettings, 
       enableRequestLogs,
       enableTranslator,
-      hasPassword: !!password
+      hasPassword: !!(password || process.env.INITIAL_PASSWORD)
     }, { headers: SETTINGS_RESPONSE_HEADERS });
   } catch (error) {
     console.log("Error getting settings:", error);

--- a/src/app/api/settings/storage/route.js
+++ b/src/app/api/settings/storage/route.js
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { DATA_FILE } from "@/lib/db/paths.js";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json({ databaseLocation: DATA_FILE });
+}

--- a/src/app/api/settings/transfer/catalog/route.js
+++ b/src/app/api/settings/transfer/catalog/route.js
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { getTransferCatalog } from "@/lib/localDb";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    return NextResponse.json(await getTransferCatalog());
+  } catch (error) {
+    console.log("[Transfer] Failed to load catalog:", error.message);
+    return NextResponse.json({ error: "Failed to load transferable items" }, { status: 500 });
+  }
+}

--- a/src/app/api/settings/transfer/export/route.js
+++ b/src/app/api/settings/transfer/export/route.js
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { createTransferBundle } from "@/lib/localDb";
+import { verifyDashboardPassword } from "@/lib/auth/dashboardSession";
+
+export async function POST(request) {
+  try {
+    const { password, providerConnectionIds, comboIds } = await request.json();
+    const providerSelection = Array.isArray(providerConnectionIds) ? providerConnectionIds : [];
+    // Combo-only exports contain no credentials and should remain usable when
+    // a dashboard is configured without a password. Provider exports still
+    // require the existing dashboard password check.
+    if (providerSelection.length > 0 && !(await verifyDashboardPassword(password))) {
+      return NextResponse.json({ error: "Invalid password" }, { status: 401 });
+    }
+    return NextResponse.json(await createTransferBundle({ providerConnectionIds, comboIds }));
+  } catch (error) {
+    console.log("[Transfer] Export failed:", error.message);
+    return NextResponse.json({ error: error.message || "Failed to export selection" }, { status: 400 });
+  }
+}

--- a/src/app/api/settings/transfer/import/route.js
+++ b/src/app/api/settings/transfer/import/route.js
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { applySelectiveTransfer } from "@/lib/localDb";
+import { verifyDashboardPassword } from "@/lib/auth/dashboardSession";
+import { resetComboRotation } from "open-sse/services/combo.js";
+
+export async function POST(request) {
+  try {
+    const { password, payload, resolutions } = await request.json();
+    const providerPayload = Array.isArray(payload?.providerConnections) ? payload.providerConnections : [];
+    // A metadata-only combo transfer does not contain credentials. Provider
+    // imports retain the existing dashboard password protection.
+    if (providerPayload.length > 0 && !(await verifyDashboardPassword(password))) {
+      return NextResponse.json({ error: "Invalid password" }, { status: 401 });
+    }
+    const result = await applySelectiveTransfer(payload, resolutions || {});
+    resetComboRotation();
+    return NextResponse.json(result);
+  } catch (error) {
+    console.log("[Transfer] Import failed:", error.message);
+    return NextResponse.json({ error: error.message || "Failed to import selection" }, { status: 400 });
+  }
+}

--- a/src/app/api/settings/transfer/preview/route.js
+++ b/src/app/api/settings/transfer/preview/route.js
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { planSelectiveTransfer } from "@/lib/localDb";
+
+export async function POST(request) {
+  try {
+    const { payload } = await request.json();
+    return NextResponse.json(await planSelectiveTransfer(payload));
+  } catch (error) {
+    console.log("[Transfer] Preview failed:", error.message);
+    return NextResponse.json({ error: error.message || "Invalid transfer file" }, { status: 400 });
+  }
+}

--- a/src/lib/db/index.js
+++ b/src/lib/db/index.js
@@ -55,6 +55,31 @@ export {
   getDisabledModels, getDisabledByProvider, disableModels, enableModels,
 } from "./repos/disabledModelsRepo.js";
 
+// Selective provider + combo transfer
+export async function getTransferCatalog() {
+  const db = await getAdapter();
+  const { getTransferCatalogFromDb } = await import("./transfer/providerComboTransfer.js");
+  return getTransferCatalogFromDb(db);
+}
+
+export async function createTransferBundle(selection) {
+  const db = await getAdapter();
+  const { createTransferBundleFromDb } = await import("./transfer/providerComboTransfer.js");
+  return createTransferBundleFromDb(db, selection);
+}
+
+export async function planSelectiveTransfer(payload) {
+  const db = await getAdapter();
+  const { planTransferFromDb } = await import("./transfer/providerComboTransfer.js");
+  return planTransferFromDb(db, payload);
+}
+
+export async function applySelectiveTransfer(payload, resolutions) {
+  const db = await getAdapter();
+  const { applyTransferToDb } = await import("./transfer/providerComboTransfer.js");
+  return applyTransferToDb(db, payload, resolutions);
+}
+
 // Usage
 export {
   statsEmitter, trackPendingRequest, getActiveRequests,
@@ -89,7 +114,6 @@ export async function exportDb() {
   for (const r of db.all(`SELECT key, value FROM kv WHERE scope = 'customModels'`)) out.customModels.push(parseJson(r.value));
   for (const r of db.all(`SELECT key, value FROM kv WHERE scope = 'mitmAlias'`)) out.mitmAlias[r.key] = parseJson(r.value);
   for (const r of db.all(`SELECT key, value FROM kv WHERE scope = 'pricing'`)) out.pricing[r.key] = parseJson(r.value);
-
   return out;
 }
 

--- a/src/lib/db/repos/connectionsRepo.js
+++ b/src/lib/db/repos/connectionsRepo.js
@@ -67,6 +67,38 @@ function deriveConnectionName(data, fallbackName) {
   return fallbackName;
 }
 
+// Shared provider-specific identity matcher. Account creation and selective
+// transfer must use the same rules so imports cannot collapse identities that
+// a normal login would keep separate (notably Codex workspaces and cross-IdP accounts).
+export function findMatchingProviderConnection(existingConnections, data) {
+  const all = Array.isArray(existingConnections) ? existingConnections : [];
+  if (data.authType === "oauth" && data.email) {
+    const incomingUsername = data.providerSpecificData?.username;
+    const incomingWs = data.providerSpecificData?.chatgptAccountId;
+    return all.find((connection) => {
+      if (connection.provider !== data.provider || connection.authType !== "oauth" || connection.email !== data.email) return false;
+
+      if (data.provider === "codex") {
+        const existingWs = connection.providerSpecificData?.chatgptAccountId;
+        return Boolean(incomingWs && existingWs && incomingWs === existingWs);
+      }
+
+      const existingWs = connection.providerSpecificData?.chatgptAccountId;
+      if (incomingWs || existingWs) return Boolean(incomingWs && existingWs && incomingWs === existingWs);
+
+      const existingUsername = connection.providerSpecificData?.username;
+      if (incomingUsername || existingUsername) {
+        return Boolean(incomingUsername && existingUsername && incomingUsername === existingUsername);
+      }
+      return true;
+    }) || null;
+  }
+  if (data.authType === "apikey" && data.name) {
+    return all.find((connection) => connection.provider === data.provider && connection.authType === "apikey" && connection.name === data.name) || null;
+  }
+  return null;
+}
+
 export async function getProviderConnections(filter = {}) {
   const db = await getAdapter();
   const where = [];
@@ -107,43 +139,7 @@ export async function createProviderConnection(data) {
   db.transaction(() => {
     const all = db.all(`SELECT * FROM providerConnections WHERE provider = ?`, [data.provider]).map(rowToConn);
 
-    let existing = null;
-    if (data.authType === "oauth" && data.email) {
-      const incomingUsername = data.providerSpecificData?.username;
-      const incomingWs = data.providerSpecificData?.chatgptAccountId;
-      existing = all.find(c => {
-        if (c.authType !== "oauth" || c.email !== data.email) return false;
-
-        // Codex/OpenAI can issue multiple OAuth grants for the same email.
-        // Refresh tokens are rotated single-use; collapsing a new login onto an
-        // existing bare-email row overwrites the first account's token pair and
-        // makes it look "invalid" after adding a second account. Only update an
-        // existing Codex row when both rows expose the same ChatGPT account ID.
-        if (data.provider === "codex") {
-          const existingWs = c.providerSpecificData?.chatgptAccountId;
-          return !!incomingWs && !!existingWs && incomingWs === existingWs;
-        }
-
-        // Workspace providers use workspace ID when both sides have it
-        const existingWs = c.providerSpecificData?.chatgptAccountId;
-        if (incomingWs && existingWs) return incomingWs === existingWs;
-        if (incomingWs && !existingWs) return false;
-        if (!incomingWs && existingWs) return false;
-        // Non-workspace providers: match on (email + username) so cross-IdP
-        // accounts don't overwrite each other. Require username on both sides
-        // — if only one side has it, treat as a distinct identity rather than
-        // collapsing onto the bare-email fallback (which would re-introduce
-        // the cross-IdP overwrite).
-        const existingUsername = c.providerSpecificData?.username;
-        if (incomingUsername && existingUsername) {
-          return incomingUsername === existingUsername;
-        }
-        if (incomingUsername || existingUsername) return false;
-        return true;
-      });
-    } else if (data.authType === "apikey" && data.name) {
-      existing = all.find(c => c.authType === "apikey" && c.name === data.name);
-    }
+    const existing = findMatchingProviderConnection(all, data);
     // access_token: never dedup — user manages duplicates manually
 
     if (existing) {

--- a/src/lib/db/transfer/providerComboTransfer.js
+++ b/src/lib/db/transfer/providerComboTransfer.js
@@ -1,0 +1,551 @@
+import { randomUUID } from "node:crypto";
+import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
+import { findMatchingProviderConnection } from "../repos/connectionsRepo.js";
+
+export const TRANSFER_FORMAT = "9router-provider-combo-transfer";
+export const TRANSFER_VERSION = 1;
+const SOURCE_VERSION = process.env.npm_package_version || null;
+
+const COMBO_NAME_PATTERN = /^[a-zA-Z0-9_.-]+$/;
+const MAX_ITEMS = 5000;
+const MAX_PAYLOAD_BYTES = 10 * 1024 * 1024;
+const TRANSIENT_CONNECTION_FIELDS = new Set([
+  "testStatus", "lastTested", "lastError", "lastErrorAt", "rateLimitedUntil",
+  "errorCode", "consecutiveUseCount", "lastRefreshAt", "modelLocks",
+]);
+const TARGET_PROXY_FIELDS = new Set([
+  "proxyPoolId", "connectionProxyEnabled", "connectionProxyUrl", "connectionNoProxy",
+]);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function stable(value) {
+  if (Array.isArray(value)) return `[${value.map(stable).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stable(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function asObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`);
+  return value;
+}
+
+function asArray(value, label) {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) fail(`${label} must be an array`);
+  if (value.length > MAX_ITEMS) fail(`${label} exceeds the ${MAX_ITEMS}-item limit`);
+  return value;
+}
+
+function assertUnique(items, keyFor, label) {
+  const seen = new Set();
+  for (const item of items) {
+    const key = keyFor(item);
+    if (seen.has(key)) fail(`${label} contains duplicate identity: ${key}`);
+    seen.add(key);
+  }
+}
+
+function connectionFromRow(row) {
+  return {
+    ...parseJson(row.data, {}),
+    id: row.id,
+    provider: row.provider,
+    authType: row.authType,
+    name: row.name,
+    email: row.email,
+    priority: row.priority,
+    isActive: row.isActive === 1 || row.isActive === true,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function nodeFromRow(row) {
+  return {
+    ...parseJson(row.data, {}),
+    id: row.id,
+    type: row.type,
+    name: row.name,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function comboFromRow(row) {
+  return {
+    id: row.id,
+    name: row.name,
+    kind: row.kind,
+    models: parseJson(row.models, []),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function flattenDataObject(value) {
+  if (typeof value?.data !== "string") return { ...(value || {}) };
+  const { data, ...columns } = value;
+  return { ...parseJson(data, {}), ...columns };
+}
+
+export function sanitizeConnection(value) {
+  const connection = flattenDataObject(asObject(value, "Provider connection"));
+  if (!connection.id || !connection.provider) fail("Provider connection requires id and provider");
+  const clean = { ...connection, authType: connection.authType || "oauth" };
+  delete clean.priority;
+  delete clean.isActive;
+  delete clean.createdAt;
+  delete clean.updatedAt;
+  for (const field of TRANSIENT_CONNECTION_FIELDS) delete clean[field];
+  if (clean.providerSpecificData && typeof clean.providerSpecificData === "object") {
+    clean.providerSpecificData = { ...clean.providerSpecificData };
+    for (const field of TARGET_PROXY_FIELDS) delete clean.providerSpecificData[field];
+    if (Object.keys(clean.providerSpecificData).length === 0) delete clean.providerSpecificData;
+  }
+  return clean;
+}
+
+function sanitizeNode(value) {
+  const node = flattenDataObject(asObject(value, "Provider node"));
+  if (!node.id) fail("Provider node requires id");
+  delete node.createdAt;
+  delete node.updatedAt;
+  return node;
+}
+
+function sanitizeCombo(value) {
+  const combo = asObject(value, "Combo");
+  if (!combo.id || !combo.name || !COMBO_NAME_PATTERN.test(combo.name)) fail("Combo requires a valid id and name");
+  const models = asArray(combo.models, `Models for combo ${combo.name}`);
+  if (models.some((model) => typeof model !== "string" || !model.trim())) fail(`Combo ${combo.name} has an invalid model`);
+  return { id: combo.id, name: combo.name, kind: combo.kind || null, models: models.map((model) => model.trim()) };
+}
+
+function sanitizeAliases(value) {
+  const aliases = value === undefined ? {} : asObject(value, "Model aliases");
+  const clean = {};
+  for (const [key, target] of Object.entries(aliases)) {
+    if (typeof key !== "string" || !key.trim() || typeof target !== "string" || !target.trim()) {
+      fail("Model aliases must contain non-empty string keys and values");
+    }
+    clean[key.trim()] = target.trim();
+  }
+  return clean;
+}
+
+function sanitizeCustomModels(value) {
+  return asArray(value, "Custom models").map((model) => {
+    asObject(model, "Custom model");
+    if (!model.providerAlias || !model.id) fail("Custom model requires providerAlias and id");
+    return {
+      providerAlias: String(model.providerAlias),
+      id: String(model.id),
+      type: String(model.type || "llm"),
+      name: String(model.name || model.id),
+    };
+  });
+}
+
+function referencedModelStrings(combos) {
+  return new Set(combos.flatMap((combo) => combo.models));
+}
+
+function referencedPrefixes(models, aliases, customModels) {
+  const prefixes = new Set();
+  const collect = (model) => {
+    if (typeof model === "string" && model.includes("/")) prefixes.add(model.split("/", 1)[0]);
+  };
+  for (const model of models) collect(model);
+  for (const [key, target] of Object.entries(aliases)) {
+    if (models.has(key) || models.has(target)) collect(target);
+  }
+  for (const model of customModels) {
+    if (models.has(`${model.providerAlias}/${model.id}`) || models.has(model.id)) prefixes.add(model.providerAlias);
+  }
+  return prefixes;
+}
+
+function dependencySubset({ providerConnections, providerNodes, combos, modelAliases, customModels }) {
+  const models = referencedModelStrings(combos);
+  const aliases = Object.fromEntries(Object.entries(modelAliases).filter(([key, value]) => models.has(key) || models.has(value)));
+  const custom = customModels.filter((model) => models.has(`${model.providerAlias}/${model.id}`) || models.has(model.id));
+  const prefixes = referencedPrefixes(models, aliases, custom);
+  const providerIds = new Set(providerConnections.map((connection) => connection.provider));
+  const nodes = providerNodes.filter((node) => providerIds.has(node.id) || (node.prefix && prefixes.has(node.prefix)));
+  return { providerConnections, providerNodes: nodes, combos, modelAliases: aliases, customModels: custom };
+}
+
+export function parseTransferPayload(input) {
+  const raw = Array.isArray(input) ? { providerConnections: input } : asObject(input, "Transfer payload");
+  if (Buffer.byteLength(JSON.stringify(raw), "utf8") > MAX_PAYLOAD_BYTES) fail("Transfer payload exceeds the 10 MB limit");
+  if (raw.format && (raw.format !== TRANSFER_FORMAT || raw.version !== TRANSFER_VERSION)) {
+    fail("Unsupported selective-transfer format or version");
+  }
+  const providerConnections = asArray(raw.providerConnections, "Provider connections").map(sanitizeConnection);
+  const providerNodes = asArray(raw.providerNodes, "Provider nodes").map(sanitizeNode);
+  const combos = asArray(raw.combos, "Combos").map(sanitizeCombo);
+  const comboStrategies = raw.comboStrategies === undefined
+    ? (raw.settings?.comboStrategies || {})
+    : asObject(raw.comboStrategies, "Combo strategies");
+  const modelAliases = sanitizeAliases(raw.modelAliases);
+  const customModels = sanitizeCustomModels(raw.customModels);
+  assertUnique(providerConnections, (item) => item.id, "Provider connections");
+  assertUnique(providerNodes, (item) => item.id, "Provider nodes");
+  assertUnique(combos, (item) => item.id, "Combos");
+  assertUnique(combos, (item) => item.name, "Combos");
+  assertUnique(customModels, customModelKey, "Custom models");
+  const scoped = dependencySubset({ providerConnections, providerNodes, combos, modelAliases, customModels });
+  return {
+    format: TRANSFER_FORMAT,
+    version: TRANSFER_VERSION,
+    sourceVersion: raw.sourceVersion || null,
+    exportedAt: raw.exportedAt || null,
+    ...scoped,
+    comboStrategies: Object.fromEntries(scoped.combos
+      .filter((combo) => comboStrategies[combo.name] && typeof comboStrategies[combo.name] === "object")
+      .map((combo) => [combo.name, comboStrategies[combo.name]])),
+  };
+}
+
+function readAliases(db) {
+  return Object.fromEntries(db.all("SELECT key, value FROM kv WHERE scope = 'modelAliases'")
+    .map((row) => [row.key, parseJson(row.value, "")]
+    ).filter(([, value]) => typeof value === "string"));
+}
+
+function readCustomModels(db) {
+  return db.all("SELECT value FROM kv WHERE scope = 'customModels'").map((row) => parseJson(row.value, null)).filter(Boolean);
+}
+
+function readSettings(db) {
+  const row = db.get("SELECT data FROM settings WHERE id = 1");
+  return row ? parseJson(row.data, {}) : {};
+}
+
+export function getTransferCatalogFromDb(db) {
+  return {
+    providerConnections: db.all("SELECT * FROM providerConnections ORDER BY provider, priority, name")
+      .map(connectionFromRow)
+      .map(({ id, provider, authType, name, email }) => ({ id, provider, authType, name, email })),
+    combos: db.all("SELECT * FROM combos ORDER BY name").map(comboFromRow)
+      .map(({ id, name, kind, models }) => ({ id, name, kind, modelCount: models.length })),
+  };
+}
+
+export function createTransferBundleFromDb(db, selection = {}) {
+  const providerIds = new Set(asArray(selection.providerConnectionIds, "Selected provider IDs").map(String));
+  const comboIds = new Set(asArray(selection.comboIds, "Selected combo IDs").map(String));
+  if (providerIds.size === 0 && comboIds.size === 0) fail("Select at least one provider account or combo");
+
+  const providerConnections = db.all("SELECT * FROM providerConnections")
+    .map(connectionFromRow).filter((connection) => providerIds.has(connection.id)).map(sanitizeConnection);
+  const combos = db.all("SELECT * FROM combos").map(comboFromRow).filter((combo) => comboIds.has(combo.id)).map(sanitizeCombo);
+  if (providerConnections.length !== providerIds.size) fail("One or more selected provider accounts no longer exist");
+  if (combos.length !== comboIds.size) fail("One or more selected combos no longer exist");
+
+  const allNodes = db.all("SELECT * FROM providerNodes").map(nodeFromRow).map(sanitizeNode);
+  const allAliases = readAliases(db);
+  const allCustomModels = readCustomModels(db);
+  const scoped = dependencySubset({ providerConnections, providerNodes: allNodes, combos, modelAliases: allAliases, customModels: allCustomModels });
+  const settings = readSettings(db);
+  return {
+    format: TRANSFER_FORMAT,
+    version: TRANSFER_VERSION,
+    sourceVersion: SOURCE_VERSION,
+    exportedAt: new Date().toISOString(),
+    ...scoped,
+    comboStrategies: Object.fromEntries(combos
+      .filter((combo) => settings.comboStrategies?.[combo.name])
+      .map((combo) => [combo.name, settings.comboStrategies[combo.name]])),
+  };
+}
+
+function nodePortable(node) {
+  const { id, name, ...rest } = node;
+  return { name: name || null, ...rest };
+}
+
+function nodePlan(db, payload) {
+  const existing = db.all("SELECT * FROM providerNodes").map(nodeFromRow).map(sanitizeNode);
+  return payload.providerNodes.map((source) => {
+    const byId = existing.find((target) => target.id === source.id);
+    const byPrefix = source.prefix ? existing.find((target) => target.prefix === source.prefix) : null;
+    const target = byId || byPrefix || null;
+    const status = !target ? "new" : stable(nodePortable(target)) === stable(nodePortable(source)) ? "identical" : "conflict";
+    return {
+      sourceId: source.id,
+      targetId: target?.id || source.id,
+      name: source.name || source.prefix || source.id,
+      prefix: source.prefix || null,
+      status,
+      recommended: status === "new" ? "add" : "keep",
+    };
+  });
+}
+
+function remapProvider(provider, nodes) {
+  return nodes.find((node) => node.sourceId === provider)?.targetId || provider;
+}
+
+function findConnectionMatch(existing, source) {
+  const idMatch = existing.find((target) => target.id === source.id);
+  if (idMatch) return idMatch;
+  const sharedMatch = findMatchingProviderConnection(existing, source);
+  if (sharedMatch) return sharedMatch;
+  if (source.authType === "access_token" && source.accessToken) {
+    return existing.find((target) => target.provider === source.provider && target.authType === source.authType && target.accessToken === source.accessToken) || null;
+  }
+  return null;
+}
+
+function connectionComparable(connection) {
+  const clean = sanitizeConnection(connection);
+  delete clean.id;
+  return clean;
+}
+
+function connectionPlan(db, payload, nodes) {
+  const existing = db.all("SELECT * FROM providerConnections").map(connectionFromRow).map(sanitizeConnection);
+  return payload.providerConnections.map((original) => {
+    const source = { ...original, provider: remapProvider(original.provider, nodes) };
+    const idCollision = existing.find((target) => target.id === source.id && (target.provider !== source.provider || target.authType !== source.authType));
+    const target = idCollision || findConnectionMatch(existing, source);
+    const status = idCollision
+      ? "ambiguous"
+      : !target
+        ? "new"
+        : stable(connectionComparable(target)) === stable(connectionComparable(source)) ? "identical" : "conflict";
+    return {
+      sourceId: original.id,
+      targetId: target?.id || null,
+      provider: source.provider,
+      authType: source.authType,
+      label: source.name || source.email || `${source.provider} account`,
+      status,
+      recommended: status === "new" ? "add" : "skip",
+    };
+  });
+}
+
+function comboPlan(db, payload) {
+  const existing = db.all("SELECT * FROM combos").map(comboFromRow);
+  const aliases = readAliases(db);
+  const settings = readSettings(db);
+  return payload.combos.map((source) => {
+    const target = existing.find((combo) => combo.name === source.name) || null;
+    const aliasCollision = Object.prototype.hasOwnProperty.call(aliases, source.name);
+    const sourceStrategy = payload.comboStrategies[source.name] || null;
+    const targetStrategy = target ? settings.comboStrategies?.[target.name] || null : null;
+    const status = aliasCollision && !target
+      ? "name_conflict"
+      : !target
+        ? "new"
+        : stable({ kind: target.kind || null, models: target.models, strategy: targetStrategy }) === stable({ kind: source.kind || null, models: source.models, strategy: sourceStrategy })
+          ? "identical" : "conflict";
+    return {
+      sourceId: source.id,
+      targetId: target?.id || null,
+      name: source.name,
+      kind: source.kind,
+      modelCount: source.models.length,
+      status,
+      recommended: status === "new" ? "add" : "skip",
+    };
+  });
+}
+
+function aliasPlan(db, payload) {
+  const existing = readAliases(db);
+  return Object.entries(payload.modelAliases).map(([key, value]) => ({
+    key,
+    value,
+    status: existing[key] === undefined ? "new" : existing[key] === value ? "identical" : "conflict",
+    recommended: existing[key] === undefined ? "add" : "skip",
+  }));
+}
+
+function customModelKey(model) {
+  return `${model.providerAlias}|${model.id}|${model.type || "llm"}`;
+}
+
+function customModelPlan(db, payload) {
+  const existing = new Map(readCustomModels(db).map((model) => [customModelKey(model), model]));
+  return payload.customModels.map((model) => {
+    const key = customModelKey(model);
+    const target = existing.get(key);
+    return {
+      key,
+      model,
+      status: !target ? "new" : stable(target) === stable(model) ? "identical" : "conflict",
+      recommended: !target ? "add" : "skip",
+    };
+  });
+}
+
+export function planTransferFromDb(db, input) {
+  const payload = parseTransferPayload(input);
+  const providerNodes = nodePlan(db, payload);
+  const providerConnections = connectionPlan(db, payload, providerNodes);
+  const combos = comboPlan(db, payload);
+  const modelAliases = aliasPlan(db, payload);
+  const customModels = customModelPlan(db, payload);
+  const all = [...providerNodes, ...providerConnections, ...combos, ...modelAliases, ...customModels];
+  const counts = all.reduce((result, item) => {
+    result[item.status] = (result[item.status] || 0) + 1;
+    return result;
+  }, {});
+  return {
+    format: payload.format,
+    version: payload.version,
+    sourceVersion: payload.sourceVersion,
+    summary: {
+      providerConnections: providerConnections.length,
+      combos: combos.length,
+      providerNodes: providerNodes.length,
+      modelAliases: modelAliases.length,
+      customModels: customModels.length,
+      counts,
+      deletions: 0,
+    },
+    providerConnections,
+    combos,
+    dependencies: { providerNodes, modelAliases, customModels },
+  };
+}
+
+function dataColumns(value, columns) {
+  const rest = { ...value };
+  for (const column of columns) delete rest[column];
+  return rest;
+}
+
+function targetProxyFields(connection) {
+  const source = connection.providerSpecificData || {};
+  return Object.fromEntries([...TARGET_PROXY_FIELDS].filter((key) => source[key] !== undefined).map((key) => [key, source[key]]));
+}
+
+function targetRuntimeFields(connection) {
+  return Object.fromEntries([...TRANSIENT_CONNECTION_FIELDS]
+    .filter((key) => connection[key] !== undefined)
+    .map((key) => [key, connection[key]]));
+}
+
+function validAction(action, allowed, fallback) {
+  return allowed.includes(action) ? action : fallback;
+}
+
+function importNode(db, source, targetId, now, replace) {
+  const data = dataColumns(source, ["id", "type", "name"]);
+  if (replace) {
+    db.run("UPDATE providerNodes SET type = ?, name = ?, data = ?, updatedAt = ? WHERE id = ?", [source.type || null, source.name || null, stringifyJson(data), now, targetId]);
+  } else {
+    db.run("INSERT INTO providerNodes(id, type, name, data, createdAt, updatedAt) VALUES(?, ?, ?, ?, ?, ?)", [targetId, source.type || null, source.name || null, stringifyJson(data), now, now]);
+  }
+}
+
+export function applyTransferToDb(db, input, resolutions = {}) {
+  const payload = parseTransferPayload(input);
+  let result;
+  db.transaction(() => {
+    const plan = planTransferFromDb(db, payload);
+    const now = new Date().toISOString();
+    const applied = { providerConnections: 0, combos: 0, providerNodes: 0, modelAliases: 0, customModels: 0, skipped: 0 };
+
+    for (const item of plan.dependencies.providerNodes) {
+      const source = payload.providerNodes.find((node) => node.id === item.sourceId);
+      const requested = resolutions[`node:${item.sourceId}`]?.action;
+      const action = validAction(requested, ["add", "keep", "replace", "skip"], item.recommended);
+      if (action === "add" && item.status === "new") {
+        importNode(db, source, item.targetId, now, false);
+        applied.providerNodes++;
+      } else if (action === "replace" && item.targetId) {
+        importNode(db, source, item.targetId, now, true);
+        applied.providerNodes++;
+      } else applied.skipped++;
+    }
+
+    for (const item of plan.providerConnections) {
+      const original = payload.providerConnections.find((connection) => connection.id === item.sourceId);
+      const source = { ...original, provider: item.provider };
+      const requested = resolutions[`provider:${item.sourceId}`]?.action;
+      const action = validAction(requested, ["add", "replace", "skip"], item.recommended);
+      if (action === "add" && item.status === "new") {
+        const collision = db.get("SELECT id FROM providerConnections WHERE id = ?", [source.id]);
+        const id = collision ? randomUUID() : source.id;
+        const max = db.get("SELECT MAX(priority) AS priority FROM providerConnections WHERE provider = ?", [source.provider]);
+        const priority = Number(max?.priority || 0) + 1;
+        const data = dataColumns(source, ["id", "provider", "authType", "name", "email"]);
+        db.run("INSERT INTO providerConnections(id, provider, authType, name, email, priority, isActive, data, createdAt, updatedAt) VALUES(?, ?, ?, ?, ?, ?, 1, ?, ?, ?)", [id, source.provider, source.authType, source.name || null, source.email || null, priority, stringifyJson(data), now, now]);
+        applied.providerConnections++;
+      } else if (action === "replace" && item.targetId && item.status !== "ambiguous") {
+        const targetRow = db.get("SELECT * FROM providerConnections WHERE id = ?", [item.targetId]);
+        const target = connectionFromRow(targetRow);
+        const data = dataColumns(source, ["id", "provider", "authType", "name", "email"]);
+        const proxy = targetProxyFields(target);
+        if (Object.keys(proxy).length > 0) data.providerSpecificData = { ...(data.providerSpecificData || {}), ...proxy };
+        Object.assign(data, targetRuntimeFields(target));
+        db.run("UPDATE providerConnections SET provider = ?, authType = ?, name = ?, email = ?, data = ?, updatedAt = ? WHERE id = ?", [source.provider, source.authType, source.name || null, source.email || null, stringifyJson(data), now, item.targetId]);
+        applied.providerConnections++;
+      } else applied.skipped++;
+    }
+
+    for (const item of plan.dependencies.modelAliases) {
+      const requested = resolutions[`alias:${item.key}`]?.action;
+      const action = validAction(requested, ["add", "replace", "skip"], item.recommended);
+      if ((action === "add" && item.status === "new") || action === "replace") {
+        db.run("INSERT INTO kv(scope, key, value) VALUES('modelAliases', ?, ?) ON CONFLICT(scope, key) DO UPDATE SET value = excluded.value", [item.key, stringifyJson(item.value)]);
+        applied.modelAliases++;
+      } else applied.skipped++;
+    }
+
+    for (const item of plan.dependencies.customModels) {
+      const requested = resolutions[`custom:${item.key}`]?.action;
+      const action = validAction(requested, ["add", "replace", "skip"], item.recommended);
+      if ((action === "add" && item.status === "new") || action === "replace") {
+        db.run("INSERT INTO kv(scope, key, value) VALUES('customModels', ?, ?) ON CONFLICT(scope, key) DO UPDATE SET value = excluded.value", [item.key, stringifyJson(item.model)]);
+        applied.customModels++;
+      } else applied.skipped++;
+    }
+
+    const settings = readSettings(db);
+    const comboStrategies = { ...(settings.comboStrategies || {}) };
+    for (const item of plan.combos) {
+      const source = payload.combos.find((combo) => combo.id === item.sourceId);
+      const resolution = resolutions[`combo:${item.sourceId}`] || {};
+      const action = validAction(resolution.action, ["add", "replace", "merge", "rename", "skip"], item.recommended);
+      let targetName = source.name;
+      if (action === "rename") {
+        targetName = String(resolution.renameTo || "").trim();
+        if (!COMBO_NAME_PATTERN.test(targetName)) fail(`Combo ${source.name} requires a valid new name`);
+        if (db.get("SELECT id FROM combos WHERE name = ?", [targetName])) fail(`Combo name already exists: ${targetName}`);
+      }
+      if ((action === "add" && item.status === "new") || action === "rename") {
+        const collision = db.get("SELECT id FROM combos WHERE id = ?", [source.id]);
+        db.run("INSERT INTO combos(id, name, kind, models, createdAt, updatedAt) VALUES(?, ?, ?, ?, ?, ?)", [collision ? randomUUID() : source.id, targetName, source.kind, stringifyJson(source.models), now, now]);
+        const strategy = payload.comboStrategies[source.name];
+        if (strategy) comboStrategies[targetName] = strategy;
+        applied.combos++;
+      } else if (action === "replace" && item.targetId) {
+        db.run("UPDATE combos SET kind = ?, models = ?, updatedAt = ? WHERE id = ?", [source.kind, stringifyJson(source.models), now, item.targetId]);
+        const strategy = payload.comboStrategies[source.name];
+        if (strategy) comboStrategies[source.name] = strategy;
+        else delete comboStrategies[source.name];
+        applied.combos++;
+      } else if (action === "merge" && item.targetId) {
+        const target = comboFromRow(db.get("SELECT * FROM combos WHERE id = ?", [item.targetId]));
+        const models = [...target.models, ...source.models.filter((model) => !target.models.includes(model))];
+        db.run("UPDATE combos SET models = ?, updatedAt = ? WHERE id = ?", [stringifyJson(models), now, item.targetId]);
+        applied.combos++;
+      } else applied.skipped++;
+    }
+    settings.comboStrategies = comboStrategies;
+    db.run("INSERT INTO settings(id, data) VALUES(1, ?) ON CONFLICT(id) DO UPDATE SET data = excluded.data", [stringifyJson(settings)]);
+    result = { success: true, applied, deletions: 0 };
+  });
+  return result;
+}

--- a/src/lib/localDb.js
+++ b/src/lib/localDb.js
@@ -18,4 +18,5 @@ export {
   getMitmAlias, setMitmAliasAll,
   getPricing, getPricingForModel, updatePricing, resetPricing, resetAllPricing,
   exportDb, importDb,
+  getTransferCatalog, createTransferBundle, planSelectiveTransfer, applySelectiveTransfer,
 } from "@/lib/db/index.js";

--- a/src/shared/components/ProviderComboTransferModal.js
+++ b/src/shared/components/ProviderComboTransferModal.js
@@ -1,0 +1,321 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import Modal from "./Modal";
+import Button from "./Button";
+import Input from "./Input";
+import Select from "./Select";
+
+function downloadJson(payload) {
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `9router-transfer-${new Date().toISOString().replace(/[.:]/g, "-")}.json`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+function CheckRow({ checked, onChange, title, detail }) {
+  return (
+    <label className="flex items-start gap-3 rounded-lg border border-border p-3 hover:border-primary/40 cursor-pointer">
+      <input type="checkbox" checked={checked} onChange={onChange} className="mt-1 accent-[var(--color-primary)]" />
+      <span className="min-w-0">
+        <span className="block text-sm font-medium text-text-main truncate">{title}</span>
+        {detail && <span className="block text-xs text-text-muted truncate">{detail}</span>}
+      </span>
+    </label>
+  );
+}
+
+function SummaryPill({ label, value }) {
+  return (
+    <div className="rounded-lg border border-border bg-bg px-3 py-2">
+      <p className="text-xs text-text-muted">{label}</p>
+      <p className="text-lg font-semibold">{value}</p>
+    </div>
+  );
+}
+
+function providerActions(item) {
+  if (item.status === "new") return [{ value: "add", label: "Add" }, { value: "skip", label: "Skip" }];
+  if (item.status === "conflict") return [{ value: "skip", label: "Keep destination" }, { value: "replace", label: "Replace credentials" }];
+  return [{ value: "skip", label: item.status === "ambiguous" ? "Skip (ambiguous)" : "Skip (already present)" }];
+}
+
+function comboActions(item) {
+  if (item.status === "new") return [{ value: "add", label: "Add" }, { value: "skip", label: "Skip" }];
+  if (item.status === "conflict") return [
+    { value: "skip", label: "Keep destination" },
+    { value: "replace", label: "Replace" },
+    { value: "merge", label: "Merge models" },
+    { value: "rename", label: "Import renamed" },
+  ];
+  if (item.status === "name_conflict") return [{ value: "skip", label: "Skip" }, { value: "rename", label: "Import renamed" }];
+  return [{ value: "skip", label: "Skip (already present)" }];
+}
+
+export default function ProviderComboTransferModal({ isOpen, mode, onClose, onComplete }) {
+  const fileRef = useRef(null);
+  const [catalog, setCatalog] = useState({ providerConnections: [], combos: [] });
+  const [selectedProviders, setSelectedProviders] = useState([]);
+  const [selectedCombos, setSelectedCombos] = useState([]);
+  const [payload, setPayload] = useState(null);
+  const [plan, setPlan] = useState(null);
+  const [resolutions, setResolutions] = useState({});
+  const [password, setPassword] = useState("");
+  const [credentialAcknowledged, setCredentialAcknowledged] = useState(false);
+  const [importCredentialAcknowledged, setImportCredentialAcknowledged] = useState(false);
+  const [providerFilter, setProviderFilter] = useState("");
+  const [comboFilter, setComboFilter] = useState("");
+  const [loading, setLoading] = useState(mode === "export");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!isOpen || mode !== "export") return;
+    let cancelled = false;
+    fetch("/api/settings/transfer/catalog", { cache: "no-store" })
+      .then(async (response) => {
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || "Failed to load transferable items");
+        if (cancelled) return;
+        setCatalog(data);
+        // Credentials are never selected implicitly. Users can still select all
+        // with one click after reviewing the warning and scope.
+        setSelectedProviders([]);
+        setSelectedCombos([]);
+      })
+      .catch((reason) => {
+        if (!cancelled) setError(reason.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, mode]);
+
+  const selectedCount = selectedProviders.length + selectedCombos.length;
+  const filteredProviders = useMemo(() => {
+    const query = providerFilter.trim().toLowerCase();
+    if (!query) return catalog.providerConnections;
+    return catalog.providerConnections.filter((item) => [item.provider, item.authType, item.name, item.email]
+      .filter(Boolean).some((value) => String(value).toLowerCase().includes(query)));
+  }, [catalog.providerConnections, providerFilter]);
+  const filteredCombos = useMemo(() => {
+    const query = comboFilter.trim().toLowerCase();
+    if (!query) return catalog.combos;
+    return catalog.combos.filter((item) => [item.name, item.kind]
+      .filter(Boolean).some((value) => String(value).toLowerCase().includes(query)));
+  }, [catalog.combos, comboFilter]);
+  const exportNeedsPassword = selectedProviders.length > 0;
+  const importNeedsPassword = (plan?.providerConnections?.length || 0) > 0;
+  const counts = plan?.summary?.counts || {};
+  const defaultResolutions = useMemo(() => {
+    if (!plan) return {};
+    const next = {};
+    for (const item of plan.providerConnections) next[`provider:${item.sourceId}`] = { action: item.recommended };
+    for (const item of plan.combos) next[`combo:${item.sourceId}`] = { action: item.recommended };
+    return next;
+  }, [plan]);
+
+  const toggle = (value, setValues) => setValues((current) => current.includes(value)
+    ? current.filter((item) => item !== value)
+    : [...current, value]);
+
+  const runExport = async () => {
+    if (selectedCount === 0) {
+      setError("Select at least one provider account or combo");
+      return;
+    }
+    if (exportNeedsPassword && (!password || !credentialAcknowledged)) {
+      setError("A password and credential acknowledgment are required for provider exports");
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      const response = await fetch("/api/settings/transfer/export", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password, providerConnectionIds: selectedProviders, comboIds: selectedCombos }),
+      });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || "Failed to export selection");
+      downloadJson(data);
+      onComplete?.("Selective transfer downloaded");
+      onClose();
+    } catch (reason) {
+      setError(reason.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const inspectFile = async (event) => {
+    const file = event.target.files?.[0];
+    if (fileRef.current) fileRef.current.value = "";
+    if (!file) return;
+    setLoading(true);
+    setError("");
+    setPlan(null);
+    setImportCredentialAcknowledged(false);
+    try {
+      const parsed = JSON.parse(await file.text());
+      const response = await fetch("/api/settings/transfer/preview", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ payload: parsed }),
+      });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || "Invalid transfer file");
+      setPayload(parsed);
+      setPlan(data);
+      const defaults = {};
+      for (const item of data.providerConnections) defaults[`provider:${item.sourceId}`] = { action: item.recommended };
+      for (const item of data.combos) defaults[`combo:${item.sourceId}`] = { action: item.recommended };
+      setResolutions(defaults);
+    } catch (reason) {
+      setPayload(null);
+      setError(reason.message || "Invalid transfer file");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const setResolution = (key, patch) => setResolutions((current) => ({
+    ...current,
+    [key]: { ...(current[key] || {}), ...patch },
+  }));
+
+  const runImport = async () => {
+    if (importNeedsPassword && (!password || !importCredentialAcknowledged)) {
+      setError("A password and credential acknowledgment are required for provider imports");
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      const response = await fetch("/api/settings/transfer/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password, payload, resolutions: { ...defaultResolutions, ...resolutions } }),
+      });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || "Failed to import selection");
+      const changed = Object.entries(data.applied || {}).filter(([key]) => key !== "skipped").reduce((sum, [, value]) => sum + value, 0);
+      onComplete?.(`Selective import completed: ${changed} item${changed === 1 ? "" : "s"} changed`);
+      onClose();
+    } catch (reason) {
+      setError(reason.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const footer = mode === "export" ? (
+    <>
+      <Button variant="ghost" onClick={onClose} disabled={loading}>Cancel</Button>
+      <Button icon="download" onClick={runExport} loading={loading} disabled={selectedCount === 0 || (exportNeedsPassword && (!password || !credentialAcknowledged))}>
+        {selectedCount ? `Export ${selectedCount} item${selectedCount === 1 ? "" : "s"}` : "Export Selected"}
+      </Button>
+    </>
+  ) : plan ? (
+    <>
+      <Button variant="ghost" onClick={onClose} disabled={loading}>Cancel</Button>
+      <Button icon="publish" onClick={runImport} loading={loading} disabled={importNeedsPassword && (!password || !importCredentialAcknowledged)}>
+        Apply Import
+      </Button>
+    </>
+  ) : (
+    <Button variant="ghost" onClick={onClose} disabled={loading}>Close</Button>
+  );
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={mode === "export" ? "Export Selected Configuration" : "Import Selected Configuration"} size="full" footer={footer} closeOnOverlay={!loading}>
+      {mode === "export" ? (
+        <div className="flex flex-col gap-5">
+          <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-300">
+            Provider accounts contain reusable credentials. They are never selected by default; review the scope before downloading. Combos and routing dependencies do not contain credentials.
+          </div>
+          <section>
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <div><h3 className="font-semibold">Provider accounts <span className="text-xs font-normal text-text-muted">{selectedProviders.length}/{catalog.providerConnections.length}</span></h3><p className="text-xs text-text-muted">Credentials to add or update on another 9Router.</p></div>
+              <button type="button" className="text-xs text-primary" onClick={() => setSelectedProviders(selectedProviders.length === catalog.providerConnections.length ? [] : catalog.providerConnections.map((item) => item.id))}>{selectedProviders.length === catalog.providerConnections.length ? "Clear all" : "Select all"}</button>
+            </div>
+            <Input type="search" label="Filter providers" value={providerFilter} onChange={(event) => setProviderFilter(event.target.value)} placeholder="Search by provider, email, or account name" />
+            <div className="grid max-h-56 grid-cols-1 gap-2 overflow-y-auto pr-1 sm:grid-cols-2">
+              {filteredProviders.map((item) => <CheckRow key={item.id} checked={selectedProviders.includes(item.id)} onChange={() => toggle(item.id, setSelectedProviders)} title={item.name || item.email || `${item.provider} account`} detail={`${item.provider} · ${item.authType}`} />)}
+            </div>
+            {filteredProviders.length === 0 && <p className="py-3 text-xs text-text-muted">No provider accounts match this filter.</p>}
+          </section>
+          <section>
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <div><h3 className="font-semibold">Combos <span className="text-xs font-normal text-text-muted">{selectedCombos.length}/{catalog.combos.length}</span></h3><p className="text-xs text-text-muted">Includes each combo strategy and required custom-node/model metadata.</p></div>
+              <button type="button" className="text-xs text-primary" onClick={() => setSelectedCombos(selectedCombos.length === catalog.combos.length ? [] : catalog.combos.map((item) => item.id))}>{selectedCombos.length === catalog.combos.length ? "Clear all" : "Select all"}</button>
+            </div>
+            <Input type="search" label="Filter combos" value={comboFilter} onChange={(event) => setComboFilter(event.target.value)} placeholder="Search by combo name" />
+            <div className="grid max-h-48 grid-cols-1 gap-2 overflow-y-auto pr-1 sm:grid-cols-2">
+              {filteredCombos.map((item) => <CheckRow key={item.id} checked={selectedCombos.includes(item.id)} onChange={() => toggle(item.id, setSelectedCombos)} title={item.name} detail={`${item.modelCount} model${item.modelCount === 1 ? "" : "s"}${item.kind ? ` · ${item.kind}` : ""}`} />)}
+            </div>
+            {filteredCombos.length === 0 && <p className="py-3 text-xs text-text-muted">No combos match this filter.</p>}
+          </section>
+          {exportNeedsPassword ? (
+            <>
+              <label className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-300">
+                <input type="checkbox" checked={credentialAcknowledged} onChange={(event) => setCredentialAcknowledged(event.target.checked)} className="mt-0.5 accent-[var(--color-primary)]" />
+                <span>I understand this download contains provider credentials and I will store and transfer the JSON securely.</span>
+              </label>
+              <Input type="password" label="Current password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="Required to export provider credentials" />
+            </>
+          ) : <p className="rounded-lg border border-green-500/30 bg-green-500/10 p-3 text-xs text-green-700 dark:text-green-300">No provider accounts selected. This export contains configuration metadata only.</p>}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-5">
+          {!plan && (
+            <button type="button" onClick={() => fileRef.current?.click()} className="rounded-xl border-2 border-dashed border-border p-10 text-center hover:border-primary/50">
+              <span className="material-symbols-outlined mb-2 text-3xl text-primary">upload_file</span>
+              <span className="block font-medium">Choose a selective transfer JSON file</span>
+              <span className="block text-xs text-text-muted">The file is inspected before anything changes.</span>
+            </button>
+          )}
+          <input ref={fileRef} type="file" accept="application/json,.json" className="hidden" onChange={inspectFile} />
+          {plan && (
+            <>
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+                <SummaryPill label="New" value={counts.new || 0} />
+                <SummaryPill label="Existing" value={counts.identical || 0} />
+                <SummaryPill label="Conflicts" value={(counts.conflict || 0) + (counts.name_conflict || 0)} />
+                <SummaryPill label="Ambiguous" value={counts.ambiguous || 0} />
+                <SummaryPill label="Deletions" value="0" />
+              </div>
+              <p className="text-xs text-text-muted">Dependencies: {plan.summary.providerNodes} custom nodes, {plan.summary.modelAliases} aliases, {plan.summary.customModels} custom models. New dependencies are added; existing conflicts are kept by default.</p>
+              {importNeedsPassword && (
+                <p className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-300">
+                  This file contains provider credentials. OAuth refresh tokens may rotate; running the same imported OAuth account on two installations can invalidate one installation. Disable the source account after a move.
+                </p>
+              )}
+              {plan.providerConnections.length > 0 && <section><h3 className="mb-2 font-semibold">Provider accounts</h3><div className="flex max-h-64 flex-col gap-2 overflow-y-auto pr-1">{plan.providerConnections.map((item) => { const key = `provider:${item.sourceId}`; return <div key={key} className="grid items-center gap-2 rounded-lg border border-border p-3 sm:grid-cols-[1fr_140px_220px]"><div className="min-w-0"><p className="truncate text-sm font-medium">{item.label}</p><p className="text-xs text-text-muted">{item.provider} · {item.authType}</p></div><span className="text-xs capitalize text-text-muted">{item.status.replace("_", " ")}</span><Select value={resolutions[key]?.action || item.recommended} onChange={(event) => setResolution(key, { action: event.target.value })} options={providerActions(item)} placeholder="Action" /></div>; })}</div></section>}
+              {plan.combos.length > 0 && <section><h3 className="mb-2 font-semibold">Combos</h3><div className="flex max-h-64 flex-col gap-2 overflow-y-auto pr-1">{plan.combos.map((item) => { const key = `combo:${item.sourceId}`; const action = resolutions[key]?.action || item.recommended; return <div key={key} className="grid items-center gap-2 rounded-lg border border-border p-3 sm:grid-cols-[1fr_140px_220px]"><div className="min-w-0"><p className="truncate text-sm font-medium">{item.name}</p><p className="text-xs text-text-muted">{item.modelCount} models</p></div><span className="text-xs capitalize text-text-muted">{item.status.replace("_", " ")}</span><div className="flex flex-col gap-2"><Select value={action} onChange={(event) => setResolution(key, { action: event.target.value })} options={comboActions(item)} placeholder="Action" />{action === "rename" && <Input value={resolutions[key]?.renameTo || ""} onChange={(event) => setResolution(key, { renameTo: event.target.value })} placeholder="New combo name" />}</div></div>; })}</div></section>}
+              <div className="flex items-center justify-between gap-3"><Button variant="outline" icon="upload_file" onClick={() => fileRef.current?.click()} disabled={loading}>Choose another file</Button><span className="text-xs text-green-600 dark:text-green-400">No destination records will be deleted.</span></div>
+              {importNeedsPassword ? (
+                <>
+                  <label className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-300">
+                    <input type="checkbox" checked={importCredentialAcknowledged} onChange={(event) => setImportCredentialAcknowledged(event.target.checked)} className="mt-0.5 accent-[var(--color-primary)]" />
+                    <span>I understand this import adds or updates provider credentials on this destination.</span>
+                  </label>
+                  <Input type="password" label="Current password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="Required to apply provider credentials" />
+                </>
+              ) : <p className="rounded-lg border border-green-500/30 bg-green-500/10 p-3 text-xs text-green-700 dark:text-green-300">No provider credentials are included. This import changes only configuration metadata.</p>}
+            </>
+          )}
+        </div>
+      )}
+      {loading && !plan && <p className="mt-4 text-sm text-text-muted">Working…</p>}
+      {error && <p className="mt-4 text-sm text-red-500">{error}</p>}
+    </Modal>
+  );
+}

--- a/tests/unit/provider-combo-transfer.test.js
+++ b/tests/unit/provider-combo-transfer.test.js
@@ -1,0 +1,174 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let tempDir;
+let db;
+const originalDataDir = process.env.DATA_DIR;
+
+beforeEach(async () => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-transfer-"));
+  process.env.DATA_DIR = tempDir;
+  delete global._dbAdapter;
+  vi.resetModules();
+  db = await import("@/lib/db/index.js");
+  await db.initDb();
+});
+
+afterEach(() => {
+  try { global._dbAdapter?.instance?.close?.(); } catch {}
+  delete global._dbAdapter;
+  fs.rmSync(tempDir, { recursive: true, force: true });
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+});
+
+describe("provider + combo selective transfer", () => {
+  it("exports selected records and closes over routing dependencies", async () => {
+    const node = await db.createProviderNode({
+      type: "openai-compatible",
+      name: "Personal",
+      prefix: "personal",
+      apiType: "openai",
+      baseUrl: "https://example.test/v1",
+    });
+    const connection = await db.createProviderConnection({
+      provider: node.id,
+      authType: "apikey",
+      name: "Personal key",
+      apiKey: "secret",
+      testStatus: "error",
+      providerSpecificData: { proxyPoolId: "local-pool", tenant: "portable" },
+    });
+    const combo = await db.createCombo({ name: "coding", kind: "llm", models: ["personal/model-a"] });
+    await db.addCustomModel({ providerAlias: "personal", id: "model-a", type: "llm", name: "Model A" });
+    await db.setModelAlias("personal/model-a", "my-model");
+    await db.updateSettings({ comboStrategies: { coding: { fallbackStrategy: "round-robin" } } });
+
+    const bundle = await db.createTransferBundle({
+      providerConnectionIds: [connection.id],
+      comboIds: [combo.id],
+    });
+
+    expect(bundle.format).toBe("9router-provider-combo-transfer");
+    expect(bundle.providerConnections).toHaveLength(1);
+    expect(bundle.providerConnections[0]).not.toHaveProperty("priority");
+    expect(bundle.providerConnections[0]).not.toHaveProperty("isActive");
+    expect(bundle.providerConnections[0]).not.toHaveProperty("testStatus");
+    expect(bundle.providerConnections[0].providerSpecificData).toEqual({ tenant: "portable" });
+    expect(bundle.providerNodes.map((item) => item.id)).toContain(node.id);
+    expect(bundle.customModels).toHaveLength(1);
+    expect(bundle.modelAliases).toEqual({ "personal/model-a": "my-model" });
+    expect(bundle.comboStrategies.coding.fallbackStrategy).toBe("round-robin");
+
+    const fullBackupPlan = await db.planSelectiveTransfer(await db.exportDb());
+    expect(fullBackupPlan.summary.providerConnections).toBeGreaterThanOrEqual(1);
+    expect(fullBackupPlan.summary.combos).toBeGreaterThanOrEqual(1);
+  });
+
+  it("replaces credentials and merges combos without overwriting target policy", async () => {
+    const target = await db.createProviderConnection({
+      provider: "codex",
+      authType: "oauth",
+      email: "user@example.test",
+      accessToken: "old-access",
+      refreshToken: "old-refresh",
+      testStatus: "connected",
+      isActive: false,
+      providerSpecificData: { chatgptAccountId: "workspace-1", proxyPoolId: "target-pool" },
+    });
+    await db.updateProviderConnection(target.id, { isActive: false });
+    const originalPriority = (await db.getProviderConnectionById(target.id)).priority;
+    const targetCombo = await db.createCombo({ name: "coding", kind: "llm", models: ["codex/model-a"] });
+    await db.updateSettings({ comboStrategies: { coding: { fallbackStrategy: "fallback" } } });
+
+    const payload = {
+      format: "9router-provider-combo-transfer",
+      version: 1,
+      providerConnections: [{
+        id: "source-account",
+        provider: "codex",
+        authType: "oauth",
+        email: "user@example.test",
+        name: "Imported",
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+        providerSpecificData: { chatgptAccountId: "workspace-1", proxyPoolId: "source-pool" },
+      }],
+      combos: [{ id: "source-combo", name: "coding", kind: "llm", models: ["codex/model-b"] }],
+      comboStrategies: { coding: { fallbackStrategy: "round-robin" } },
+    };
+
+    const plan = await db.planSelectiveTransfer(payload);
+    expect(plan.providerConnections[0]).toMatchObject({ status: "conflict", targetId: target.id });
+    expect(plan.combos[0]).toMatchObject({ status: "conflict", targetId: targetCombo.id });
+    expect(plan.summary.deletions).toBe(0);
+    expect(JSON.stringify(plan)).not.toContain("new-access");
+    expect(JSON.stringify(plan)).not.toContain("new-refresh");
+
+    const result = await db.applySelectiveTransfer(payload, {
+      "provider:source-account": { action: "replace" },
+      "combo:source-combo": { action: "merge" },
+    });
+    expect(result.deletions).toBe(0);
+
+    const updated = await db.getProviderConnectionById(target.id);
+    expect(updated.accessToken).toBe("new-access");
+    expect(updated.refreshToken).toBe("new-refresh");
+    expect(updated.priority).toBe(originalPriority);
+    expect(updated.isActive).toBe(false);
+    expect(updated.providerSpecificData.proxyPoolId).toBe("target-pool");
+    expect(updated.providerSpecificData.chatgptAccountId).toBe("workspace-1");
+    expect(updated.testStatus).toBe("connected");
+    expect((await db.getComboById(targetCombo.id)).models).toEqual(["codex/model-a", "codex/model-b"]);
+    expect((await db.getSettings()).comboStrategies.coding.fallbackStrategy).toBe("fallback");
+  });
+
+  it("keeps same-email Codex workspaces separate and rolls back a failed apply", async () => {
+    await db.createProviderConnection({
+      provider: "codex",
+      authType: "oauth",
+      email: "same@example.test",
+      accessToken: "one",
+      providerSpecificData: { chatgptAccountId: "workspace-a" },
+    });
+    await db.createCombo({ name: "existing", models: ["codex/model-a"] });
+    const payload = {
+      format: "9router-provider-combo-transfer",
+      version: 1,
+      providerConnections: [{
+        id: "workspace-b-source",
+        provider: "codex",
+        authType: "oauth",
+        email: "same@example.test",
+        accessToken: "two",
+        providerSpecificData: { chatgptAccountId: "workspace-b" },
+      }],
+      combos: [{ id: "combo-source", name: "existing", models: ["codex/model-b"] }],
+    };
+    expect((await db.planSelectiveTransfer(payload)).providerConnections[0].status).toBe("new");
+
+    await expect(db.applySelectiveTransfer(payload, {
+      "provider:workspace-b-source": { action: "add" },
+      "combo:combo-source": { action: "rename", renameTo: "invalid name" },
+    })).rejects.toThrow("valid new name");
+
+    const accounts = await db.getProviderConnections({ provider: "codex" });
+    expect(accounts).toHaveLength(1);
+    expect((await db.getComboByName("existing")).models).toEqual(["codex/model-a"]);
+  });
+
+  it("rejects duplicate source identities before planning", async () => {
+    const duplicate = {
+      format: "9router-provider-combo-transfer",
+      version: 1,
+      providerConnections: [
+        { id: "duplicate", provider: "openrouter", authType: "apikey", name: "one", apiKey: "a" },
+        { id: "duplicate", provider: "openrouter", authType: "apikey", name: "two", apiKey: "b" },
+      ],
+    };
+    await expect(db.planSelectiveTransfer(duplicate)).rejects.toThrow("duplicate identity");
+    expect(await db.getProviderConnections({ provider: "openrouter" })).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

This adds a selective JSON transfer workflow for moving provider accounts and combos between 9Router installations without replacing unrelated destination configuration.

The existing full backup and restore workflow remains available and unchanged for complete database migration.

## What changed

- Separates **Full backup** from **Selective transfer** in Settings → Data & Transfer.
- Lets users search and explicitly select provider accounts and combos for export.
- Keeps credential-bearing provider accounts unselected by default.
- Includes required combo dependencies such as custom provider nodes, models, aliases, and strategies.
- Previews imports before applying changes and offers per-item conflict handling: add, skip, replace, merge, or rename.
- Applies imports transactionally and never deletes destination records.
- Preserves destination-specific provider policy such as priority, activation state, health status, and proxy-pool assignment.
- Requires the configured dashboard password plus an explicit acknowledgment whenever provider credentials are exported or imported.
- Treats an environment-configured initial dashboard password as configured authentication.

## Security behavior

- Provider credentials are included only when the user explicitly selects provider accounts.
- Combo-only transfers contain configuration metadata and do not require a password.
- Import previews report identities and conflicts without returning credential values.
- Runtime-only connection state and source-specific proxy-pool references are excluded.
- The UI warns that OAuth refresh-token rotation may make running the same account on two installations unreliable.

## Validation

- ESLint passes for every changed source and test file.
- Selective-transfer and database-parity tests: **24 passed**.
- Production build: **passed**.

## Screenshots

### Selective transfer entry point

<img width="1476" height="1000" alt="9router-pr-selective-transfer-highlight" src="https://github.com/user-attachments/assets/998c6127-ce09-4e32-8230-41391454628e" />

### Select providers and combos

<img width="1898" height="1458" alt="9router-pr-export-redacted-top" src="https://github.com/user-attachments/assets/2dc8d210-e59e-4537-b60c-4f364e34b97d" />

### Credential acknowledgment

<img width="1826" height="1412" alt="9router-pr-export-redacted-bottom" src="https://github.com/user-attachments/assets/e41a1b8e-3c4b-4c3b-9dda-2e210c5f6a70" />
