### PR TITLE
feat(models): generic live /models catalog for API-key providers + provider page fetch button

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -71,6 +71,9 @@ export default function ProviderDetailPage() {
   const [suggestedModels, setSuggestedModels] = useState([]);
   const [liveModels, setLiveModels] = useState([]);
   const [kiloFreeModels, setKiloFreeModels] = useState([]);
+  const [modelSearch, setModelSearch] = useState("");
+  const [modelFilter, setModelFilter] = useState("all"); // all | enabled | disabled
+  const [liveFetching, setLiveFetching] = useState(false);
   const [disabledModelIds, setDisabledModelIds] = useState([]);
   const [confirmState, setConfirmState] = useState(null);
   const [showAgRiskModal, setShowAgRiskModal] = useState(false);
@@ -146,8 +149,8 @@ export default function ProviderDetailPage() {
   const supportsApiKeyAuth = !!APIKEY_PROVIDERS[providerId] || authModes.includes("apikey");
   const isFreeNoAuth = !!FREE_PROVIDERS[providerId]?.noAuth;
   const staticModels = getModelsByProviderId(providerId);
-  const models = providerId === "cursor" && liveModels.length > 0
-    ? liveModels
+  const models = liveModels.length > 0
+    ? [...liveModels.filter((m) => !staticModels.some((s) => s.id === m.id)), ...staticModels]
     : staticModels;
   const providerAlias = getProviderAlias(providerId);
   
@@ -464,7 +467,10 @@ export default function ProviderDetailPage() {
   // Load the active account's live catalog for the dashboard; the static
   // registry remains the fallback while the request is pending or unavailable.
   useEffect(() => {
-    if (providerId !== "cursor") {
+    // Load the active connection live catalog for providers exposing a /models
+    // endpoint (nvidia, openrouter, cursor, ...). Compatible nodes are managed
+    // in their own section; the static registry stays as fallback.
+    if (isCompatible) {
       setLiveModels([]);
       return;
     }
@@ -481,12 +487,14 @@ export default function ProviderDetailPage() {
       .then(({ ok, data }) => {
         if (!cancelled && ok && Array.isArray(data.models) && data.models.length > 0) {
           setLiveModels(data.models);
+        } else if (!cancelled) {
+          setLiveModels([]);
         }
       })
       .catch(() => {});
 
     return () => { cancelled = true; };
-  }, [providerId, connections]);
+  }, [providerId, connections, isCompatible]);
 
   // Fetch suggested models from provider's public API (if configured)
   useEffect(() => {
@@ -1072,6 +1080,31 @@ export default function ProviderDetailPage() {
     }
   };
 
+  const handleFetchLiveModels = async () => {
+    const connection = connections.find((item) => item.isActive !== false);
+    if (!connection?.id) {
+      setModelsTestError(translate("Add an API key/connection before fetching models"));
+      return;
+    }
+    setLiveFetching(true);
+    try {
+      const res = await fetch(`/api/providers/${connection.id}/models?refresh=1`, { cache: "no-store" });
+      const data = await res.json();
+      if (res.ok && Array.isArray(data.models) && data.models.length > 0) {
+        setLiveModels(data.models);
+        setModelsTestError("");
+      } else {
+        setLiveModels([]);
+        setModelsTestError(data?.error ? `${translate("Failed to fetch models")}: ${data.error}` : translate("Failed to fetch models, please check the API key"));
+      }
+    } catch {
+      setLiveModels([]);
+      setModelsTestError(translate("Failed to fetch models: network error"));
+    } finally {
+      setLiveFetching(false);
+    }
+  };
+
   const renderModelsSection = () => {
     if (isCompatible) {
       return (
@@ -1098,8 +1131,17 @@ export default function ProviderDetailPage() {
       ...kiloFreeModels.filter((fm) => !models.some((m) => m.id === fm.id)),
     ].filter((m) => { const k = getModelKind(m); return !k || k === "llm"; });
     const disabledSet = new Set(disabledModelIds);
-    const displayModels = allModels.filter((m) => !disabledSet.has(m.id));
-    const disabledDisplayModels = allModels.filter((m) => disabledSet.has(m.id));
+    const lowerQuery = modelSearch.trim().toLowerCase();
+    const matchesQuery = (m) =>
+      !lowerQuery ||
+      m.id.toLowerCase().includes(lowerQuery) ||
+      String(m.name || "").toLowerCase().includes(lowerQuery);
+    const displayModels = allModels
+      .filter((m) => !disabledSet.has(m.id))
+      .filter(matchesQuery);
+    const disabledDisplayModels = allModels
+      .filter((m) => disabledSet.has(m.id))
+      .filter(matchesQuery);
     const customModelRows = getProviderCustomModelRows({
       customModels,
       modelAliases,
@@ -1109,7 +1151,47 @@ export default function ProviderDetailPage() {
     });
 
     return (
-      <div className="flex flex-wrap gap-3">
+      <div>
+        <div className="mb-3 flex flex-wrap items-center gap-2">
+          <input
+            type="text"
+            value={modelSearch}
+            onChange={(e) => setModelSearch(e.target.value)}
+            placeholder={translate("Search models...")}
+            className="w-64 py-2 px-3 text-sm text-text-main bg-surface-2 rounded-[10px] border border-transparent placeholder-text-muted/70 focus:outline-none focus:ring-2 focus:ring-brand-500/30 focus:border-brand-500/40"
+          />
+          <div className="flex items-center gap-1">
+            {[
+              { key: "all", label: `All (${allModels.length})` },
+              { key: "enabled", label: `Enabled (${displayModels.length})` },
+              { key: "disabled", label: `Disabled (${disabledDisplayModels.length})` },
+            ].map((opt) => (
+              <button
+                key={opt.key}
+                onClick={() => setModelFilter(opt.key)}
+                className={
+                  modelFilter === opt.key
+                    ? "px-2.5 py-1.5 rounded-lg text-xs bg-brand-500/15 text-brand-600 dark:text-brand-400 border border-brand-500/30"
+                    : "px-2.5 py-1.5 rounded-lg text-xs text-text-muted border border-black/10 dark:border-white/10 hover:text-primary hover:border-primary/40"
+                }
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+          <button
+            onClick={handleFetchLiveModels}
+            disabled={liveFetching || connections.length === 0}
+            title={connections.length === 0 ? translate("Add an API key/connection first") : translate("Fetch live models for this provider")}
+            className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs border border-primary/30 text-primary hover:bg-primary/5 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            <span className="material-symbols-outlined text-[13px]" style={liveFetching ? { animation: "spin 1s linear infinite" } : undefined}>
+              {liveFetching ? "progress_activity" : "refresh"}
+            </span>
+            {liveFetching ? translate("Fetching...") : translate("Fetch Models")}
+          </button>
+        </div>
+        <div className="flex flex-wrap gap-3 max-h-[480px] overflow-y-auto pr-1">
         {/* Custom models first */}
         {customModelRows.map((model) => (
           <ModelRow
@@ -1137,7 +1219,7 @@ export default function ProviderDetailPage() {
           />
         ))}
 
-        {displayModels.map((model) => {
+        {modelFilter !== "disabled" && displayModels.map((model) => {
           const fullModel = `${providerStorageAlias}/${model.id}`;
           const oldFormatModel = `${providerId}/${model.id}`;
           const existingAlias = Object.entries(modelAliases).find(
@@ -1221,7 +1303,7 @@ export default function ProviderDetailPage() {
         })()}
 
         {/* Disabled models — restorable */}
-        {disabledDisplayModels.length > 0 && (
+        {modelFilter !== "enabled" && disabledDisplayModels.length > 0 && (
           <div className="w-full mt-2">
             <p className="text-xs text-text-muted mb-2">Disabled models ({disabledDisplayModels.length}):</p>
             <div className="flex flex-wrap gap-2">
@@ -1239,6 +1321,7 @@ export default function ProviderDetailPage() {
             </div>
           </div>
         )}
+        </div>
       </div>
     );
   };

--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -11,6 +11,7 @@ import { resolveQoderModels } from "open-sse/services/qoderModels.js";
 import { resolveGrokCliModels } from "open-sse/services/grokCliModels.js";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { resolveCursorModels } from "open-sse/services/cursorModels.js";
+import { fetchProviderLiveModels } from "@/shared/utils/providerLiveModels";
 
 const GEMINI_CLI_MODELS_URL = "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels";
 
@@ -440,6 +441,7 @@ const PROVIDER_MODELS_CONFIG = {
  * GET /api/providers/[id]/models - Get models list from provider
  */
 export async function GET(request, { params }) {
+  const refresh = request.nextUrl?.searchParams?.get("refresh") === "1";
   try {
     const { id } = await params;
     const connection = await getProviderConnectionById(id);
@@ -524,6 +526,19 @@ export async function GET(request, { params }) {
 
     const config = PROVIDER_MODELS_CONFIG[connection.provider];
     if (!config) {
+      // Generic fallback for API-key providers that declare a /models endpoint in
+      // their registry entry (nvidia, openrouter, groq, ...). The caller falls
+      // back to the static list when this returns empty.
+      if (connection.apiKey) {
+        const live = await fetchProviderLiveModels(connection.provider, connection.apiKey, { useCache: !refresh });
+        if (live?.length) {
+          return NextResponse.json({
+            provider: connection.provider,
+            connectionId: connection.id,
+            models: live,
+          });
+        }
+      }
       return NextResponse.json(
         { error: `Provider ${connection.provider} does not support models listing` },
         { status: 400 }

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -15,6 +15,7 @@ import { resolveClinepassModels } from "open-sse/services/clinepassModels.js";
 import { resolveGrokCliModels } from "open-sse/services/grokCliModels.js";
 import { resolveCursorModels } from "open-sse/services/cursorModels.js";
 import { resolveZedModels } from "open-sse/shared/zedAuth.js";
+import { fetchProviderLiveModels } from "@/shared/utils/providerLiveModels";
 import { updateProviderCredentials } from "@/sse/services/tokenRefresh";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { capabilitiesFromServiceKind, getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
@@ -404,6 +405,34 @@ export async function buildModelsList(kindFilter, options = {}) {
         }
       }
 
+      // Generic live catalog for built-in API-key providers (nvidia, openrouter,
+      // groq, ...): fetch the provider's /models endpoint and UNION it with the
+      // static list so newly released models appear immediately. Skipped when the
+      // user configured an explicit model whitelist (enabledModels), for
+      // compatible nodes (they have their own /models fetch above), or for
+      // providers with a dedicated live resolver.
+      if (
+        !liveResolver &&
+        !isCompatibleProvider &&
+        !hasExplicitEnabledModels &&
+        !skipDynamicFetch &&
+        conn?.apiKey
+      ) {
+        try {
+          const live = await fetchProviderLiveModels(providerId, conn.apiKey);
+          if (live?.length) {
+            rawModelIds = Array.from(new Set([...live.map((m) => m.id), ...rawModelIds]));
+            liveModelKindById = new Map(
+              live.filter((m) => m?.id).map((m) => [m.id, modelKind(m)])
+            );
+            liveCapabilitiesById = new Map(
+              live.filter((m) => m?.id && m.capabilities).map((m) => [m.id, m.capabilities])
+            );
+          }
+        } catch (err) {
+          console.log(`Generic live model fetch failed for ${providerId}: ${err?.message || err}`);
+        }
+      }
       const modelIds = rawModelIds
         .map((modelId) => {
           if (modelId.startsWith(`${outputAlias}/`)) {

--- a/src/shared/components/ModelSelectModal.js
+++ b/src/shared/components/ModelSelectModal.js
@@ -50,6 +50,7 @@ export default function ModelSelectModal({
   const [customModels, setCustomModels] = useState([]);
   const [disabledModels, setDisabledModels] = useState({});
   const [cursorModels, setCursorModels] = useState([]);
+  const [liveModelsByProvider, setLiveModelsByProvider] = useState({});
 
   // Cursor exposes the usable catalog per account. Keep the static catalog only
   // as a fallback, since it quickly becomes stale and different accounts can
@@ -91,6 +92,44 @@ export default function ModelSelectModal({
 
     return () => { cancelled = true; };
   }, [isOpen, cursorConnectionIds]);
+
+  // Live catalogs for the other connected providers (nvidia, openrouter, kiro,
+  // ...). The provider detail page fetches the same endpoint, and the selector
+  // needs the union so newly released models can be picked into combos.
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    const connections = activeProviders.filter((p) => p.provider !== "cursor" && p.id);
+    if (connections.length === 0) return undefined;
+
+    let cancelled = false;
+    Promise.all(connections.map(async (conn) => {
+      try {
+        const response = await fetch(`/api/providers/${conn.id}/models`, { cache: "no-store" });
+        if (!response.ok) return { provider: conn.provider, models: [] };
+        const data = await response.json();
+        return { provider: conn.provider, models: Array.isArray(data.models) ? data.models : [] };
+      } catch {
+        return { provider: conn.provider, models: [] };
+      }
+    }))
+      .then((results) => {
+        if (cancelled) return;
+        const byProvider = {};
+        for (const result of results) {
+          const existing = byProvider[result.provider] || [];
+          const seen = new Set(existing.map((m) => m.id));
+          for (const model of result.models) {
+            if (model?.id && !seen.has(model.id)) {
+              seen.add(model.id);
+              existing.push(model);
+            }
+          }
+          byProvider[result.provider] = existing;
+        }
+        setLiveModelsByProvider(byProvider);
+      });
+    return () => { cancelled = true; };
+  }, [isOpen, activeProviders]);
 
   const fetchCombos = async () => {
     try {
@@ -323,9 +362,10 @@ export default function ModelSelectModal({
           hasModels: mergedModels.length > 0,
         };
       } else {
-        const hardcodedModels = providerId === "cursor" && cursorModels.length > 0
+        const liveModels = liveModelsByProvider[providerId] || [];
+        const hardcodedModels = (providerId === "cursor" && cursorModels.length > 0)
           ? cursorModels
-          : getModelsByProviderId(providerId);
+          : [...liveModels, ...getModelsByProviderId(providerId)];
         const hardcodedIds = new Set(hardcodedModels.map((m) => m.id));
 
         // Custom models: if no hardcoded models (e.g. openrouter), show all aliases for this provider
@@ -394,7 +434,7 @@ export default function ModelSelectModal({
     });
 
     return groups;
-  }, [filteredActiveProviders, modelAliases, allProviders, providerNodes, customModels, disabledModels, kindFilter, activeProviders, cursorModels]);
+  }, [filteredActiveProviders, modelAliases, allProviders, providerNodes, customModels, disabledModels, kindFilter, activeProviders, cursorModels, liveModelsByProvider]);
 
   // Filter combos by search query (and hide combos when kindFilter is set — combos are LLM-only by design)
   const filteredCombos = useMemo(() => {

--- a/src/shared/utils/providerLiveModels.js
+++ b/src/shared/utils/providerLiveModels.js
@@ -1,0 +1,90 @@
+/**
+ * Generic live model catalog fetcher for API-key providers.
+ *
+ * Most built-in providers already declare a public /models endpoint in their
+ * registry entry (modelsFetcher.url, transport.validateUrl or transport.baseUrl),
+ * so instead of writing one resolver per provider we derive the URL from the
+ * registry and fetch it with the connection's API key. Results are cached in
+ * memory briefly so /v1/models and the dashboard don't hammer upstream.
+ */
+
+import REGISTRY from "open-sse/providers/registry/index.js";
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const TIMEOUT_MS = 5000;
+
+const KNOWN_URL_SUFFIXES = ["/chat/completions", "/completions", "/messages"];
+
+const cache = new Map(); // providerId -> { models, expiresAt }
+
+/**
+ * Derive the /models URL for a provider from its registry entry, or null when
+ * no reliable URL can be found (callers then keep their static fallback).
+ */
+export function deriveModelsUrl(providerId) {
+  const entry = REGISTRY.find((r) => r.id === providerId);
+  if (!entry) return null;
+
+  const fetcher = Array.isArray(entry.modelsFetcher)
+    ? entry.modelsFetcher[0]
+    : entry.modelsFetcher;
+  if (fetcher?.url) return fetcher.url;
+
+  const validateUrl = entry.transport?.validateUrl;
+  if (validateUrl && /\/models(\?|$)/.test(validateUrl)) return validateUrl.split("?")[0];
+
+  const baseUrl = entry.transport?.baseUrl;
+  if (!baseUrl) return null;
+  for (const suffix of KNOWN_URL_SUFFIXES) {
+    if (baseUrl.endsWith(suffix)) return `${baseUrl.slice(0, -suffix.length)}/models`;
+  }
+  return null;
+}
+
+/**
+ * Fetch the live model catalog for an API-key provider.
+ * @returns {Promise<Array<{id: string, name?: string}>|null>} null on any failure
+ */
+export async function fetchProviderLiveModels(providerId, apiKey, { useCache = true } = {}) {
+  if (!apiKey) return null;
+
+  if (useCache) {
+    const cached = cache.get(providerId);
+    if (cached && Date.now() < cached.expiresAt) return cached.models;
+  }
+
+  const url = deriveModelsUrl(providerId);
+  if (!url) return null;
+
+  try {
+    const controller = new AbortController();
+    const tid = setTimeout(() => controller.abort(), TIMEOUT_MS);
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      cache: "no-store",
+      signal: controller.signal,
+    });
+    clearTimeout(tid);
+    if (!res.ok) return null;
+
+    const data = await res.json();
+    // OpenAI-style { data: [...] }, { models: [...] }, or a bare array.
+    const raw = Array.isArray(data) ? data : (data?.data || data?.models || []);
+    const models = raw
+      .map((m) => ({ id: m?.id || m?.name, name: m?.name || m?.id }))
+      .filter((m) => typeof m.id === "string" && m.id.trim() !== "");
+
+    if (!models.length) return null;
+    cache.set(providerId, { models, expiresAt: Date.now() + CACHE_TTL_MS });
+    return models;
+  } catch {
+    return null;
+  }
+}
+
+export function clearProviderLiveModelsCache() {
+  cache.clear();
+}

--- a/tests/unit/live-models-util.test.js
+++ b/tests/unit/live-models-util.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { deriveModelsUrl, fetchProviderLiveModels } from "@/shared/utils/providerLiveModels";
+
+describe("generic live models util", () => {
+  it("derives nvidia /models url from validateUrl", () => {
+    expect(deriveModelsUrl("nvidia")).toBe("https://integrate.api.nvidia.com/v1/models");
+  });
+  it("derives openrouter url from modelsFetcher", () => {
+    expect(deriveModelsUrl("openrouter")).toBe("https://openrouter.ai/api/v1/models");
+  });
+  it("derives groq url from baseUrl", () => {
+    expect(deriveModelsUrl("groq")).toBe("https://api.groq.com/openai/v1/models");
+  });
+  it("returns null for unknown provider", () => {
+    expect(deriveModelsUrl("no-such-provider")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

The static per-provider model lists go stale the moment a provider ships a new model. This PR makes built-in API-key providers (nvidia, openrouter, groq, ...) resolve their **live** `/models` catalog and union it with the static list, so newly released models appear immediately. It also adds dashboard controls to search, filter, and manually fetch the live catalog, and exposes the live catalogs in the combo model selector.

## Changes

- **`src/shared/utils/providerLiveModels.js`** (new): derives the `/models` URL from each provider's registry entry (`modelsFetcher.url` → `transport.validateUrl` → `transport.baseUrl`), fetches it with the connection's API key, caches for 5 minutes, 5s timeout, returns `null` on any failure.
- **`src/app/api/v1/models/route.js`**: for built-in API-key providers, fetches the live catalog and unions it with the static list. Skipped when the user configured an explicit `enabledModels` whitelist, for compatible nodes (they have their own `/models` fetch), or for providers with a dedicated live resolver (kiro, qoder, github, clinepass, grok-cli, cursor, zed).
- **`src/app/api/providers/[id]/models/route.js`**: generic fallback for providers without a specific models config, plus `?refresh=1` to bypass the cache.
- **`src/app/(dashboard)/dashboard/providers/[id]/page.js`**: provider page gains a search box, All/Enabled/Disabled filter, and a manual "Fetch Models" button with cache bypass.
- **`src/shared/components/ModelSelectModal.js`**: the combo model selector now fetches `/api/providers/:id/models` for every connected provider and unions the live catalog with the static registry, so models fetched from nvidia/openrouter/... can be picked into combos. Cursor keeps its existing dedicated multi-account fetch.
- **`tests/unit/live-models-util.test.js`**: URL derivation tests for nvidia/openrouter/groq.

## Notes

- UI text uses the existing `translate()` i18n helper.
- Live fetch is best-effort: any failure falls back to the static list.