### PR TITLE
fix(translator): emit max_completion_tokens for gpt-5/o-series in *-to-openai request builders

### DIFF
--- a/open-sse/translator/formats/maxTokens.js
+++ b/open-sse/translator/formats/maxTokens.js
@@ -32,3 +32,15 @@ export function adjustMaxTokens(body, ceiling = DEFAULT_MAX_TOKENS) {
   return maxTokens;
 }
 
+/**
+ * Newer OpenAI models (gpt-5+, o1, o3, o4) reject `max_tokens` on Chat
+ * Completions with 400 unsupported_parameter ("Use 'max_completion_tokens'
+ * instead"). Same match the GitHub executor applies in its transformRequest
+ * (open-sse/executors/github.js).
+ * @param {string} model - Outbound provider model id
+ * @returns {boolean} true when the request must carry max_completion_tokens
+ */
+export function requiresMaxCompletionTokens(model) {
+  return /gpt-5|o[134]-/i.test(model);
+}
+

--- a/open-sse/translator/request/antigravity-to-openai.js
+++ b/open-sse/translator/request/antigravity-to-openai.js
@@ -1,6 +1,6 @@
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
-import { adjustMaxTokens } from "../formats/maxTokens.js";
+import { adjustMaxTokens, requiresMaxCompletionTokens } from "../formats/maxTokens.js";
 import { encodeDataUri } from "../concerns/image.js";
 import { ROLE, GEMINI_ROLE, OPENAI_BLOCK } from "../schema/index.js";
 import { budgetToEffort } from "../concerns/thinking.js";
@@ -21,7 +21,8 @@ export function antigravityToOpenAIRequest(model, body, stream) {
     const config = req.generationConfig;
     if (config.maxOutputTokens) {
       const tempBody = { max_tokens: config.maxOutputTokens, tools: req.tools };
-      result.max_tokens = adjustMaxTokens(tempBody);
+      const tokenParam = requiresMaxCompletionTokens(model) ? "max_completion_tokens" : "max_tokens";
+      result[tokenParam] = adjustMaxTokens(tempBody);
     }
     if (config.temperature !== undefined) {
       result.temperature = config.temperature;

--- a/open-sse/translator/request/claude-to-openai.js
+++ b/open-sse/translator/request/claude-to-openai.js
@@ -1,6 +1,6 @@
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
-import { adjustMaxTokens } from "../formats/maxTokens.js";
+import { adjustMaxTokens, requiresMaxCompletionTokens } from "../formats/maxTokens.js";
 import { encodeDataUri } from "../concerns/image.js";
 import { ROLE, OPENAI_BLOCK, CLAUDE_BLOCK } from "../schema/index.js";
 import { collapseTextParts } from "../concerns/message.js";
@@ -18,9 +18,10 @@ export function claudeToOpenAIRequest(model, body, stream) {
     stream: stream
   };
 
-  // Max tokens
+  // Max tokens (gpt-5/o-series Chat Completions only accept max_completion_tokens)
   if (body.max_tokens) {
-    result.max_tokens = adjustMaxTokens(body);
+    const tokenParam = requiresMaxCompletionTokens(model) ? "max_completion_tokens" : "max_tokens";
+    result[tokenParam] = adjustMaxTokens(body);
   }
 
   // Temperature

--- a/open-sse/translator/request/gemini-to-openai.js
+++ b/open-sse/translator/request/gemini-to-openai.js
@@ -1,6 +1,6 @@
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
-import { adjustMaxTokens } from "../formats/maxTokens.js";
+import { adjustMaxTokens, requiresMaxCompletionTokens } from "../formats/maxTokens.js";
 import { encodeDataUri } from "../concerns/image.js";
 import { collapseTextParts } from "../concerns/message.js";
 import { ROLE, GEMINI_ROLE, OPENAI_BLOCK } from "../schema/index.js";
@@ -18,7 +18,8 @@ export function geminiToOpenAIRequest(model, body, stream) {
     const config = body.generationConfig;
     if (config.maxOutputTokens) {
       const tempBody = { max_tokens: config.maxOutputTokens, tools: body.tools };
-      result.max_tokens = adjustMaxTokens(tempBody);
+      const tokenParam = requiresMaxCompletionTokens(model) ? "max_completion_tokens" : "max_tokens";
+      result[tokenParam] = adjustMaxTokens(tempBody);
     }
     if (config.temperature !== undefined) {
       result.temperature = config.temperature;

--- a/tests/unit/to-openai-max-completion-tokens.test.js
+++ b/tests/unit/to-openai-max-completion-tokens.test.js
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for the max_tokens → max_completion_tokens mapping in the
+ * *-to-openai request translators.
+ *
+ * OpenAI's Chat Completions API rejects `max_tokens` for gpt-5.x / o-series
+ * models with 400 unsupported_parameter:
+ *   "Unsupported parameter: 'max_tokens' is not supported with this model.
+ *    Use 'max_completion_tokens' instead."
+ * The GitHub executor already maps the param (requiresMaxCompletionTokens);
+ * these tests pin the same mapping at the translator layer so requests built
+ * from Claude/Gemini/Antigravity ingress are born with the right param for
+ * every executor, including the native openai api-key provider.
+ */
+
+import { describe, it, expect } from "vitest";
+import { requiresMaxCompletionTokens } from "../../open-sse/translator/formats/maxTokens.js";
+import { claudeToOpenAIRequest } from "../../open-sse/translator/request/claude-to-openai.js";
+import { geminiToOpenAIRequest } from "../../open-sse/translator/request/gemini-to-openai.js";
+import { antigravityToOpenAIRequest } from "../../open-sse/translator/request/antigravity-to-openai.js";
+
+describe("requiresMaxCompletionTokens", () => {
+  it("matches gpt-5 family and hyphenated o-series ids", () => {
+    for (const model of ["gpt-5", "gpt-5.4", "gpt-5.4-mini", "GPT-5-nano", "o1-preview", "o3-mini", "o4-mini"]) {
+      expect(requiresMaxCompletionTokens(model), model).toBe(true);
+    }
+  });
+
+  it("leaves older OpenAI models on max_tokens", () => {
+    for (const model of ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4-turbo", "claude-sonnet-4-6", "gemini-2.5-pro"]) {
+      expect(requiresMaxCompletionTokens(model), model).toBe(false);
+    }
+  });
+});
+
+describe("claude-to-openai max tokens param", () => {
+  const body = { max_tokens: 2048, messages: [{ role: "user", content: "hi" }] };
+
+  it("emits max_completion_tokens for gpt-5 models", () => {
+    const result = claudeToOpenAIRequest("gpt-5.4-mini", body, false);
+    expect(result.max_completion_tokens).toBe(2048);
+    expect(result.max_tokens).toBeUndefined();
+  });
+
+  it("emits max_completion_tokens for o-series models", () => {
+    const result = claudeToOpenAIRequest("o3-mini", body, false);
+    expect(result.max_completion_tokens).toBe(2048);
+    expect(result.max_tokens).toBeUndefined();
+  });
+
+  it("keeps max_tokens for older models", () => {
+    const result = claudeToOpenAIRequest("gpt-4o", body, false);
+    expect(result.max_tokens).toBe(2048);
+    expect(result.max_completion_tokens).toBeUndefined();
+  });
+});
+
+describe("gemini-to-openai max tokens param", () => {
+  const body = { generationConfig: { maxOutputTokens: 1024 }, contents: [] };
+
+  it("emits max_completion_tokens for gpt-5 models", () => {
+    const result = geminiToOpenAIRequest("gpt-5", body, false);
+    expect(result.max_completion_tokens).toBe(1024);
+    expect(result.max_tokens).toBeUndefined();
+  });
+
+  it("keeps max_tokens for older models", () => {
+    const result = geminiToOpenAIRequest("gpt-4o", body, false);
+    expect(result.max_tokens).toBe(1024);
+    expect(result.max_completion_tokens).toBeUndefined();
+  });
+});
+
+describe("antigravity-to-openai max tokens param", () => {
+  const body = { request: { generationConfig: { maxOutputTokens: 1024 }, contents: [] } };
+
+  it("emits max_completion_tokens for gpt-5 models", () => {
+    const result = antigravityToOpenAIRequest("gpt-5.4", body, false);
+    expect(result.max_completion_tokens).toBe(1024);
+    expect(result.max_tokens).toBeUndefined();
+  });
+
+  it("keeps max_tokens for older models", () => {
+    const result = antigravityToOpenAIRequest("gpt-4o", body, false);
+    expect(result.max_tokens).toBe(1024);
+    expect(result.max_completion_tokens).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

OpenAI's Chat Completions API rejects `max_tokens` for gpt-5.x and hyphenated o-series models:

```
400 invalid_request_error / unsupported_parameter
"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."
```

The claude→openai request builder emits `max_tokens` unconditionally (`open-sse/translator/request/claude-to-openai.js:22-24`), and gemini→openai + antigravity→openai do the same. The GitHub executor already maps the param at its own layer (`requiresMaxCompletionTokens`, `/gpt-5|o[134]-/i`), but the native `openai` api-key provider goes through the default executor, which never touches token params — so every Claude-format request (Claude Code, etc.) routed to an `openai/gpt-5.x` model dies at the provider with the 400 above. We hit this in production routing Claude-format traffic to BYOK gpt-5 keys (observed live 2026-08-31).

## Fix

- Hoist the exact match the GitHub executor uses into `translator/formats/maxTokens.js` as `requiresMaxCompletionTokens`, next to `adjustMaxTokens`.
- In the three `*-to-openai` request builders (`claude-to-openai.js`, `gemini-to-openai.js`, `antigravity-to-openai.js`), emit the adjusted budget as `max_completion_tokens` when the model matches, `max_tokens` otherwise.

Requests are born with the right param for every executor, and no downstream path regresses:

- `executors/github.js` maps only when `transformed.max_tokens !== undefined` → clean no-op on the new field.
- `translator/request/openai-responses.js` already prefers `max_completion_tokens` when mapping to `max_output_tokens`.
- `executors/opencode.js` normalizes either field to `max_output_tokens`; `codex.js` / `grok-cli.js` delete both; `qoder.js` reads both.
- `handlers/chatCore/requestDetail.js` `OPTIONAL_PARAMS` already lists both; nothing in `open-sse/handlers/` reads `.max_tokens` post-translation.

The GitHub executor's private copy of the regex is left untouched to keep the diff minimal — happy to point it at the shared helper here if you prefer.

## Tests

New `tests/unit/to-openai-max-completion-tokens.test.js`: the predicate plus each builder × (gpt-5.x, o3-mini, legacy gpt-4o) — 9/9 pass. The full `tests/` suite has a byte-identical failure set with and without this change (the failures on a fresh clone of master are credential/environment-bound, none related).

## Related

- Issues: #560, #1745, #2830, #3587.
- Complementary to #664 / #1828 / #2134 / #3165, which add the mapping in `executors/default.js`. That layer is still the right place to catch passthrough OpenAI-format ingress (deliberately not touched here); this PR fixes translated ingress at the source so it holds for every executor.
- Deeper follow-up worth considering: for gpt-5.x, Chat Completions refuses requests combining function tools with `reasoning_effort` outright (OpenAI's error directs to `/v1/responses`). The native `openai` provider may want Responses-endpoint escalation the way `executors/github.js` already does it (`supportsResponsesEndpoint` + the openai-responses translators; cf. #1797) — that would fix the whole class rather than one parameter name. Happy to open a separate issue with repro details if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
