### PR TITLE
fix: allow CORS preflight on public LLM API paths

### DIFF
--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -216,6 +216,11 @@ export async function proxy(request) {
   }
 
   if (isPublicLlmApi(pathname)) {
+    // A CORS preflight carries no credentials and performs no action, so it must
+    // reach the route's OPTIONS handler (which answers with the CORS headers)
+    // instead of being rejected here — otherwise browsers can never complete a
+    // cross-origin request that sends an Authorization header.
+    if (request.method === "OPTIONS") return NextResponse.next();
     if (await canAccessPublicLlmApi(request)) return NextResponse.next();
     return NextResponse.json({ error: "API key required for remote API access" }, { status: 401 });
   }


### PR DESCRIPTION
### Problem

The dashboard guard (`src/dashboardGuard.js`) requires a valid API key on **every** request to the public LLM prefixes (`/v1`, `/v1beta`, `/codex`), including the CORS **preflight** `OPTIONS` request. A preflight never carries the `Authorization` header, so it is rejected with `401 { "error": "API key required for remote API access" }`.

As a result, any browser-based client that talks to these endpoints with a bearer token can never complete the request: the preflight fails, so the real `GET`/`POST` is never sent. This notably breaks **Open WebUI "Direct Connections"** (the browser fetches `/v1/models` directly with an `Authorization` header) — no models load and chat is unusable when `requireApiKey` is on.

### Fix

Let `OPTIONS` through the guard on public LLM paths so the route's own `OPTIONS` handler answers with the CORS headers. The actual `GET`/`POST` still goes through `canAccessPublicLlmApi` and requires the key — a preflight carries no credentials and performs no action, so this has no security impact.

### Verification

- `OPTIONS /v1/models` → `200` with `Access-Control-Allow-Origin/Methods/Headers`
- `GET /v1/models` without key → `401` (unchanged)
- `GET /v1/models` with a valid key → `200` (unchanged)
- Open WebUI Direct Connection now lists models and chats.
