### PR TITLE
fix: apply persisted theme before first paint to avoid flash on reload

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -32,6 +32,14 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        {/* Apply persisted theme before first paint so a reload does not flash the
+            default (light) theme before the client store hydrates. Mirrors the
+            zustand-persist "theme" key and the `dark` class applyTheme() sets. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var s=localStorage.getItem('theme');var t=s?(JSON.parse(s).state||{}).theme:'system';t=t||'system';var m=window.matchMedia('(prefers-color-scheme: dark)').matches;if(t==='dark'||(t==='system'&&m)){document.documentElement.classList.add('dark')}}catch(e){}})();`,
+          }}
+        />
         <script
           dangerouslySetInnerHTML={{
             __html: `var d=document,r=d.documentElement,f=function(){r.classList.add('fonts-loaded')};if(d.fonts&&d.fonts.load){d.fonts.load('24px "Material Symbols Outlined"').then(f).catch(f);setTimeout(f,3000)}else{f()}`,


### PR DESCRIPTION
### Problem

The theme is applied from the client store inside a `useEffect` (`ThemeProvider` → `themeStore.initTheme`), which runs after hydration. On a reload the page therefore paints the default (light) theme for a frame before the stored `dark` theme is reapplied — a visible white flash.

### Fix

Add a small blocking `<head>` script that reads the persisted zustand `theme` key from `localStorage` and sets the `dark` class on `document.documentElement` before first paint. It mirrors exactly what `applyTheme()` does (including the `system` → `prefers-color-scheme` resolution), so there is no behaviour change — only the flash is removed. Wrapped in try/catch; a light or system-light theme is unaffected.
