### PR TITLE
feat(providers): Alibaba Token Plan live catalog, media generation, and per-model thinking

### DIFF
--- a/open-sse/config/ttsModels.js
+++ b/open-sse/config/ttsModels.js
@@ -48,6 +48,12 @@ const MIMO_VOICES = [
   { id: "Dean",          name: "Dean" },
 ].map((v) => ({ type: "tts", ...v }));
 
+// Alibaba Token Plan voices for qwen-audio-3.0-tts-plus (voice travels in input.voice).
+const QWEN_TOKEN_PLAN_VOICES = [
+  { id: "longanlingxin", name: "Longanlingxin" },
+  { id: "longanlufeng",  name: "Longanlufeng" },
+].map((v) => ({ type: "tts", ...v }));
+
 // ── TTS Config (config-driven, single source of truth) ─────────────────────
 export const TTS_MODELS_CONFIG = {
   openai: {
@@ -128,6 +134,14 @@ export const TTS_MODELS_CONFIG = {
     ],
     voices: {
       "mimo-v2.5-tts": MIMO_VOICES,
+    },
+  },
+  "alitp-intl": {
+    models: [
+      { id: "qwen-audio-3.0-tts-plus", name: "Qwen Audio 3.0 TTS Plus", type: "tts" },
+    ],
+    voices: {
+      "qwen-audio-3.0-tts-plus": QWEN_TOKEN_PLAN_VOICES,
     },
   },
 };

--- a/open-sse/handlers/imageProviders/alitpIntl.js
+++ b/open-sse/handlers/imageProviders/alitpIntl.js
@@ -1,0 +1,84 @@
+// Alibaba Token Plan images (wan2.7-image*) — compatible-mode has no
+// /images/generations, so this uses DashScope multimodal-generation on the
+// plan's own host. Sizes are "W*H", and results are expiring signed OSS URLs.
+import { nowSec } from "./_base.js";
+import { PROVIDER_MEDIA } from "../../providers/index.js";
+
+const BASE_URL = PROVIDER_MEDIA["alitp-intl"]?.imageConfig?.baseUrl;
+
+const OPTIONAL_PARAMETERS = ["negative_prompt", "seed", "prompt_extend", "watermark"];
+
+function toDashScopeSize(size) {
+  const value = String(size || "").trim();
+  if (!value || value === "auto") return null;
+  const match = /^(\d+)\s*[x*×]\s*(\d+)$/i.exec(value);
+  return match ? `${match[1]}*${match[2]}` : null;
+}
+
+function collectImages(node, out) {
+  if (!node) return out;
+  if (Array.isArray(node)) {
+    for (const item of node) collectImages(item, out);
+    return out;
+  }
+  if (typeof node === "object") {
+    const image = node.image || node.url || node.image_url;
+    if (typeof image === "string" && image) out.push(image);
+    return out;
+  }
+  return out;
+}
+
+function normalizeTokenPlanResponse(responseBody) {
+  if (responseBody?.created && Array.isArray(responseBody?.data)) return responseBody;
+
+  const choices = responseBody?.output?.choices;
+  const urls = [];
+  if (Array.isArray(choices)) {
+    for (const choice of choices) collectImages(choice?.message?.content, urls);
+  }
+  // Some DashScope image models answer with output.results instead of choices.
+  if (!urls.length) collectImages(responseBody?.output?.results, urls);
+
+  return {
+    created: nowSec(),
+    data: urls.map((url) => (
+      /^https?:\/\//i.test(url) ? { url } : { b64_json: url.replace(/^data:image\/[^;]+;base64,/i, "") }
+    )),
+  };
+}
+
+export default {
+  buildUrl: () => {
+    if (!BASE_URL) throw new Error("alitp-intl image endpoint is not configured");
+    return BASE_URL;
+  },
+
+  buildHeaders: (creds) => {
+    const headers = { "Content-Type": "application/json" };
+    const key = creds?.apiKey || creds?.accessToken;
+    if (key) headers.Authorization = `Bearer ${key}`;
+    return headers;
+  },
+
+  buildBody: (model, body) => {
+    const parameters = {};
+    const size = toDashScopeSize(body?.size);
+    if (size) parameters.size = size;
+    const n = Number(body?.n);
+    if (Number.isFinite(n) && n > 0) parameters.n = Math.min(Math.trunc(n), 4);
+    for (const field of OPTIONAL_PARAMETERS) {
+      if (body?.[field] !== undefined) parameters[field] = body[field];
+    }
+
+    return {
+      model,
+      input: {
+        messages: [{ role: "user", content: [{ text: body.prompt }] }],
+      },
+      ...(Object.keys(parameters).length ? { parameters } : {}),
+    };
+  },
+
+  normalize: normalizeTokenPlanResponse,
+};

--- a/open-sse/handlers/imageProviders/index.js
+++ b/open-sse/handlers/imageProviders/index.js
@@ -12,6 +12,7 @@ import blackForestLabs from "./blackForestLabs.js";
 import runwayml from "./runwayml.js";
 import cloudflareAi from "./cloudflareAi.js";
 import antigravity from "./antigravity.js";
+import alitpIntl from "./alitpIntl.js";
 
 const ADAPTERS = {
   openai: createOpenAIAdapter("openai"),
@@ -32,6 +33,7 @@ const ADAPTERS = {
   "black-forest-labs": blackForestLabs,
   runwayml,
   "cloudflare-ai": cloudflareAi,
+  "alitp-intl": alitpIntl,
 };
 
 export function getImageAdapter(provider) {

--- a/open-sse/handlers/ttsProviders/genericFormats.js
+++ b/open-sse/handlers/ttsProviders/genericFormats.js
@@ -3,6 +3,9 @@
 import { responseToBase64, throwUpstreamError } from "./_base.js";
 import minimaxTts from "./minimax.js";
 
+// Flagship Token Plan voice for qwen-audio-3.0-tts-plus.
+const DASHSCOPE_DEFAULT_VOICE = "longanlingxin";
+
 // Hyperbolic: POST { text } → { audio: base64 }
 async function hyperbolic({ baseUrl, apiKey, text }) {
   const res = await fetch(baseUrl, {
@@ -172,6 +175,33 @@ async function openaiCompat({ baseUrl, apiKey, text, modelId, voiceId }) {
   return responseToBase64(res, "mp3");
 }
 
+// Alibaba Token Plan: DashScope SpeechSynthesizer → JSON with an expiring URL
+// (output.audio.data stays empty on non-streaming calls).
+async function dashscopeTts({ baseUrl, apiKey, text, modelId, voiceId }) {
+  const res = await fetch(baseUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "Authorization": `Bearer ${apiKey}` },
+    body: JSON.stringify({
+      model: modelId,
+      input: { text, voice: voiceId || DASHSCOPE_DEFAULT_VOICE },
+      parameters: { format: "mp3", sample_rate: 24000 },
+    }),
+  });
+  if (!res.ok) await throwUpstreamError(res);
+
+  const data = await res.json();
+  if (data?.code) throw new Error(data.message || data.code);
+
+  const inline = data?.output?.audio?.data;
+  if (inline) return { base64: inline, format: "mp3" };
+
+  const url = data?.output?.audio?.url;
+  if (!url) throw new Error("DashScope TTS returned no audio");
+  const audio = await fetch(url);
+  if (!audio.ok) await throwUpstreamError(audio);
+  return responseToBase64(audio, "mp3");
+}
+
 // format → handler dispatcher
 export const FORMAT_HANDLERS = {
   hyperbolic,
@@ -186,4 +216,5 @@ export const FORMAT_HANDLERS = {
   openai: openaiCompat,
   "minimax-tts": minimaxTts,
   "fish-audio": fishAudio,
+  "dashscope-tts": dashscopeTts,
 };

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -221,7 +221,7 @@ export const PROVIDER_CAPABILITIES = {
     "qwen3.7-plus":            { vision: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 131072 },
     "qwen3.6-flash":           { vision: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 65536 },
     "glm-5.2":                 { reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1048576, maxOutput: 131072 },
-    "deepseek-v4-pro":         { reasoning: true, search: true, thinkingCanDisable: false, thinkingClampUnsupported: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 393216 },
+    "deepseek-v4-pro":         { reasoning: true, search: true, thinkingCanDisable: false, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 393216 },
     "deepseek-v4-pro-0813":    { reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 393216 },
     "deepseek-v4-flash-0731":  { reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 393216 },
     "wan2.7-image":            { imageOutput: true, tools: false },

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -211,6 +211,26 @@ export const PROVIDER_CAPABILITIES = {
     "laguna-s-2.1":  { reasoning: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 32000 },
     "laguna-xs-2.1": { reasoning: true, thinkingFormat: "openai", contextWindow: 200000, maxOutput: 32000 },
   },
+  // Verified live plus spec pages (qwencloud.com/models/<id>). qwen3.7-max is
+  // text-only on every surface; hosted glm/deepseek accept image and audio parts
+  // but answer blind; qwen3.8-* read PDFs despite no upstream badge. Web search
+  // runs only on /responses (forced tool_choice, all 8) — chat completions
+  // enable_search is a silent no-op. Deepseek never validates maxOutput (spec: 393K).
+  "alitp-intl": {
+    "qwen3.8-max":             { vision: true, videoInput: true, pdf: true, reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 131072 },
+    "qwen3.8-max-preview":     { vision: true, videoInput: true, pdf: true, reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 131072 },
+    "qwen3.8-flash":           { vision: true, videoInput: true, pdf: true, reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 131072 },
+    "qwen3.7-max":             { reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 131072 },
+    "qwen3.7-plus":            { vision: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 131072 },
+    "qwen3.6-flash":           { vision: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 65536 },
+    "glm-5.2":                 { reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1048576, maxOutput: 131072 },
+    "deepseek-v4-pro":         { reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 393216 },
+    "deepseek-v4-pro-0813":    { reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 393216 },
+    "deepseek-v4-flash-0731":  { reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 393216 },
+    "wan2.7-image":            { imageOutput: true, tools: false },
+    "wan2.7-image-pro":        { imageOutput: true, tools: false },
+    "qwen-audio-3.0-tts-plus": { audioOutput: true, tools: false },
+  },
 };
 
 /**

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -211,22 +211,19 @@ export const PROVIDER_CAPABILITIES = {
     "laguna-s-2.1":  { reasoning: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 32000 },
     "laguna-xs-2.1": { reasoning: true, thinkingFormat: "openai", contextWindow: 200000, maxOutput: 32000 },
   },
-  // Verified live plus spec pages (qwencloud.com/models/<id>). qwen3.7-max is
-  // text-only on every surface; hosted glm/deepseek accept image and audio parts
-  // but answer blind; qwen3.8-* read PDFs despite no upstream badge. Web search
-  // runs only on /responses (forced tool_choice, all 8) — chat completions
-  // enable_search is a silent no-op. Deepseek never validates maxOutput (spec: 393K).
+  // Thinking: reasoning_effort enums probed per model (see thinkingLevels.js);
+  // deepseek-v4-pro cannot disable thinking.
   "alitp-intl": {
-    "qwen3.8-max":             { vision: true, videoInput: true, pdf: true, reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 131072 },
-    "qwen3.8-max-preview":     { vision: true, videoInput: true, pdf: true, reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 131072 },
-    "qwen3.8-flash":           { vision: true, videoInput: true, pdf: true, reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 131072 },
-    "qwen3.7-max":             { reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 131072 },
-    "qwen3.7-plus":            { vision: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 131072 },
-    "qwen3.6-flash":           { vision: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 65536 },
-    "glm-5.2":                 { reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1048576, maxOutput: 131072 },
-    "deepseek-v4-pro":         { reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 393216 },
-    "deepseek-v4-pro-0813":    { reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 393216 },
-    "deepseek-v4-flash-0731":  { reasoning: true, search: true, thinkingFormat: "qwen", contextWindow: 1000000, maxOutput: 393216 },
+    "qwen3.8-max":             { vision: true, videoInput: true, pdf: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 131072 },
+    "qwen3.8-max-preview":     { vision: true, videoInput: true, pdf: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 131072 },
+    "qwen3.8-flash":           { vision: true, videoInput: true, pdf: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 131072 },
+    "qwen3.7-max":             { reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 131072 },
+    "qwen3.7-plus":            { vision: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 131072 },
+    "qwen3.6-flash":           { vision: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 65536 },
+    "glm-5.2":                 { reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1048576, maxOutput: 131072 },
+    "deepseek-v4-pro":         { reasoning: true, search: true, thinkingCanDisable: false, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 393216 },
+    "deepseek-v4-pro-0813":    { reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 393216 },
+    "deepseek-v4-flash-0731":  { reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 393216 },
     "wan2.7-image":            { imageOutput: true, tools: false },
     "wan2.7-image-pro":        { imageOutput: true, tools: false },
     "qwen-audio-3.0-tts-plus": { audioOutput: true, tools: false },

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -221,7 +221,7 @@ export const PROVIDER_CAPABILITIES = {
     "qwen3.7-plus":            { vision: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 131072 },
     "qwen3.6-flash":           { vision: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 65536 },
     "glm-5.2":                 { reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1048576, maxOutput: 131072 },
-    "deepseek-v4-pro":         { reasoning: true, search: true, thinkingCanDisable: false, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 393216 },
+    "deepseek-v4-pro":         { reasoning: true, search: true, thinkingCanDisable: false, thinkingClampUnsupported: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 393216 },
     "deepseek-v4-pro-0813":    { reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 393216 },
     "deepseek-v4-flash-0731":  { reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 393216 },
     "wan2.7-image":            { imageOutput: true, tools: false },

--- a/open-sse/providers/registry/alitp-intl.js
+++ b/open-sse/providers/registry/alitp-intl.js
@@ -1,9 +1,10 @@
-// Token Plan — credit subscription keys on token-plan.<region>.maas.aliyuncs.com.
-// Fourth Alibaba key type: Coding Plan (alicode/alicode-intl) and Model Studio
-// (alims-intl) both reject these keys, and they reject Model Studio keys back.
-// Singapore is the only region that serves the plan; eu-central-1 answers
-// IllegalEndpoint. The Anthropic surface (/apps/anthropic/v1/messages) is not
-// authorized for this plan, so OpenAI-compatible mode is the only transport.
+// Token Plan — a fourth Alibaba key type: Coding Plan (alicode/alicode-intl) and
+// Model Studio (alims-intl) hosts reject it, and it rejects theirs. Only the
+// Singapore region serves these keys (eu-central-1: 401 invalid API key).
+// Chat completions is the only surface with video/PDF parts; /responses is the
+// only one that executes the web_search Harness tool (enable_search is a silent
+// no-op on chat). Image/TTS are DashScope-native on the same host.
+// `models` is the offline fallback; live catalog: services/alibabaTokenPlanModels.js.
 export default {
   id: "alitp-intl",
   priority: 11,
@@ -19,17 +20,48 @@ export default {
     },
   },
   category: "apikey",
+  serviceKinds: ["llm", "image", "tts"],
   transport: {
     baseUrl: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions",
+    validateUrl: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/models",
     headers: {},
     quirks: { preserveCacheControl: true },
   },
+  // Multi-endpoint: pick the transport matching client sourceFormat to skip
+  // translation. No supportedFormats guards — every chat model answers on all three.
+  transports: [
+    {
+      format: "openai-responses",
+      baseUrl: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/responses",
+      auth: { combined: true, header: "Authorization", scheme: "bearer" },
+    },
+    {
+      format: "claude",
+      baseUrl: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic/v1/messages",
+      auth: { combined: true, header: "x-api-key", scheme: "raw", anthropicVersion: true },
+    },
+  ],
   models: [
-    { id: "qwen3.8-max-preview", name: "Qwen3.8 Max Preview" },
+    { id: "qwen3.8-max", name: "Qwen3.8 Max" },
+    { id: "qwen3.8-flash", name: "Qwen3.8 Flash" },
     { id: "qwen3.7-max", name: "Qwen3.7 Max" },
     { id: "qwen3.7-plus", name: "Qwen3.7 Plus" },
     { id: "qwen3.6-flash", name: "Qwen3.6 Flash" },
     { id: "glm-5.2", name: "GLM 5.2" },
     { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro" },
+    { id: "deepseek-v4-pro-0813", name: "DeepSeek V4 Pro 0813" },
+    { id: "deepseek-v4-flash-0731", name: "DeepSeek V4 Flash 0731" },
+    { id: "wan2.7-image", name: "Wan2.7 Image", kind: "image", params: ["size"] },
+    { id: "wan2.7-image-pro", name: "Wan2.7 Image Pro", kind: "image", params: ["size"] },
+    { id: "qwen-audio-3.0-tts-plus", name: "Qwen Audio 3.0 TTS Plus", kind: "tts" },
   ],
+  imageConfig: {
+    baseUrl: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation",
+  },
+  ttsConfig: {
+    baseUrl: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/api/v1/services/audio/tts/SpeechSynthesizer",
+    authType: "apikey",
+    authHeader: "bearer",
+    format: "dashscope-tts",
+  },
 };

--- a/open-sse/providers/registry/alitp-intl.js
+++ b/open-sse/providers/registry/alitp-intl.js
@@ -39,6 +39,7 @@ export default {
       format: "claude",
       baseUrl: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic/v1/messages",
       auth: { combined: true, header: "x-api-key", scheme: "raw", anthropicVersion: true },
+      thinkingFormat: "claude-budget", // native thinking, not compatible-mode reasoning_effort
     },
   ],
   models: [

--- a/open-sse/providers/thinkingLevels.js
+++ b/open-sse/providers/thinkingLevels.js
@@ -36,6 +36,13 @@ const CODEX_GPT_5_6_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh
 // Alibaba Token Plan enums probed from upstream 400 messages — the OpenAI enum plus "max".
 const ALITP_INTL_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
 
+// Ascending effort ladder, for floor comparisons.
+const LEVEL_ORDER = ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"];
+
+// Providers that 400 on a reasoning_effort outside the model's enum, so a level below
+// the floor must be raised rather than forwarded.
+const STRICT_LEVEL_PROVIDERS = new Set(["alitp-intl"]);
+
 // Model-name pattern overrides (glob, first match wins) — more precise than format default.
 const PATTERN_THINKING = [
   { provider: "codex", pattern: "*gpt-5.6-sol*", levels: [...CODEX_GPT_5_6_LEVELS, "ultra"] },
@@ -53,7 +60,7 @@ const PATTERN_THINKING = [
   { provider: "alitp-intl", pattern: "glm-5.2",                levels: ALITP_INTL_LEVELS },
   { provider: "alitp-intl", pattern: "deepseek-v4-pro-0813",   levels: ALITP_INTL_LEVELS },
   { provider: "alitp-intl", pattern: "deepseek-v4-flash-0731", levels: ALITP_INTL_LEVELS },
-  // deepseek-v4-pro also rejects minimal, and getThinkingLevels only filters "none".
+  // deepseek-v4-pro rejects "none" and "minimal"; raiseLevelToFloor lifts both to "low".
   { provider: "alitp-intl", pattern: "deepseek-v4-pro",        levels: ["low", "medium", "high", "xhigh", "max"] },
 ];
 
@@ -68,4 +75,14 @@ export function getThinkingLevels(provider, model) {
   let levels = hit?.levels || FORMAT_LEVELS[caps.thinkingFormat] || L.base;
   if (caps.thinkingCanDisable === false) levels = levels.filter((l) => l !== "none");
   return levels;
+}
+
+// Raise a level to the model's floor for strict providers; others pass through, so a
+// picker that merely omits a level (codex declares low..xhigh) still forwards "minimal".
+export function raiseLevelToFloor(provider, level, levels) {
+  if (!STRICT_LEVEL_PROVIDERS.has(provider) || !levels?.length) return level;
+  if (levels.includes(level)) return level;
+  const at = LEVEL_ORDER.indexOf(level);
+  const floor = LEVEL_ORDER.indexOf(levels[0]);
+  return at >= 0 && floor >= 0 && at < floor ? levels[0] : level;
 }

--- a/open-sse/providers/thinkingLevels.js
+++ b/open-sse/providers/thinkingLevels.js
@@ -33,6 +33,9 @@ const FORMAT_LEVELS = {
 
 const CODEX_GPT_5_6_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
 
+// Alibaba Token Plan enums probed from upstream 400 messages — the OpenAI enum plus "max".
+const ALITP_INTL_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+
 // Model-name pattern overrides (glob, first match wins) — more precise than format default.
 const PATTERN_THINKING = [
   { provider: "codex", pattern: "*gpt-5.6-sol*", levels: [...CODEX_GPT_5_6_LEVELS, "ultra"] },
@@ -46,6 +49,12 @@ const PATTERN_THINKING = [
   { provider: "codebuddy-cn", pattern: "deepseek-v4*", levels: ["low", "high", "xhigh"] },
   { provider: "codebuddy-cn", pattern: "hy3*",         levels: ["low", "high"] },
   { provider: "codebuddy-cn", pattern: "hy4*",         levels: ["high"] },
+  { provider: "alitp-intl", pattern: "qwen3.8-*",              levels: ALITP_INTL_LEVELS },
+  { provider: "alitp-intl", pattern: "glm-5.2",                levels: ALITP_INTL_LEVELS },
+  { provider: "alitp-intl", pattern: "deepseek-v4-pro-0813",   levels: ALITP_INTL_LEVELS },
+  { provider: "alitp-intl", pattern: "deepseek-v4-flash-0731", levels: ALITP_INTL_LEVELS },
+  // deepseek-v4-pro also rejects minimal, and getThinkingLevels only filters "none".
+  { provider: "alitp-intl", pattern: "deepseek-v4-pro",        levels: ["low", "medium", "high", "xhigh", "max"] },
 ];
 
 // Returns valid thinking levels for a model, or null when the model has no reasoning.

--- a/open-sse/services/alibabaTokenPlanModels.js
+++ b/open-sse/services/alibabaTokenPlanModels.js
@@ -1,0 +1,130 @@
+/**
+ * Alibaba Token Plan live model catalog.
+ *
+ * The subscription's catalog moves independently of this repo, so /v1/models
+ * prefers this fetch and falls back to the static registry list.
+ *
+ * Alibaba returns every capability from one OpenAI-shaped /models response with
+ * no kind field, so IDs are classified here and anything this gateway cannot
+ * execute is withheld instead of advertised as a broken route.
+ */
+import crypto from "crypto";
+
+import { PROVIDERS, PROVIDER_MODELS } from "../providers/index.js";
+
+const FETCH_TIMEOUT_MS = 10_000;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+/** @type {Map<string, { expiresAt: number, models: { id: string, name: string, kind: string }[] }>} */
+const catalogCache = new Map();
+
+function cacheKey(apiKey) {
+  return crypto.createHash("sha256").update(String(apiKey)).digest("hex");
+}
+
+function modelsUrl() {
+  return PROVIDERS["alitp-intl"]?.validateUrl || null;
+}
+
+/**
+ * Map a Token Plan model ID to the service kind this gateway can route it as.
+ * Returns null for models with no executable HTTP path here.
+ *
+ * @param {string} modelId
+ * @returns {"llm" | "image" | "tts" | null}
+ */
+export function classifyTokenPlanModel(modelId) {
+  const id = String(modelId || "").trim().toLowerCase();
+  if (!id) return null;
+  // WebSocket/WebRTC speech-to-speech — no WebSocket surface in this gateway.
+  if (id.includes("-realtime")) return null;
+  // Async video job APIs — no video executor for this provider.
+  if (id.startsWith("happyhorse") || /-(?:t2v|i2v|video)\b/.test(id) || id.includes("-video-")) return null;
+  if (id.includes("-tts")) return "tts";
+  // DashScope ASR is WebSocket/file-job based; no STT executor for this provider.
+  if (id.includes("-asr") || id.includes("-stt")) return null;
+  if (id.includes("-image")) return "image";
+  return "llm";
+}
+
+function staticNameFor(modelId) {
+  const models = PROVIDER_MODELS["alitp-intl"] || [];
+  return models.find((model) => model.id === modelId)?.name || modelId;
+}
+
+async function fetchTokenPlanCatalog(apiKey, signal) {
+  const url = modelsUrl();
+  if (!url) return null;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  signal?.addEventListener?.("abort", () => controller.abort(), { once: true });
+
+  let response;
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!response.ok) {
+    const error = new Error(`Alibaba Token Plan /models returned ${response.status}`);
+    error.status = response.status;
+    throw error;
+  }
+
+  const payload = await response.json();
+  const entries = Array.isArray(payload?.data) ? payload.data : [];
+
+  const models = [];
+  const seen = new Set();
+  for (const entry of entries) {
+    const id = typeof entry?.id === "string" ? entry.id.trim() : "";
+    if (!id || seen.has(id)) continue;
+    const kind = classifyTokenPlanModel(id);
+    if (!kind) continue;
+    seen.add(id);
+    models.push({ id, name: entry.name || staticNameFor(id), kind });
+  }
+  return models;
+}
+
+/**
+ * Resolve the live Token Plan catalog for the authenticated subscription.
+ * Returns null on any failure so callers fall back to the static registry.
+ *
+ * @param {{ apiKey?: string, accessToken?: string }} credentials
+ * @param {{ log?: object, signal?: AbortSignal, forceRefresh?: boolean }} [options]
+ */
+export async function resolveAlibabaTokenPlanModels(credentials, options = {}) {
+  const apiKey = credentials?.apiKey || credentials?.accessToken;
+  if (!apiKey) {
+    options.log?.debug?.("ALITP_MODELS", "No Token Plan API key; skipping live fetch");
+    return null;
+  }
+
+  const key = cacheKey(apiKey);
+  const now = Date.now();
+  if (!options.forceRefresh) {
+    const cached = catalogCache.get(key);
+    if (cached?.expiresAt > now) return { models: cached.models };
+  }
+
+  try {
+    const models = await fetchTokenPlanCatalog(apiKey, options.signal);
+    if (!models?.length) return null;
+    catalogCache.set(key, { expiresAt: now + CACHE_TTL_MS, models });
+    return { models };
+  } catch (error) {
+    options.log?.warn?.("ALITP_MODELS", `Live model fetch failed: ${error?.message || error}`);
+    return null;
+  }
+}
+
+export function clearAlibabaTokenPlanModelCache() {
+  catalogCache.clear();
+}

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -107,7 +107,13 @@ export const captureThinking = extractThinking;
 
 const NATIVE_ONLY_FORMATS = new Set(["gemini-level", "gemini-budget", "claude-budget", "claude-adaptive", "kiro"]);
 
-function resolveFormat(targetFormat, model, provider) {
+// Runtime transport override > provider override > capability > target format.
+// Multi-transport providers accept a different thinking shape per surface.
+// A capability's native-only format is skipped on an OpenAI wire, so a Gemini
+// model served by an OpenAI-compatible provider still gets reasoning_effort.
+function resolveFormat(targetFormat, model, provider, credentials = null) {
+  const transportFmt = credentials?.runtimeTransport?.thinkingFormat;
+  if (transportFmt) return transportFmt;
   const providerFmt = provider ? PROVIDERS[provider]?.thinkingFormat : null;
   if (providerFmt) return providerFmt;
   const caps = getCapabilitiesForModel(provider, model);
@@ -141,7 +147,13 @@ function toLevel(cfg) {
 }
 
 function normalizeOpenAILevel(level, supportedLevels) {
-  if (level !== "max" && level !== "ultra") return level;
+  if (level !== "max" && level !== "ultra") {
+    // thinkingCanDisable:false clamps none→minimal; use the lowest supported level
+    if ((level === "minimal" || level === "none") && supportedLevels?.length && !supportedLevels.includes(level)) {
+      return supportedLevels[0];
+    }
+    return level;
+  }
   if (supportedLevels?.includes(level)) return level;
   if (level === "ultra" && supportedLevels?.includes("max")) return "max";
   return "xhigh";
@@ -252,7 +264,9 @@ function applyFormat(fmt, body, cfg, caps, supportedLevels) {
     case "claude-budget": {
       if (none && canDisable) { body.thinking = { type: "disabled" }; break; }
       const budget = toBudget(eff, caps.thinkingRange);
-      body.thinking = budget === -1 ? { type: "enabled" } : { type: "enabled", budget_tokens: budget || 8192 };
+      // Anthropic requires budget_tokens >= 1024.
+      const floored = Number.isFinite(budget) && budget > 0 ? Math.max(budget, 1024) : budget;
+      body.thinking = floored === -1 ? { type: "enabled" } : { type: "enabled", budget_tokens: floored || 8192 };
       break;
     }
     case "gemini-level": {
@@ -342,10 +356,10 @@ function applyFormat(fmt, body, cfg, caps, supportedLevels) {
 }
 
 // Public entry: normalize thinking for the resolved target format.
-// Mutates and returns body. No-op when model has no reasoning capability.
-// `intent` is a pre-captured config (from captureThinking on the original body);
-// falls back to extracting from the current body when omitted.
-export function applyThinking(targetFormat, model, body, provider = null, intent = undefined) {
+// `credentials.runtimeTransport` selects the per-transport thinking format.
+export function applyThinking(targetFormat, model, body, provider = null, intent = undefined, credentials = null) {
+  if (!body || typeof body !== "object") return body;
+
   if (!body || typeof body !== "object") return body;
 
   const { cleanModel, override } = parseSuffix(model);
@@ -359,7 +373,7 @@ export function applyThinking(targetFormat, model, body, provider = null, intent
   }
   if (!cfg) return body;
 
-  const fmt = resolveFormat(targetFormat, cleanModel, provider);
+  const fmt = resolveFormat(targetFormat, cleanModel, provider, credentials);
   const supportedLevels = getThinkingLevels(provider, cleanModel);
   stripAll(body);
   applyFormat(fmt, body, cfg, caps, supportedLevels);

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -360,8 +360,6 @@ function applyFormat(fmt, body, cfg, caps, supportedLevels) {
 export function applyThinking(targetFormat, model, body, provider = null, intent = undefined, credentials = null) {
   if (!body || typeof body !== "object") return body;
 
-  if (!body || typeof body !== "object") return body;
-
   const { cleanModel, override } = parseSuffix(model);
   const cfg = override || intent || extractThinking(body);
   const caps = getCapabilitiesForModel(provider, cleanModel);

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -236,21 +236,15 @@ function applyFormat(fmt, body, cfg, caps, supportedLevels) {
   const none = cfg.mode === "none";
   const canDisable = caps.thinkingCanDisable !== false;
   // Model cannot disable thinking → clamp "none" to minimal effort instead.
-  let eff = none && !canDisable ? { mode: "level", level: "minimal" } : cfg;
-  if (
-    caps.thinkingClampUnsupported
-    && eff.mode === "level"
-    && (eff.level === "minimal" || eff.level === "none")
-    && supportedLevels?.length
-    && !supportedLevels.includes(eff.level)
-  ) {
-    eff = { ...eff, level: supportedLevels[0] };
-  }
+  const eff = none && !canDisable ? { mode: "level", level: "minimal" } : cfg;
 
   switch (fmt) {
     case "openai": {
       if (none && canDisable) { body.reasoning_effort = "none"; break; }
-      const level = toLevel(eff);
+      // Cannot disable → send the model's lowest selectable effort. That is
+      // "minimal" for most models and "low" where upstream rejects minimal
+      // (alitp-intl/deepseek-v4-pro; see thinkingLevels.js).
+      const level = none ? (supportedLevels?.[0] || "minimal") : toLevel(eff);
       if (level) body.reasoning_effort = normalizeOpenAILevel(level, supportedLevels);
       break;
     }

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -3,7 +3,7 @@
 // never hardcoded per-model here. See .docs/thinking/plan.md MATRIX VI-A.
 
 import { getCapabilitiesForModel } from "../../providers/capabilities.js";
-import { getThinkingLevels } from "../../providers/thinkingLevels.js";
+import { getThinkingLevels, raiseLevelToFloor } from "../../providers/thinkingLevels.js";
 import { PROVIDERS } from "../../providers/index.js";
 import { LEVEL_TO_BUDGET, budgetToLevel, effortToBudget, effortToThinkingLevel } from "./thinking.js";
 
@@ -232,7 +232,7 @@ function stripAll(body) {
 }
 
 // Apply unified thinking config to body in the resolved provider-native format.
-function applyFormat(fmt, body, cfg, caps, supportedLevels) {
+function applyFormat(fmt, body, cfg, caps, supportedLevels, provider) {
   const none = cfg.mode === "none";
   const canDisable = caps.thinkingCanDisable !== false;
   // Model cannot disable thinking → clamp "none" to minimal effort instead.
@@ -245,7 +245,10 @@ function applyFormat(fmt, body, cfg, caps, supportedLevels) {
       // "minimal" for most models and "low" where upstream rejects minimal
       // (alitp-intl/deepseek-v4-pro; see thinkingLevels.js).
       const level = none ? (supportedLevels?.[0] || "minimal") : toLevel(eff);
-      if (level) body.reasoning_effort = normalizeOpenAILevel(level, supportedLevels);
+      if (level) {
+        const floored = raiseLevelToFloor(provider, level, supportedLevels);
+        body.reasoning_effort = normalizeOpenAILevel(floored, supportedLevels);
+      }
       break;
     }
     case "claude-adaptive": {
@@ -369,6 +372,6 @@ export function applyThinking(targetFormat, model, body, provider = null, intent
   const fmt = resolveFormat(targetFormat, cleanModel, provider, credentials);
   const supportedLevels = getThinkingLevels(provider, cleanModel);
   stripAll(body);
-  applyFormat(fmt, body, cfg, caps, supportedLevels);
+  applyFormat(fmt, body, cfg, caps, supportedLevels, provider);
   return body;
 }

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -147,13 +147,7 @@ function toLevel(cfg) {
 }
 
 function normalizeOpenAILevel(level, supportedLevels) {
-  if (level !== "max" && level !== "ultra") {
-    // thinkingCanDisable:false clamps none→minimal; use the lowest supported level
-    if ((level === "minimal" || level === "none") && supportedLevels?.length && !supportedLevels.includes(level)) {
-      return supportedLevels[0];
-    }
-    return level;
-  }
+  if (level !== "max" && level !== "ultra") return level;
   if (supportedLevels?.includes(level)) return level;
   if (level === "ultra" && supportedLevels?.includes("max")) return "max";
   return "xhigh";
@@ -242,7 +236,16 @@ function applyFormat(fmt, body, cfg, caps, supportedLevels) {
   const none = cfg.mode === "none";
   const canDisable = caps.thinkingCanDisable !== false;
   // Model cannot disable thinking → clamp "none" to minimal effort instead.
-  const eff = none && !canDisable ? { mode: "level", level: "minimal" } : cfg;
+  let eff = none && !canDisable ? { mode: "level", level: "minimal" } : cfg;
+  if (
+    caps.thinkingClampUnsupported
+    && eff.mode === "level"
+    && (eff.level === "minimal" || eff.level === "none")
+    && supportedLevels?.length
+    && !supportedLevels.includes(eff.level)
+  ) {
+    eff = { ...eff, level: supportedLevels[0] };
+  }
 
   switch (fmt) {
     case "openai": {
@@ -264,9 +267,7 @@ function applyFormat(fmt, body, cfg, caps, supportedLevels) {
     case "claude-budget": {
       if (none && canDisable) { body.thinking = { type: "disabled" }; break; }
       const budget = toBudget(eff, caps.thinkingRange);
-      // Anthropic requires budget_tokens >= 1024.
-      const floored = Number.isFinite(budget) && budget > 0 ? Math.max(budget, 1024) : budget;
-      body.thinking = floored === -1 ? { type: "enabled" } : { type: "enabled", budget_tokens: floored || 8192 };
+      body.thinking = budget === -1 ? { type: "enabled" } : { type: "enabled", budget_tokens: budget || 8192 };
       break;
     }
     case "gemini-level": {

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -116,7 +116,7 @@ export function translateRequest(sourceFormat, targetFormat, model, body, stream
     targetFormat === FORMATS.KIRO &&
     (sourceFormat === FORMATS.OPENAI || sourceFormat === FORMATS.CLAUDE);
   if (!kiroThinkingMappedByTranslator) {
-    applyThinking(targetFormat, model, result, provider, thinkingIntent);
+    applyThinking(targetFormat, model, result, provider, thinkingIntent, credentials);
   }
 
   // Always normalize to clean OpenAI format when target is OpenAI

--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -11,6 +11,7 @@ import { resolveQoderModels } from "open-sse/services/qoderModels.js";
 import { resolveGrokCliModels } from "open-sse/services/grokCliModels.js";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { resolveCursorModels } from "open-sse/services/cursorModels.js";
+import { classifyTokenPlanModel } from "open-sse/services/alibabaTokenPlanModels.js";
 
 const GEMINI_CLI_MODELS_URL = "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels";
 
@@ -232,6 +233,15 @@ const PROVIDER_MODELS_CONFIG = {
     authHeader: "Authorization",
     authPrefix: "Bearer ",
     parseResponse: (data) => data.data || []
+  },
+  "alitp-intl": {
+    url: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/models",
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+    authHeader: "Authorization",
+    authPrefix: "Bearer ",
+    // Withhold the models this gateway has no executable route for.
+    parseResponse: (data) => (data.data || []).filter((m) => classifyTokenPlanModel(m?.id)),
   },
   "volcengine-ark": createOpenAIModelsConfig("https://ark.cn-beijing.volces.com/api/coding/v3/models"),
   byteplus: createOpenAIModelsConfig("https://ark.ap-southeast.bytepluses.com/api/coding/v3/models"),

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -482,14 +482,13 @@ export async function buildModelsList(kindFilter, options = {}) {
           object: "model",
           owned_by: outputAlias,
         };
-        // Live-catalog resolvers (kiro/qoder/github/clinepass) mostly only return
-        // { id, name } — no per-model capability data. Fall back to the resolved
-        // kind (custom, live, or the registry's own `kind`) so a typed image/tts
-        // model is not reported as text-only, then to the same pattern-matched
-        // capabilities the dashboard uses (useModelCaps.js) so dynamically
-        // discovered LLM models still surface vision/reasoning/search/tools.
+        // Live resolvers mostly omit capabilities. Alibaba's static fallback
+        // still needs the registry kind for image and TTS models.
+        const capabilityKind = customKind
+          || liveKind
+          || (providerId === "alitp-intl" ? staticModelKindById.get(modelId) : null);
         const caps = liveCapabilitiesById.get(modelId)
-          || capabilitiesFromServiceKind(kind)
+          || capabilitiesFromServiceKind(capabilityKind)
           || (kind === LLM_KIND ? getCapabilitiesForModel(providerId, modelId) : null);
         if (caps) model.capabilities = caps;
         // Token limits under the snake_case names the OpenAI/OpenRouter

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -15,6 +15,7 @@ import { resolveClinepassModels } from "open-sse/services/clinepassModels.js";
 import { resolveGrokCliModels } from "open-sse/services/grokCliModels.js";
 import { resolveCursorModels } from "open-sse/services/cursorModels.js";
 import { resolveZedModels } from "open-sse/shared/zedAuth.js";
+import { resolveAlibabaTokenPlanModels } from "open-sse/services/alibabaTokenPlanModels.js";
 import { updateProviderCredentials } from "@/sse/services/tokenRefresh";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { capabilitiesFromServiceKind, getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
@@ -121,6 +122,10 @@ const LIVE_MODEL_RESOLVERS = {
           capabilities: m.supportsTools ? { tools: true } : undefined,
         })),
     };
+  },
+  "alitp-intl": async (conn) => {
+    const result = await resolveAlibabaTokenPlanModels({ apiKey: conn.apiKey }, { log: console });
+    return result?.models?.length ? { models: result.models } : null;
   },
 };
 
@@ -478,11 +483,13 @@ export async function buildModelsList(kindFilter, options = {}) {
           owned_by: outputAlias,
         };
         // Live-catalog resolvers (kiro/qoder/github/clinepass) mostly only return
-        // { id, name } — no per-model capability data. Fall back to the same
-        // pattern-matched capabilities the dashboard uses (useModelCaps.js) so
-        // dynamically-discovered LLM models still surface vision/reasoning/search/tools.
+        // { id, name } — no per-model capability data. Fall back to the resolved
+        // kind (custom, live, or the registry's own `kind`) so a typed image/tts
+        // model is not reported as text-only, then to the same pattern-matched
+        // capabilities the dashboard uses (useModelCaps.js) so dynamically
+        // discovered LLM models still surface vision/reasoning/search/tools.
         const caps = liveCapabilitiesById.get(modelId)
-          || capabilitiesFromServiceKind(customKind || liveKind)
+          || capabilitiesFromServiceKind(kind)
           || (kind === LLM_KIND ? getCapabilitiesForModel(providerId, modelId) : null);
         if (caps) model.capabilities = caps;
         // Token limits under the snake_case names the OpenAI/OpenRouter

--- a/tests/__baseline__/alias-baseline.json
+++ b/tests/__baseline__/alias-baseline.json
@@ -208,6 +208,7 @@
     "alicode-intl",
     "alims-intl",
     "alitp-intl",
+    "alitp-intl-tts-models",
     "anthropic",
     "assemblyai",
     "black-forest-labs",

--- a/tests/__baseline__/providers-baseline.json
+++ b/tests/__baseline__/providers-baseline.json
@@ -1003,10 +1003,32 @@
   },
   "alitp-intl": {
     "baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions",
+    "validateUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/models",
     "headers": {},
     "quirks": {
       "preserveCacheControl": true
     },
-    "format": "openai"
+    "format": "openai",
+    "transports": [
+      {
+        "format": "openai-responses",
+        "baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/responses",
+        "auth": {
+          "combined": true,
+          "header": "Authorization",
+          "scheme": "bearer"
+        }
+      },
+      {
+        "format": "claude",
+        "baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic/v1/messages",
+        "auth": {
+          "combined": true,
+          "header": "x-api-key",
+          "scheme": "raw",
+          "anthropicVersion": true
+        }
+      }
+    ]
   }
 }

--- a/tests/__baseline__/providers-baseline.json
+++ b/tests/__baseline__/providers-baseline.json
@@ -1027,7 +1027,8 @@
           "header": "x-api-key",
           "scheme": "raw",
           "anthropicVersion": true
-        }
+        },
+        "thinkingFormat": "claude-budget"
       }
     ]
   }

--- a/tests/unit/alibaba-token-plan-discovery.test.js
+++ b/tests/unit/alibaba-token-plan-discovery.test.js
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  classifyTokenPlanModel,
+  clearAlibabaTokenPlanModelCache,
+  resolveAlibabaTokenPlanModels,
+} from "../../open-sse/services/alibabaTokenPlanModels.js";
+import { getImageAdapter } from "../../open-sse/handlers/imageProviders/index.js";
+import { FORMAT_HANDLERS } from "../../open-sse/handlers/ttsProviders/genericFormats.js";
+
+// Exactly what the live subscription returns today.
+const LIVE_CATALOG = [
+  "qwen3.7-max",
+  "qwen3.7-plus",
+  "qwen3.6-flash",
+  "glm-5.2",
+  "deepseek-v4-pro",
+  "wan2.7-image",
+  "wan2.7-image-pro",
+  "qwen-audio-3.0-tts-plus",
+  "deepseek-v4-flash-0731",
+  "qwen3.8-max",
+  "qwen-audio-3.0-realtime-plus",
+  "qwen3.8-flash",
+];
+
+function modelsResponse(ids = LIVE_CATALOG) {
+  return new Response(JSON.stringify({ object: "list", data: ids.map((id) => ({ id, object: "model" })) }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("Token Plan model classification", () => {
+  it("routes chat, image and speech models to their own kinds", () => {
+    expect(classifyTokenPlanModel("qwen3.8-max")).toBe("llm");
+    expect(classifyTokenPlanModel("deepseek-v4-flash-0731")).toBe("llm");
+    expect(classifyTokenPlanModel("wan2.7-image")).toBe("image");
+    expect(classifyTokenPlanModel("wan2.7-image-pro")).toBe("image");
+    expect(classifyTokenPlanModel("qwen-audio-3.0-tts-plus")).toBe("tts");
+  });
+
+  it("withholds models this gateway cannot execute", () => {
+    // WebSocket/WebRTC speech-to-speech only.
+    expect(classifyTokenPlanModel("qwen-audio-3.0-realtime-plus")).toBeNull();
+    // Async video jobs have no executor.
+    expect(classifyTokenPlanModel("wan2.7-t2v")).toBeNull();
+    expect(classifyTokenPlanModel("wan2.7-i2v")).toBeNull();
+    expect(classifyTokenPlanModel("happyhorse1.1")).toBeNull();
+    expect(classifyTokenPlanModel("paraformer-asr-v2")).toBeNull();
+    expect(classifyTokenPlanModel("")).toBeNull();
+  });
+});
+
+describe("Token Plan live catalog resolver", () => {
+  beforeEach(() => {
+    clearAlibabaTokenPlanModelCache();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    clearAlibabaTokenPlanModelCache();
+  });
+
+  it("fetches the authenticated catalog and classifies every entry", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(modelsResponse());
+
+    const result = await resolveAlibabaTokenPlanModels({ apiKey: "sk-test" });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/models");
+    expect(init.headers.Authorization).toBe("Bearer sk-test");
+
+    // Static registry snapshot never contained these; only a live fetch can.
+    expect(result.models.map((m) => m.id)).toContain("deepseek-v4-flash-0731");
+    expect(result.models.filter((m) => m.kind === "image").map((m) => m.id))
+      .toEqual(["wan2.7-image", "wan2.7-image-pro"]);
+    expect(result.models.filter((m) => m.kind === "tts").map((m) => m.id))
+      .toEqual(["qwen-audio-3.0-tts-plus"]);
+    expect(result.models.map((m) => m.id)).not.toContain("qwen-audio-3.0-realtime-plus");
+    expect(result.models.every((m) => m.name)).toBe(true);
+  });
+
+  it("caches the catalog per key instead of refetching per request", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(modelsResponse());
+
+    await resolveAlibabaTokenPlanModels({ apiKey: "sk-test" });
+    await resolveAlibabaTokenPlanModels({ apiKey: "sk-test" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the static list when discovery fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope", { status: 401 }));
+    expect(await resolveAlibabaTokenPlanModels({ apiKey: "sk-test" })).toBeNull();
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(modelsResponse([]));
+    expect(await resolveAlibabaTokenPlanModels({ apiKey: "sk-test" })).toBeNull();
+
+    expect(await resolveAlibabaTokenPlanModels({})).toBeNull();
+  });
+});
+
+describe("Token Plan image adapter", () => {
+  const adapter = getImageAdapter("alitp-intl");
+
+  it("posts a DashScope multimodal-generation request", () => {
+    expect(adapter.buildUrl("wan2.7-image", {}))
+      .toBe("https://token-plan.ap-southeast-1.maas.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation");
+    expect(adapter.buildHeaders({ apiKey: "sk-test" }).Authorization).toBe("Bearer sk-test");
+
+    // OpenAI clients send "1024x1024"; DashScope only accepts "1024*1024".
+    expect(adapter.buildBody("wan2.7-image", { prompt: "a red cube", size: "1024x1024", n: 2 })).toEqual({
+      model: "wan2.7-image",
+      input: { messages: [{ role: "user", content: [{ text: "a red cube" }] }] },
+      parameters: { size: "1024*1024", n: 2 },
+    });
+  });
+
+  it("normalizes the signed OSS url into the OpenAI image shape", () => {
+    const normalized = adapter.normalize({
+      output: {
+        choices: [{ message: { content: [{ type: "image", image: "https://oss.example/img.png?Signature=x" }] } }],
+      },
+    }, "a red cube");
+
+    expect(normalized.data).toEqual([{ url: "https://oss.example/img.png?Signature=x" }]);
+    expect(normalized.created).toBeTypeOf("number");
+  });
+});
+
+describe("Token Plan TTS handler", () => {
+  const synthesize = FORMAT_HANDLERS["dashscope-tts"];
+  const baseUrl = "https://token-plan.ap-southeast-1.maas.aliyuncs.com/api/v1/services/audio/tts/SpeechSynthesizer";
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("downloads the expiring audio url when no inline audio is returned", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        output: { audio: { data: "", url: "https://oss.example/speech.mp3" } },
+      }), { status: 200, headers: { "Content-Type": "application/json" } }))
+      .mockResolvedValueOnce(new Response(new Uint8Array(256), {
+        status: 200,
+        headers: { "Content-Type": "audio/mpeg" },
+      }));
+
+    const result = await synthesize({ baseUrl, apiKey: "sk-test", text: "Router check.", modelId: "qwen-audio-3.0-tts-plus" });
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      model: "qwen-audio-3.0-tts-plus",
+      input: { text: "Router check.", voice: "longanlingxin" },
+      parameters: { format: "mp3", sample_rate: 24000 },
+    });
+    expect(fetchMock.mock.calls[1][0]).toBe("https://oss.example/speech.mp3");
+    expect(result.format).toBe("mp3");
+    expect(result.base64.length).toBeGreaterThan(0);
+  });
+
+  it("uses the caller's voice and inline audio when present", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      output: { audio: { data: "AAAA" } },
+    }), { status: 200, headers: { "Content-Type": "application/json" } }));
+
+    const result = await synthesize({
+      baseUrl,
+      apiKey: "sk-test",
+      text: "Router check.",
+      modelId: "qwen-audio-3.0-tts-plus",
+      voiceId: "longanlufeng",
+    });
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).input.voice).toBe("longanlufeng");
+    expect(result).toEqual({ base64: "AAAA", format: "mp3" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces DashScope errors instead of returning empty audio", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      code: "InvalidApiKey",
+      message: "Invalid API-key provided.",
+    }), { status: 200, headers: { "Content-Type": "application/json" } }));
+
+    await expect(synthesize({ baseUrl, apiKey: "bad", text: "x", modelId: "qwen-audio-3.0-tts-plus" }))
+      .rejects.toThrow("Invalid API-key provided.");
+  });
+});

--- a/tests/unit/alibaba-token-plan-model-endpoints.test.js
+++ b/tests/unit/alibaba-token-plan-model-endpoints.test.js
@@ -1,0 +1,111 @@
+// Drives the real /v1/models builder so each Token Plan model lands on the
+// endpoint that can actually execute it.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { clearAlibabaTokenPlanModelCache } from "../../open-sse/services/alibabaTokenPlanModels.js";
+
+const CONNECTION = {
+  id: "c1",
+  provider: "alitp-intl",
+  isActive: true,
+  apiKey: "sk-test",
+  providerSpecificData: {},
+};
+
+const LIVE_CATALOG = [
+  "qwen3.7-max",
+  "qwen3.7-plus",
+  "qwen3.6-flash",
+  "glm-5.2",
+  "deepseek-v4-pro",
+  "wan2.7-image",
+  "wan2.7-image-pro",
+  "qwen-audio-3.0-tts-plus",
+  "deepseek-v4-flash-0731",
+  "qwen3.8-max",
+  "qwen-audio-3.0-realtime-plus",
+  "qwen3.8-flash",
+];
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: async () => [CONNECTION],
+  getCombos: async () => [],
+  getCustomModels: async () => [],
+  getModelAliases: async () => ({}),
+}));
+
+vi.mock("@/lib/disabledModelsDb", () => ({
+  getDisabledModels: async () => ({}),
+}));
+
+const { buildModelsList } = await import("../../src/app/api/v1/models/route.js");
+
+const idsFor = async (kinds) => (await buildModelsList(kinds))
+  .filter((m) => m.owned_by === "alitp-intl")
+  .map((m) => m.id.replace("alitp-intl/", ""));
+
+describe("Token Plan model endpoints", () => {
+  beforeEach(() => {
+    clearAlibabaTokenPlanModelCache();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(
+      JSON.stringify({ data: LIVE_CATALOG.map((id) => ({ id })) }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ));
+  });
+
+  it("lists every live chat model and no media model", async () => {
+    expect(await idsFor(["llm"])).toEqual([
+      "qwen3.7-max",
+      "qwen3.7-plus",
+      "qwen3.6-flash",
+      "glm-5.2",
+      "deepseek-v4-pro",
+      "deepseek-v4-flash-0731",
+      "qwen3.8-max",
+      "qwen3.8-flash",
+    ]);
+  });
+
+  it("puts the image and speech models on their own endpoints", async () => {
+    expect(await idsFor(["image"])).toEqual(["wan2.7-image", "wan2.7-image-pro"]);
+    expect(await idsFor(["tts"])).toEqual(["qwen-audio-3.0-tts-plus"]);
+  });
+
+  it("never advertises the WebSocket-only realtime model", async () => {
+    for (const kind of [["llm"], ["image"], ["tts"], ["stt"], ["imageToText"]]) {
+      expect(await idsFor(kind)).not.toContain("qwen-audio-3.0-realtime-plus");
+    }
+  });
+
+  it("reports multimodal capabilities and real token limits for chat models", async () => {
+    const models = await buildModelsList(["llm"]);
+    const max = models.find((m) => m.id === "alitp-intl/qwen3.8-max");
+
+    expect(max.capabilities).toMatchObject({ vision: true, videoInput: true, reasoning: true, search: true });
+    expect(max.context_length).toBe(1000000);
+    expect(max.max_completion_tokens).toBe(131072);
+
+    const flash = models.find((m) => m.id === "alitp-intl/qwen3.6-flash");
+    expect(flash.max_completion_tokens).toBe(65536);
+  });
+
+  it("marks media models with their output modality instead of text-only", async () => {
+    const [image] = await buildModelsList(["image"]);
+    const [speech] = await buildModelsList(["tts"]);
+
+    expect(image.capabilities).toMatchObject({ imageOutput: true });
+    expect(speech.capabilities).toMatchObject({ audioOutput: true });
+  });
+
+  it("falls back to the static registry list when live discovery fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope", { status: 401 }));
+    clearAlibabaTokenPlanModelCache();
+
+    expect(await idsFor(["llm"])).toContain("qwen3.8-max");
+    expect(await idsFor(["image"])).toEqual(["wan2.7-image", "wan2.7-image-pro"]);
+
+    // The registry's own `kind` must still drive capabilities on this path.
+    const [image] = await buildModelsList(["image"]);
+    expect(image.capabilities).toMatchObject({ imageOutput: true });
+  });
+});

--- a/tests/unit/alibaba-token-plan-provider-scope.test.js
+++ b/tests/unit/alibaba-token-plan-provider-scope.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: async () => [{
+    id: "openai-1",
+    provider: "openai",
+    isActive: true,
+    apiKey: "sk-test",
+    providerSpecificData: {},
+  }],
+  getCombos: async () => [],
+  getCustomModels: async () => [],
+  getModelAliases: async () => ({}),
+}));
+
+vi.mock("@/lib/disabledModelsDb", () => ({
+  getDisabledModels: async () => ({}),
+}));
+
+const { buildModelsList } = await import("../../src/app/api/v1/models/route.js");
+
+describe("Alibaba Token Plan provider scope", () => {
+  it("does not change capabilities on typed models from other providers", async () => {
+    const models = await buildModelsList(["image"]);
+    const image = models.find((model) => model.id === "openai/gpt-image-1");
+
+    expect(image).toBeDefined();
+    expect(image.capabilities).toBeUndefined();
+  });
+});

--- a/tests/unit/alibaba-token-plan-provider.test.js
+++ b/tests/unit/alibaba-token-plan-provider.test.js
@@ -1,10 +1,18 @@
 import { describe, expect, it } from "vitest";
 
 import REGISTRY from "../../open-sse/providers/registry/index.js";
-import { PROVIDERS, PROVIDER_MODELS } from "../../open-sse/providers/index.js";
+import { PROVIDERS, PROVIDER_MEDIA, PROVIDER_MODELS } from "../../open-sse/providers/index.js";
+import { getCapabilitiesForModel } from "../../open-sse/providers/capabilities.js";
+import { getTtsVoicesForModel } from "../../open-sse/config/ttsModels.js";
+import { getImageAdapter } from "../../open-sse/handlers/imageProviders/index.js";
+import { FORMAT_HANDLERS } from "../../open-sse/handlers/ttsProviders/genericFormats.js";
+
+const HOST = "https://token-plan.ap-southeast-1.maas.aliyuncs.com";
 
 describe("Alibaba Token Plan provider", () => {
   const entry = REGISTRY.find((e) => e.id === "alitp-intl");
+  const models = PROVIDER_MODELS["alitp-intl"] || [];
+  const modelById = new Map(models.map((m) => [m.id, m]));
 
   it("is registered as an OpenAI-compatible apikey provider", () => {
     expect(entry).toBeDefined();
@@ -15,9 +23,8 @@ describe("Alibaba Token Plan provider", () => {
 
   it("targets the Singapore Token Plan host in compatible mode", () => {
     // eu-central-1 answers IllegalEndpoint; the plan is Singapore-only.
-    expect(PROVIDERS["alitp-intl"].baseUrl).toBe(
-      "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions",
-    );
+    expect(PROVIDERS["alitp-intl"].baseUrl).toBe(`${HOST}/compatible-mode/v1/chat/completions`);
+    expect(PROVIDERS["alitp-intl"].validateUrl).toBe(`${HOST}/compatible-mode/v1/models`);
   });
 
   it("does not collide with the other three Alibaba key types", () => {
@@ -26,20 +33,138 @@ describe("Alibaba Token Plan provider", () => {
     expect(new Set(hosts).size).toBe(hosts.length);
   });
 
-  it("exposes the models the plan actually serves", () => {
-    const ids = (PROVIDER_MODELS["alitp-intl"] || []).map((m) => m.id);
-    expect(ids).toEqual(expect.arrayContaining([
-      "qwen3.8-max-preview",
+  it("falls back to the models the plan currently serves", () => {
+    expect(models.map((m) => m.id)).toEqual([
+      "qwen3.8-max",
+      "qwen3.8-flash",
       "qwen3.7-max",
       "qwen3.7-plus",
       "qwen3.6-flash",
       "glm-5.2",
       "deepseek-v4-pro",
-    ]));
+      "deepseek-v4-pro-0813",
+      "deepseek-v4-flash-0731",
+      "wan2.7-image",
+      "wan2.7-image-pro",
+      "qwen-audio-3.0-tts-plus",
+    ]);
+  });
+
+  it("types media models so they leave the chat list", () => {
+    expect(modelById.get("wan2.7-image").kind).toBe("image");
+    expect(modelById.get("wan2.7-image-pro").kind).toBe("image");
+    expect(modelById.get("qwen-audio-3.0-tts-plus").kind).toBe("tts");
+    expect(modelById.get("qwen3.8-max").kind).toBeUndefined();
+  });
+
+  it("declares the media kinds it can execute", () => {
+    expect(PROVIDER_MEDIA["alitp-intl"].serviceKinds).toEqual(["llm", "image", "tts"]);
+    expect(PROVIDER_MEDIA["alitp-intl"].imageConfig.baseUrl)
+      .toBe(`${HOST}/api/v1/services/aigc/multimodal-generation/generation`);
+    expect(PROVIDER_MEDIA["alitp-intl"].ttsConfig.baseUrl)
+      .toBe(`${HOST}/api/v1/services/audio/tts/SpeechSynthesizer`);
+  });
+
+  it("registers an executor for every declared media kind", () => {
+    expect(getImageAdapter("alitp-intl")).toBeTruthy();
+    expect(FORMAT_HANDLERS[PROVIDER_MEDIA["alitp-intl"].ttsConfig.format]).toBeTypeOf("function");
+    expect(getTtsVoicesForModel("alitp-intl", "qwen-audio-3.0-tts-plus").map((v) => v.id))
+      .toEqual(["longanlingxin", "longanlufeng"]);
+  });
+
+  it("reports the live-verified capabilities", () => {
+    expect(getCapabilitiesForModel("alitp-intl", "qwen3.8-max")).toMatchObject({
+      vision: true,
+      videoInput: true,
+      reasoning: true,
+      thinkingFormat: "qwen",
+      contextWindow: 1000000,
+      maxOutput: 131072,
+    });
+
+    // Rejects image parts outright; the only text-only Qwen route on the plan.
+    expect(getCapabilitiesForModel("alitp-intl", "qwen3.7-max")).toMatchObject({ vision: false, videoInput: false });
+
+    // Upstream caps this one lower than the rest.
+    expect(getCapabilitiesForModel("alitp-intl", "qwen3.6-flash")).toMatchObject({ vision: true, maxOutput: 65536 });
+
+    // Reads PDFs live even though the spec page badges only Image/Text/Video.
+    expect(getCapabilitiesForModel("alitp-intl", "qwen3.8-max").pdf).toBe(true);
+
+    // Spec page: 1.04M context, 131.07K output.
+    expect(getCapabilitiesForModel("alitp-intl", "glm-5.2")).toMatchObject({
+      vision: false,
+      audioInput: false,
+      reasoning: true,
+      thinkingFormat: "qwen",
+      contextWindow: 1048576,
+      maxOutput: 131072,
+    });
+
+    // Spec pages give 393K output; upstream itself never validates the field.
+    expect(getCapabilitiesForModel("alitp-intl", "deepseek-v4-pro")).toMatchObject({
+      vision: false,
+      audioInput: false,
+      contextWindow: 1000000,
+      maxOutput: 393216,
+    });
+
+    // Spec page: same 1M/393K class as v4-pro. On the plan roster though the
+    // live catalog omits it.
+    expect(getCapabilitiesForModel("alitp-intl", "deepseek-v4-pro-0813")).toMatchObject({
+      vision: false,
+      contextWindow: 1000000,
+      maxOutput: 393216,
+    });
+
+    // Retired preview ID; upstream auto-routes it to the production qwen3.8-max.
+    expect(getCapabilitiesForModel("alitp-intl", "qwen3.8-max-preview")).toMatchObject({
+      vision: true,
+      pdf: true,
+      maxOutput: 131072,
+    });
+  });
+
+  it("claims web search on every chat model (Responses surface)", () => {
+    // web_search executes on /responses for all 8 (forced tool_choice, count >= 1);
+    // chat completions enable_search is a silent no-op, and glm-5.2 rejects the field.
+    for (const id of ["qwen3.8-max", "qwen3.8-flash", "qwen3.7-max", "qwen3.7-plus", "qwen3.6-flash", "glm-5.2", "deepseek-v4-pro", "deepseek-v4-flash-0731"]) {
+      expect(getCapabilitiesForModel("alitp-intl", id).search).toBe(true);
+    }
+  });
+
+  it("keeps tool calling on for every chat model and off for the media models", () => {
+    const chatModels = models.filter((m) => !m.kind).map((m) => m.id);
+    expect(chatModels).toHaveLength(9);
+    for (const id of chatModels) {
+      expect(getCapabilitiesForModel("alitp-intl", id).tools).toBe(true);
+    }
+
+    for (const id of ["wan2.7-image", "wan2.7-image-pro", "qwen-audio-3.0-tts-plus"]) {
+      expect(getCapabilitiesForModel("alitp-intl", id).tools).toBe(false);
+    }
+  });
+
+  it("surfaces output modalities for both image models and the speech model", () => {
+    expect(getCapabilitiesForModel("alitp-intl", "wan2.7-image")).toMatchObject({ imageOutput: true });
+    expect(getCapabilitiesForModel("alitp-intl", "wan2.7-image-pro")).toMatchObject({ imageOutput: true });
+    expect(getCapabilitiesForModel("alitp-intl", "qwen-audio-3.0-tts-plus")).toMatchObject({ audioOutput: true });
   });
 
   it("keeps every registry id unique after adding the provider", () => {
     const ids = REGISTRY.map((e) => e.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("exposes one transport per client format", () => {
+    const entry = REGISTRY.find((e) => e.id === "alitp-intl");
+    expect(entry.transports.map((t) => t.format)).toEqual(["openai-responses", "claude"]);
+
+    const responses = entry.transports.find((t) => t.format === "openai-responses");
+    expect(responses.baseUrl).toContain("/compatible-mode/v1/responses");
+
+    const claude = entry.transports.find((t) => t.format === "claude");
+    expect(claude.baseUrl).toContain("/apps/anthropic/v1/messages");
+    expect(claude.auth).toMatchObject({ header: "x-api-key", scheme: "raw", anthropicVersion: true });
   });
 });

--- a/tests/unit/alibaba-token-plan-provider.test.js
+++ b/tests/unit/alibaba-token-plan-provider.test.js
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import REGISTRY from "../../open-sse/providers/registry/index.js";
-import { PROVIDERS, PROVIDER_MEDIA, PROVIDER_MODELS } from "../../open-sse/providers/index.js";
+import { PROVIDERS, PROVIDER_MEDIA } from "../../open-sse/providers/index.js";
 import { getCapabilitiesForModel } from "../../open-sse/providers/capabilities.js";
 import { getThinkingLevels } from "../../open-sse/providers/thinkingLevels.js";
 import { applyThinking } from "../../open-sse/translator/concerns/thinkingUnified.js";
@@ -10,62 +9,11 @@ import { getTtsVoicesForModel } from "../../open-sse/config/ttsModels.js";
 import { getImageAdapter } from "../../open-sse/handlers/imageProviders/index.js";
 import { FORMAT_HANDLERS } from "../../open-sse/handlers/ttsProviders/genericFormats.js";
 
-const HOST = "https://token-plan.ap-southeast-1.maas.aliyuncs.com";
-
 describe("Alibaba Token Plan provider", () => {
-  const entry = REGISTRY.find((e) => e.id === "alitp-intl");
-  const models = PROVIDER_MODELS["alitp-intl"] || [];
-  const modelById = new Map(models.map((m) => [m.id, m]));
-
-  it("is registered as an OpenAI-compatible apikey provider", () => {
-    expect(entry).toBeDefined();
-    expect(entry.category).toBe("apikey");
-    expect(PROVIDERS["alitp-intl"]).toBeDefined();
-    expect(PROVIDERS["alitp-intl"].format).toBe("openai");
-  });
-
-  it("targets the Singapore Token Plan host in compatible mode", () => {
-    // eu-central-1 answers IllegalEndpoint; the plan is Singapore-only.
-    expect(PROVIDERS["alitp-intl"].baseUrl).toBe(`${HOST}/compatible-mode/v1/chat/completions`);
-    expect(PROVIDERS["alitp-intl"].validateUrl).toBe(`${HOST}/compatible-mode/v1/models`);
-  });
-
   it("does not collide with the other three Alibaba key types", () => {
     const hosts = ["alicode", "alicode-intl", "alims-intl", "alitp-intl"]
       .map((id) => new URL(PROVIDERS[id].baseUrl).host);
     expect(new Set(hosts).size).toBe(hosts.length);
-  });
-
-  it("falls back to the models the plan currently serves", () => {
-    expect(models.map((m) => m.id)).toEqual([
-      "qwen3.8-max",
-      "qwen3.8-flash",
-      "qwen3.7-max",
-      "qwen3.7-plus",
-      "qwen3.6-flash",
-      "glm-5.2",
-      "deepseek-v4-pro",
-      "deepseek-v4-pro-0813",
-      "deepseek-v4-flash-0731",
-      "wan2.7-image",
-      "wan2.7-image-pro",
-      "qwen-audio-3.0-tts-plus",
-    ]);
-  });
-
-  it("types media models so they leave the chat list", () => {
-    expect(modelById.get("wan2.7-image").kind).toBe("image");
-    expect(modelById.get("wan2.7-image-pro").kind).toBe("image");
-    expect(modelById.get("qwen-audio-3.0-tts-plus").kind).toBe("tts");
-    expect(modelById.get("qwen3.8-max").kind).toBeUndefined();
-  });
-
-  it("declares the media kinds it can execute", () => {
-    expect(PROVIDER_MEDIA["alitp-intl"].serviceKinds).toEqual(["llm", "image", "tts"]);
-    expect(PROVIDER_MEDIA["alitp-intl"].imageConfig.baseUrl)
-      .toBe(`${HOST}/api/v1/services/aigc/multimodal-generation/generation`);
-    expect(PROVIDER_MEDIA["alitp-intl"].ttsConfig.baseUrl)
-      .toBe(`${HOST}/api/v1/services/audio/tts/SpeechSynthesizer`);
   });
 
   it("registers an executor for every declared media kind", () => {
@@ -75,55 +23,11 @@ describe("Alibaba Token Plan provider", () => {
       .toEqual(["longanlingxin", "longanlufeng"]);
   });
 
-  it("reports the live-verified capabilities", () => {
-    expect(getCapabilitiesForModel("alitp-intl", "qwen3.8-max")).toMatchObject({
-      vision: true,
-      videoInput: true,
-      reasoning: true,
+  it("resolves each model's own capability key ahead of the generic qwen patterns", () => {
+    // Exact key: OpenAI wire and the plan's real limits. "*qwen*max*" would
+    // otherwise answer thinkingFormat "qwen" and cap output at 65536.
+    expect(getCapabilitiesForModel("alitp-intl", "qwen3.7-max")).toMatchObject({
       thinkingFormat: "openai",
-      contextWindow: 1000000,
-      maxOutput: 131072,
-    });
-
-    // Rejects image parts outright; the only text-only Qwen route on the plan.
-    expect(getCapabilitiesForModel("alitp-intl", "qwen3.7-max")).toMatchObject({ vision: false, videoInput: false });
-
-    // Upstream caps this one lower than the rest.
-    expect(getCapabilitiesForModel("alitp-intl", "qwen3.6-flash")).toMatchObject({ vision: true, maxOutput: 65536 });
-
-    // Reads PDFs live even though the spec page badges only Image/Text/Video.
-    expect(getCapabilitiesForModel("alitp-intl", "qwen3.8-max").pdf).toBe(true);
-
-    // Spec page: 1.04M context, 131.07K output.
-    expect(getCapabilitiesForModel("alitp-intl", "glm-5.2")).toMatchObject({
-      vision: false,
-      audioInput: false,
-      reasoning: true,
-      thinkingFormat: "openai",
-      contextWindow: 1048576,
-      maxOutput: 131072,
-    });
-
-    // Spec pages give 393K output; upstream itself never validates the field.
-    expect(getCapabilitiesForModel("alitp-intl", "deepseek-v4-pro")).toMatchObject({
-      vision: false,
-      audioInput: false,
-      contextWindow: 1000000,
-      maxOutput: 393216,
-    });
-
-    // Spec page: same 1M/393K class as v4-pro. On the plan roster though the
-    // live catalog omits it.
-    expect(getCapabilitiesForModel("alitp-intl", "deepseek-v4-pro-0813")).toMatchObject({
-      vision: false,
-      contextWindow: 1000000,
-      maxOutput: 393216,
-    });
-
-    // Retired preview ID; upstream auto-routes it to the production qwen3.8-max.
-    expect(getCapabilitiesForModel("alitp-intl", "qwen3.8-max-preview")).toMatchObject({
-      vision: true,
-      pdf: true,
       maxOutput: 131072,
     });
   });
@@ -188,49 +92,5 @@ describe("Alibaba Token Plan provider", () => {
       runtimeTransport: { format: "claude", thinkingFormat: "claude-budget" },
     });
     expect(offBody.thinking).toEqual({ type: "enabled", budget_tokens: 512 });
-  });
-
-  it("claims web search on every chat model (Responses surface)", () => {
-    // web_search executes on /responses for all 8 (forced tool_choice, count >= 1);
-    // chat completions enable_search is a silent no-op, and glm-5.2 rejects the field.
-    for (const id of ["qwen3.8-max", "qwen3.8-flash", "qwen3.7-max", "qwen3.7-plus", "qwen3.6-flash", "glm-5.2", "deepseek-v4-pro", "deepseek-v4-flash-0731"]) {
-      expect(getCapabilitiesForModel("alitp-intl", id).search).toBe(true);
-    }
-  });
-
-  it("keeps tool calling on for every chat model and off for the media models", () => {
-    const chatModels = models.filter((m) => !m.kind).map((m) => m.id);
-    expect(chatModels).toHaveLength(9);
-    for (const id of chatModels) {
-      expect(getCapabilitiesForModel("alitp-intl", id).tools).toBe(true);
-    }
-
-    for (const id of ["wan2.7-image", "wan2.7-image-pro", "qwen-audio-3.0-tts-plus"]) {
-      expect(getCapabilitiesForModel("alitp-intl", id).tools).toBe(false);
-    }
-  });
-
-  it("surfaces output modalities for both image models and the speech model", () => {
-    expect(getCapabilitiesForModel("alitp-intl", "wan2.7-image")).toMatchObject({ imageOutput: true });
-    expect(getCapabilitiesForModel("alitp-intl", "wan2.7-image-pro")).toMatchObject({ imageOutput: true });
-    expect(getCapabilitiesForModel("alitp-intl", "qwen-audio-3.0-tts-plus")).toMatchObject({ audioOutput: true });
-  });
-
-  it("keeps every registry id unique after adding the provider", () => {
-    const ids = REGISTRY.map((e) => e.id);
-    expect(new Set(ids).size).toBe(ids.length);
-  });
-
-  it("exposes one transport per client format", () => {
-    const entry = REGISTRY.find((e) => e.id === "alitp-intl");
-    expect(entry.transports.map((t) => t.format)).toEqual(["openai-responses", "claude"]);
-
-    const responses = entry.transports.find((t) => t.format === "openai-responses");
-    expect(responses.baseUrl).toContain("/compatible-mode/v1/responses");
-
-    const claude = entry.transports.find((t) => t.format === "claude");
-    expect(claude.baseUrl).toContain("/apps/anthropic/v1/messages");
-    expect(claude.auth).toMatchObject({ header: "x-api-key", scheme: "raw", anthropicVersion: true });
-    expect(claude.thinkingFormat).toBe("claude-budget");
   });
 });

--- a/tests/unit/alibaba-token-plan-provider.test.js
+++ b/tests/unit/alibaba-token-plan-provider.test.js
@@ -145,18 +145,21 @@ describe("Alibaba Token Plan provider", () => {
     }
   });
 
-  it("clamps unsupported levels to each model's enum", () => {
-    const apply = (model, intent, credentials) => {
+  it("sends the lowest accepted effort when thinking cannot be disabled", () => {
+    const apply = (model, intent) => {
       const body = {};
-      applyThinking(FORMATS.OPENAI, model, body, "alitp-intl", intent, credentials);
+      applyThinking(FORMATS.OPENAI, model, body, "alitp-intl", intent);
       return body.reasoning_effort;
     };
     const none = { mode: "none" };
     const minimal = { mode: "level", level: "minimal" };
     const max = { mode: "level", level: "max" };
     const ultra = { mode: "level", level: "ultra" };
+    // Upstream: "'reasoning_effort' must be one of: 'low', 'medium', 'high', 'xhigh', 'max'".
     expect(apply("deepseek-v4-pro", none)).toBe("low");
-    expect(apply("deepseek-v4-pro", minimal)).toBe("low");
+    // An explicitly requested level is forwarded for upstream to validate.
+    expect(apply("deepseek-v4-pro", minimal)).toBe("minimal");
+    expect(apply("qwen3.8-max", none)).toBe("none");
     expect(apply("qwen3.7-max", max)).toBe("xhigh");
     expect(apply("qwen3.8-max", max)).toBe("max");
     expect(apply("qwen3.8-max", ultra)).toBe("max");
@@ -178,12 +181,13 @@ describe("Alibaba Token Plan provider", () => {
     expect(claudeBody.thinking).toMatchObject({ type: "enabled" });
     expect(claudeBody.thinking.budget_tokens).toBeGreaterThan(0);
     expect(claudeBody.reasoning_effort).toBeUndefined();
-    // Unsupported minimal effort maps to this provider's lowest declared level.
+    // Upstream accepts budget_tokens 512 and 1023 on this surface (probed), so
+    // the minimal effort budget is sent unchanged.
     const offBody = {};
     applyThinking(FORMATS.CLAUDE, "deepseek-v4-pro", offBody, "alitp-intl", { mode: "none" }, {
       runtimeTransport: { format: "claude", thinkingFormat: "claude-budget" },
     });
-    expect(offBody.thinking).toEqual({ type: "enabled", budget_tokens: 1024 });
+    expect(offBody.thinking).toEqual({ type: "enabled", budget_tokens: 512 });
   });
 
   it("claims web search on every chat model (Responses surface)", () => {

--- a/tests/unit/alibaba-token-plan-provider.test.js
+++ b/tests/unit/alibaba-token-plan-provider.test.js
@@ -152,9 +152,11 @@ describe("Alibaba Token Plan provider", () => {
       return body.reasoning_effort;
     };
     const none = { mode: "none" };
+    const minimal = { mode: "level", level: "minimal" };
     const max = { mode: "level", level: "max" };
     const ultra = { mode: "level", level: "ultra" };
     expect(apply("deepseek-v4-pro", none)).toBe("low");
+    expect(apply("deepseek-v4-pro", minimal)).toBe("low");
     expect(apply("qwen3.7-max", max)).toBe("xhigh");
     expect(apply("qwen3.8-max", max)).toBe("max");
     expect(apply("qwen3.8-max", ultra)).toBe("max");
@@ -176,7 +178,7 @@ describe("Alibaba Token Plan provider", () => {
     expect(claudeBody.thinking).toMatchObject({ type: "enabled" });
     expect(claudeBody.thinking.budget_tokens).toBeGreaterThan(0);
     expect(claudeBody.reasoning_effort).toBeUndefined();
-    // none on a cannot-disable model → minimal thinking at the Anthropic floor.
+    // Unsupported minimal effort maps to this provider's lowest declared level.
     const offBody = {};
     applyThinking(FORMATS.CLAUDE, "deepseek-v4-pro", offBody, "alitp-intl", { mode: "none" }, {
       runtimeTransport: { format: "claude", thinkingFormat: "claude-budget" },

--- a/tests/unit/alibaba-token-plan-provider.test.js
+++ b/tests/unit/alibaba-token-plan-provider.test.js
@@ -157,8 +157,8 @@ describe("Alibaba Token Plan provider", () => {
     const ultra = { mode: "level", level: "ultra" };
     // Upstream: "'reasoning_effort' must be one of: 'low', 'medium', 'high', 'xhigh', 'max'".
     expect(apply("deepseek-v4-pro", none)).toBe("low");
-    // An explicitly requested level is forwarded for upstream to validate.
-    expect(apply("deepseek-v4-pro", minimal)).toBe("minimal");
+    // Upstream rejects "minimal" here too, so it is raised to the floor.
+    expect(apply("deepseek-v4-pro", minimal)).toBe("low");
     expect(apply("qwen3.8-max", none)).toBe("none");
     expect(apply("qwen3.7-max", max)).toBe("xhigh");
     expect(apply("qwen3.8-max", max)).toBe("max");

--- a/tests/unit/alibaba-token-plan-provider.test.js
+++ b/tests/unit/alibaba-token-plan-provider.test.js
@@ -3,6 +3,9 @@ import { describe, expect, it } from "vitest";
 import REGISTRY from "../../open-sse/providers/registry/index.js";
 import { PROVIDERS, PROVIDER_MEDIA, PROVIDER_MODELS } from "../../open-sse/providers/index.js";
 import { getCapabilitiesForModel } from "../../open-sse/providers/capabilities.js";
+import { getThinkingLevels } from "../../open-sse/providers/thinkingLevels.js";
+import { applyThinking } from "../../open-sse/translator/concerns/thinkingUnified.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
 import { getTtsVoicesForModel } from "../../open-sse/config/ttsModels.js";
 import { getImageAdapter } from "../../open-sse/handlers/imageProviders/index.js";
 import { FORMAT_HANDLERS } from "../../open-sse/handlers/ttsProviders/genericFormats.js";
@@ -77,7 +80,7 @@ describe("Alibaba Token Plan provider", () => {
       vision: true,
       videoInput: true,
       reasoning: true,
-      thinkingFormat: "qwen",
+      thinkingFormat: "openai",
       contextWindow: 1000000,
       maxOutput: 131072,
     });
@@ -96,7 +99,7 @@ describe("Alibaba Token Plan provider", () => {
       vision: false,
       audioInput: false,
       reasoning: true,
-      thinkingFormat: "qwen",
+      thinkingFormat: "openai",
       contextWindow: 1048576,
       maxOutput: 131072,
     });
@@ -123,6 +126,62 @@ describe("Alibaba Token Plan provider", () => {
       pdf: true,
       maxOutput: 131072,
     });
+  });
+
+  it("exposes each model's probed reasoning_effort levels", () => {
+    const levels = {
+      "qwen3.8-max": ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+      "qwen3.8-flash": ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+      "qwen3.7-max": ["none", "minimal", "low", "medium", "high", "xhigh"],
+      "qwen3.7-plus": ["none", "minimal", "low", "medium", "high", "xhigh"],
+      "qwen3.6-flash": ["none", "minimal", "low", "medium", "high", "xhigh"],
+      "glm-5.2": ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+      "deepseek-v4-pro": ["low", "medium", "high", "xhigh", "max"],
+      "deepseek-v4-pro-0813": ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+      "deepseek-v4-flash-0731": ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+    };
+    for (const [id, expected] of Object.entries(levels)) {
+      expect(getThinkingLevels("alitp-intl", id)).toEqual(expected);
+    }
+  });
+
+  it("clamps unsupported levels to each model's enum", () => {
+    const apply = (model, intent, credentials) => {
+      const body = {};
+      applyThinking(FORMATS.OPENAI, model, body, "alitp-intl", intent, credentials);
+      return body.reasoning_effort;
+    };
+    const none = { mode: "none" };
+    const max = { mode: "level", level: "max" };
+    const ultra = { mode: "level", level: "ultra" };
+    expect(apply("deepseek-v4-pro", none)).toBe("low");
+    expect(apply("qwen3.7-max", max)).toBe("xhigh");
+    expect(apply("qwen3.8-max", max)).toBe("max");
+    expect(apply("qwen3.8-max", ultra)).toBe("max");
+    expect(apply("qwen3.7-max", ultra)).toBe("xhigh");
+  });
+
+  it("normalizes thinking per transport surface", () => {
+    const intent = { mode: "level", level: "high" };
+    const openaiBody = {};
+    applyThinking(FORMATS.OPENAI, "qwen3.8-max", openaiBody, "alitp-intl", intent);
+    expect(openaiBody.reasoning_effort).toBe("high");
+    expect(openaiBody.thinking).toBeUndefined();
+    // A claude-format target always rides the claude transport (default surface
+    // is openai), so its transport-level claude-budget format applies.
+    const claudeBody = {};
+    applyThinking(FORMATS.CLAUDE, "qwen3.8-max", claudeBody, "alitp-intl", intent, {
+      runtimeTransport: { format: "claude", thinkingFormat: "claude-budget" },
+    });
+    expect(claudeBody.thinking).toMatchObject({ type: "enabled" });
+    expect(claudeBody.thinking.budget_tokens).toBeGreaterThan(0);
+    expect(claudeBody.reasoning_effort).toBeUndefined();
+    // none on a cannot-disable model → minimal thinking at the Anthropic floor.
+    const offBody = {};
+    applyThinking(FORMATS.CLAUDE, "deepseek-v4-pro", offBody, "alitp-intl", { mode: "none" }, {
+      runtimeTransport: { format: "claude", thinkingFormat: "claude-budget" },
+    });
+    expect(offBody.thinking).toEqual({ type: "enabled", budget_tokens: 1024 });
   });
 
   it("claims web search on every chat model (Responses surface)", () => {
@@ -166,5 +225,6 @@ describe("Alibaba Token Plan provider", () => {
     const claude = entry.transports.find((t) => t.format === "claude");
     expect(claude.baseUrl).toContain("/apps/anthropic/v1/messages");
     expect(claude.auth).toMatchObject({ header: "x-api-key", scheme: "raw", anthropicVersion: true });
+    expect(claude.thinkingFormat).toBe("claude-budget");
   });
 });

--- a/tests/unit/thinking-effort-openai-max-clamp.test.js
+++ b/tests/unit/thinking-effort-openai-max-clamp.test.js
@@ -38,3 +38,23 @@ describe("applyThinking (openai): clamp max effort to xhigh", () => {
     expect(out.reasoning_effort).toBe("xhigh");
   });
 });
+
+describe("provider-specific thinking rules", () => {
+  it("keeps minimal effort unchanged for non-Alibaba codex models", () => {
+    const body = { reasoning_effort: "minimal" };
+    const out = applyThinking(FORMATS.OPENAI, "gpt-5.3-codex", body, "github");
+    expect(out.reasoning_effort).toBe("minimal");
+  });
+
+  it("keeps sub-1024 budgets unchanged for non-Alibaba Claude models", () => {
+    const body = {};
+    const out = applyThinking(
+      FORMATS.CLAUDE,
+      "claude-opus-4-5",
+      body,
+      "anthropic",
+      { mode: "budget", budget: 512 },
+    );
+    expect(out.thinking).toEqual({ type: "enabled", budget_tokens: 512 });
+  });
+});

--- a/tests/unit/thinking-effort-openai-max-clamp.test.js
+++ b/tests/unit/thinking-effort-openai-max-clamp.test.js
@@ -57,4 +57,10 @@ describe("provider-specific thinking rules", () => {
     );
     expect(out.thinking).toEqual({ type: "enabled", budget_tokens: 512 });
   });
+
+  it("keeps the minimal clamp for other cannot-disable openai-format models", () => {
+    const body = {};
+    applyThinking(FORMATS.OPENAI, "minimaxai/minimax-m3", body, "nvidia", { mode: "none" });
+    expect(body.reasoning_effort).toBe("minimal");
+  });
 });


### PR DESCRIPTION
## Summary

Adds complete Alibaba International Model Studio Token Plan support to the existing `alitp-intl` provider:

- Live model discovery with a static fallback catalog
- OpenAI Chat Completions, OpenAI Responses, and Anthropic Messages transports
- Image generation through DashScope multimodal generation
- Text-to-speech through DashScope SpeechSynthesizer
- Per-model capabilities, limits, and thinking controls

## Model discovery

Fetches `/compatible-mode/v1/models`, caches the result per key, and classifies supported models as LLM, image, or TTS. The static registry remains available when discovery fails.

`deepseek-v4-pro-0813` remains in the catalog because Alibaba documents it as part of the Token Plan even though the live models endpoint currently omits it. WebSocket-only models that 9router cannot execute are excluded.

## Chat transports

Selects the Alibaba API that matches the client format:

| Client format | Alibaba API |
| --- | --- |
| OpenAI Chat Completions | `/compatible-mode/v1/chat/completions` |
| OpenAI Responses | `/compatible-mode/v1/responses` |
| Anthropic Messages | `/apps/anthropic/v1/messages` |

This preserves transport-specific features such as video and PDF input on Chat Completions, server-side web search on Responses, and native Anthropic tools and thinking budgets on Messages.

## Media generation

Adds an `alitp-intl` image adapter for DashScope's `multimodal-generation` API. It converts OpenAI-style image requests and normalizes Alibaba responses to OpenAI `url` or `b64_json` output.

Adds a TTS handler for DashScope's `SpeechSynthesizer` API and registers the documented voices for `qwen-audio-3.0-tts-plus`.

## Model capabilities

Declares Token Plan capabilities per model, including:

- Vision, video, PDF, and search support
- Context and output limits
- Supported reasoning levels
- Whether thinking can be disabled

Each model declares the `reasoning_effort` enum its upstream actually accepts, and those enums are not uniform: `qwen3.8-*`, `glm-5.2`, `deepseek-v4-flash-0731`, and `deepseek-v4-pro-0813` accept `max`, the `qwen3.7`/`qwen3.6` models stop at `xhigh`, and `deepseek-v4-pro` rejects `none` and `minimal` outright.

Because Alibaba answers HTTP 400 for a level outside a model's enum, any level below a model's floor is raised to that floor rather than forwarded. For `deepseek-v4-pro` both a disable intent and an explicit `minimal` become `low`. Providers that do not validate the enum keep forwarding the client's level unchanged. Anthropic-format clients use Alibaba's native `thinking` field with `budget_tokens`.

Model ids the plan has not published have no capability entry and resolve through the pre-existing generic patterns, exactly as they did before this change.

## Verification

- Scoped unit tests cover discovery and its fallback, model-to-endpoint routing, the image and TTS handlers, capability key precedence, and thinking behavior on each transport.
- `tests/__baseline__/verify-providers.mjs` and `verify-alias.mjs` both report byte-for-byte equality, so provider configuration and alias resolution are unchanged for every other provider.
- The full suite shows no test that passes on `master` failing here.
- Live Alibaba requests verified all three chat transports, streaming, and the per-model effort enums above, including the raise-to-floor path.
