### PR TITLE
fix(codex): support Spark constraints and 128K context

### DIFF
--- a/open-sse/config/codexConstants.js
+++ b/open-sse/config/codexConstants.js
@@ -1,0 +1,7 @@
+export const CODEX_SPARK_CONTEXT_WINDOW = 128000;
+export const CODEX_SPARK_COMPACT_THRESHOLD = 100000;
+export const CODEX_SPARK_MODEL_GLOB = "*gpt-5.3-codex-spark*";
+
+export function isCodexSparkModel(model) {
+  return /^gpt-5\.3-codex-spark(?:-|$)/i.test(model || "");
+}

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -133,6 +133,10 @@ function normalizeReasoningEffort(model, value) {
   return value;
 }
 
+function supportsReasoningSummary(model) {
+  return !/^gpt-5\.3-codex-spark(?:-|$)/i.test(model);
+}
+
 function findNestedMessage(value, depth = 0) {
   if (!value || depth > 6 || typeof value === "string") return null;
   if (Array.isArray(value)) {
@@ -446,10 +450,15 @@ export class CodexExecutor extends BaseExecutor {
     // Priority: explicit reasoning.effort > reasoning_effort param > model suffix > default (medium)
     if (!body.reasoning) {
       const effort = normalizeReasoningEffort(body.model, body.reasoning_effort || modelEffort || 'low');
-      body.reasoning = { effort, summary: "auto" };
+      body.reasoning = { effort };
+      if (supportsReasoningSummary(body.model)) body.reasoning.summary = "auto";
     } else {
       body.reasoning.effort = normalizeReasoningEffort(body.model, body.reasoning.effort);
-      if (!body.reasoning.summary) body.reasoning.summary = "auto";
+      if (supportsReasoningSummary(body.model)) {
+        if (!body.reasoning.summary) body.reasoning.summary = "auto";
+      } else {
+        delete body.reasoning.summary;
+      }
     }
     delete body.reasoning_effort;
 

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -12,6 +12,10 @@ import { getThinkingLevels } from "../providers/thinkingLevels.js";
 import { DEFAULT_RETRY_CONFIG, HTTP_STATUS, resolveRetryEntry } from "../config/runtimeConfig.js";
 import { dbg } from "../utils/debugLog.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
+import {
+  CODEX_SPARK_COMPACT_THRESHOLD,
+  isCodexSparkModel,
+} from "../config/codexConstants.js";
 
 // SSE error patterns inside 200-OK bodies. Some retry same account first; capacity rotates accounts.
 const CODEX_SSE_RETRY_PATTERNS = ["server_is_overloaded", "service_unavailable_error"];
@@ -42,7 +46,7 @@ const CODEX_PASSTHROUGH_TOOL_TYPES = new Set(["custom"]);
 const RESPONSES_API_ALLOWLIST = new Set([
   "model", "input", "instructions", "tools", "tool_choice", "stream", "store",
   "reasoning", "service_tier", "include", "prompt_cache_key", "client_metadata",
-  "text"
+  "text", "context_management"
 ]);
 
 // Convert role=system → role=developer in body.input (keeps content in cacheable prefix)
@@ -134,7 +138,21 @@ function normalizeReasoningEffort(model, value) {
 }
 
 function supportsReasoningSummary(model) {
-  return !/^gpt-5\.3-codex-spark(?:-|$)/i.test(model);
+  return !isCodexSparkModel(model);
+}
+
+function normalizeSparkContextManagement(value) {
+  const existing = Array.isArray(value)
+    ? value.find((entry) => entry?.type === "compaction")
+    : null;
+  const threshold = Number(existing?.compact_threshold);
+
+  return [{
+    type: "compaction",
+    compact_threshold: Number.isFinite(threshold) && threshold > 0
+      ? Math.min(threshold, CODEX_SPARK_COMPACT_THRESHOLD)
+      : CODEX_SPARK_COMPACT_THRESHOLD,
+  }];
 }
 
 function findNestedMessage(value, depth = 0) {
@@ -461,6 +479,12 @@ export class CodexExecutor extends BaseExecutor {
       }
     }
     delete body.reasoning_effort;
+
+    if (this._isCompact) {
+      delete body.context_management;
+    } else if (isCodexSparkModel(body.model)) {
+      body.context_management = normalizeSparkContextManagement(body.context_management);
+    }
 
     // Include reasoning encrypted content (required by Codex backend for reasoning models)
     if (body.reasoning && body.reasoning.effort && body.reasoning.effort !== 'none') {

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -34,6 +34,10 @@
 
 import { matchPattern } from "./pricing.js";
 import { looksLikeVisionModel } from "./visionPatterns.js";
+import {
+  CODEX_SPARK_CONTEXT_WINDOW,
+  CODEX_SPARK_MODEL_GLOB,
+} from "../config/codexConstants.js";
 
 /**
  * Safe floor — every resolved result is merged over this so consumers
@@ -236,6 +240,7 @@ export const PATTERN_CAPABILITIES = [
 
   // ── OpenAI GPT-5.x (vision + thinking + web search) ──────────────
   { pattern: "*gpt-5*image*",   caps: { imageOutput: true } },
+  { pattern: CODEX_SPARK_MODEL_GLOB, caps: { reasoning: true, search: true, thinkingFormat: "openai", contextWindow: CODEX_SPARK_CONTEXT_WINDOW, maxOutput: 128000 } },
   { pattern: "*gpt-5*codex*",   caps: { reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 400000, maxOutput: 128000 } },
   { pattern: "*gpt-5*",         caps: { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 400000, maxOutput: 128000 } },
   { pattern: "*gpt-4o*",        caps: { vision: true, search: true, contextWindow: 128000, maxOutput: 16384 } },

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -4,6 +4,7 @@ import {
   getProviderAlias,
   isAnthropicCompatibleProvider,
   isOpenAICompatibleProvider,
+  resolveProviderId,
 } from "@/shared/constants/providers";
 import { getProviderConnections, getCombos, getCustomModels, getModelAliases } from "@/lib/localDb";
 import { getDisabledModels } from "@/lib/disabledModelsDb";
@@ -237,6 +238,18 @@ function comboMatchesKinds(combo, kindFilter) {
   return kindFilter.includes(kind);
 }
 
+function getComboContextWindow(combo) {
+  const windows = (combo?.models || []).flatMap((fullModel) => {
+    if (typeof fullModel !== "string" || !fullModel.includes("/")) return [];
+    const slash = fullModel.indexOf("/");
+    const provider = resolveProviderId(fullModel.slice(0, slash));
+    const model = fullModel.slice(slash + 1);
+    const contextWindow = getCapabilitiesForModel(provider, model).contextWindow;
+    return Number.isFinite(contextWindow) && contextWindow > 0 ? [contextWindow] : [];
+  });
+  return windows.length > 0 ? Math.min(...windows) : null;
+}
+
 /**
  * Build OpenAI-format models list filtered by service kinds.
  * @param {string[]} kindFilter - List of service kinds to include (e.g. ["llm"], ["webSearch","webFetch"]).
@@ -300,6 +313,8 @@ export async function buildModelsList(kindFilter, options = {}) {
       object: "model",
       owned_by: "combo",
     };
+    const contextWindow = getComboContextWindow(combo);
+    if (contextWindow) entry.context_length = contextWindow;
     if (combo.kind === "webSearch" || combo.kind === "webFetch") {
       entry.kind = combo.kind;
     }

--- a/tests/unit/capabilities.test.js
+++ b/tests/unit/capabilities.test.js
@@ -55,4 +55,10 @@ describe("getCapabilitiesForModel", () => {
     expect(getCapabilitiesForModel("kiro", "gpt-5.6-luna-agentic")).toMatchObject(kiroGpt56Expected);
     expect(getCapabilitiesForModel("kiro", "gpt-5.6-sol-thinking-agentic")).toMatchObject(kiroGpt56Expected);
   });
+
+  it("reports Codex Spark variants with their 128k context window", () => {
+    expect(getCapabilitiesForModel("codex", "gpt-5.3-codex-spark").contextWindow).toBe(128000);
+    expect(getCapabilitiesForModel("codex", "gpt-5.3-codex-spark-review").contextWindow).toBe(128000);
+    expect(getCapabilitiesForModel("cx", "gpt-5.3-codex-spark-high").contextWindow).toBe(128000);
+  });
 });

--- a/tests/unit/codex-fast-capacity.test.js
+++ b/tests/unit/codex-fast-capacity.test.js
@@ -98,4 +98,14 @@ describe("Codex reasoning normalization", () => {
     expect(body.model).toBe("gpt-5.6-terra");
     expect(body.reasoning.effort).toBe("ultra");
   });
+
+  it("removes reasoning summaries unsupported by Spark", () => {
+    const body = new CodexExecutor().transformRequest("gpt-5.3-codex-spark", {
+      model: "gpt-5.3-codex-spark",
+      input: "hi",
+      reasoning: { effort: "high", summary: "auto" },
+    }, true, {});
+
+    expect(body.reasoning).toEqual({ effort: "high" });
+  });
 });

--- a/tests/unit/codex-fast-capacity.test.js
+++ b/tests/unit/codex-fast-capacity.test.js
@@ -107,5 +107,30 @@ describe("Codex reasoning normalization", () => {
     }, true, {});
 
     expect(body.reasoning).toEqual({ effort: "high" });
+    expect(body.context_management).toEqual([
+      { type: "compaction", compact_threshold: 100000 },
+    ]);
+  });
+
+  it("clamps Spark compaction below its context limit", () => {
+    const body = new CodexExecutor().transformRequest("gpt-5.3-codex-spark", {
+      model: "gpt-5.3-codex-spark",
+      input: "hi",
+      context_management: [{ type: "compaction", compact_threshold: 200000 }],
+    }, true, {});
+
+    expect(body.context_management).toEqual([
+      { type: "compaction", compact_threshold: 100000 },
+    ]);
+  });
+
+  it("keeps context management off standalone compact requests", () => {
+    const body = new CodexExecutor().transformRequest("gpt-5.3-codex-spark", {
+      model: "gpt-5.3-codex-spark",
+      input: "hi",
+      _compact: true,
+    }, true, {});
+
+    expect(body.context_management).toBeUndefined();
   });
 });

--- a/tests/unit/combo-model-context.test.js
+++ b/tests/unit/combo-model-context.test.js
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getProviderConnections: vi.fn(),
+  getCombos: vi.fn(),
+  getCustomModels: vi.fn(),
+  getModelAliases: vi.fn(),
+  getDisabledModels: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: mocks.getProviderConnections,
+  getCombos: mocks.getCombos,
+  getCustomModels: mocks.getCustomModels,
+  getModelAliases: mocks.getModelAliases,
+}));
+
+vi.mock("@/lib/disabledModelsDb", () => ({
+  getDisabledModels: mocks.getDisabledModels,
+}));
+
+describe("combo model context metadata", () => {
+  beforeEach(() => {
+    mocks.getProviderConnections.mockResolvedValue([]);
+    mocks.getCombos.mockResolvedValue([{
+      name: "gpt-5.2",
+      models: ["cx/gpt-5.3-codex-spark"],
+    }]);
+    mocks.getCustomModels.mockResolvedValue([]);
+    mocks.getModelAliases.mockResolvedValue({});
+    mocks.getDisabledModels.mockResolvedValue({});
+  });
+
+  it("inherits the smallest member context window", async () => {
+    const { buildModelsList } = await import("../../src/app/api/v1/models/route.js");
+    const models = await buildModelsList(["llm"], { skipDynamicFetch: true });
+
+    expect(models.find((model) => model.id === "gpt-5.2")).toMatchObject({
+      owned_by: "combo",
+      context_length: 128000,
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`gpt-5.3-codex-spark` differs from other Codex models in two relevant ways:

- It rejects `reasoning.summary` with a 400 `unsupported_parameter` error.
- Its context window is 128K, while the generic GPT-5 Codex capability currently reports 400K.

Clients using a combo alias can therefore send an unsupported reasoning field and continue accumulating context beyond Spark's actual limit.

## Changes

- Omit `reasoning.summary` for Spark and its suffixed variants while preserving `reasoning.effort`.
- Report a 128K context window for Spark, review, and effort variants.
- Pass through `context_management` for Responses API requests.
- Inject server-side compaction for Spark at a 100K token threshold, clamping larger client thresholds.
- Do not inject context management into standalone `/responses/compact` requests.
- Report the smallest member context window for combo models so clients can honor the effective limit.
- Add regression tests for reasoning normalization, Spark capabilities, compaction, and combo metadata.

## Testing

```bash
npx vitest run --config "tests/vitest.config.js" \
  "tests/unit/capabilities.test.js" \
  "tests/unit/codex-fast-capacity.test.js" \
  "tests/unit/combo-model-context.test.js"
```

Result: 3 test files passed, 20 tests passed.

A live request through 9Router to `cx/gpt-5.3-codex-spark`, including a client-supplied reasoning summary, completed successfully with HTTP 200 after the server-side normalization.
