### PR TITLE
fix(auth): protect root /responses rewrite

### DIFF
--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -34,7 +34,8 @@ const PUBLIC_API_PATHS = [
 ];
 
 // Public top-level prefixes (LLM API endpoints with their own API key auth).
-const PUBLIC_PREFIXES = ["/v1", "/v1beta", "/api/v1", "/api/v1beta", "/codex"];
+// Keep root-level rewrites here too: middleware runs before Next.js rewrites.
+const PUBLIC_PREFIXES = ["/v1", "/v1beta", "/api/v1", "/api/v1beta", "/codex", "/responses"];
 
 // Always require JWT token regardless of requireLogin setting
 const ALWAYS_PROTECTED = [

--- a/tests/unit/dashboard-guard.test.js
+++ b/tests/unit/dashboard-guard.test.js
@@ -125,6 +125,25 @@ describe("dashboard guard public LLM API access", () => {
     expect(response.body.error).toBe("API key required for remote API access");
   });
 
+  it("rejects remote /responses rewrite without API key", async () => {
+    const response = await proxy(request("/responses", { host: "router.example.com" }));
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe("API key required for remote API access");
+  });
+
+  it("allows remote /responses rewrite with a valid API key", async () => {
+    mocks.validateApiKey.mockResolvedValue(true);
+
+    const response = await proxy(request("/responses", {
+      host: "router.example.com",
+      authorization: "Bearer sk-valid",
+    }));
+
+    expect(response).toBe(mocks.nextResponse);
+    expect(mocks.validateApiKey).toHaveBeenCalledWith("sk-valid");
+  });
+
   it("allows remote codex rewrite with valid API key", async () => {
     mocks.validateApiKey.mockResolvedValue(true);
 


### PR DESCRIPTION
Fixes #3677

## Problem
`/responses` is a root-level alias for the OpenAI Responses API:

```text
/responses  →  /api/v1/responses
```

The alias is applied by a Next.js rewrite. Middleware runs **before** rewrites, so `dashboardGuard` receives the original pathname (`/responses`), not `/api/v1/responses`.

Before this change, `/responses` was absent from the LLM API prefix list. A remote request could therefore fall through the API-key gate before the rewrite dispatched it to the Responses handler.

## Root cause
`src/dashboardGuard.js` protects public LLM routes through `isPublicLlmApi()`. It recognizes `/v1`, `/v1beta`, `/api/v1`, `/api/v1beta`, and `/codex`, but not the root `/responses` alias declared in `next.config.mjs`.

## Change
- Add `/responses` to `PUBLIC_PREFIXES`, so the pre-rewrite request follows the established API-key validation path.
- Add regression coverage for both remote cases:
  1. no API key → `401 API key required for remote API access`;
  2. valid bearer key → request proceeds and `validateApiKey` is called.

## Behavior preserved
This reuses the existing guard; it does not change route handlers, API-key format, loopback handling, CLI-token access, or the existing `/v1`, `/api/v1`, and `/codex` behavior.

## Validation
### Reproduction on current `master` (`90b52e0`)
The two added regression tests fail before the guard change:
- unauthenticated `/responses` falls through instead of returning `401`;
- a valid bearer key is never validated because the request bypasses the LLM API gate.

### After the fix
```bash
cd tests && npm test -- unit/dashboard-guard.test.js
```

Result: **24 passed, 0 failed**.

`git diff --check` also passes.

## Scope
This intentionally fixes only middleware coverage for the existing `/responses` alias. It does not alter CORS policy or broaden authentication behavior beyond matching the other public LLM entry points.