### PR TITLE
fix(chatCore): return an Anthropic Message on the forced-SSE JSON path

### DIFF
--- a/open-sse/handlers/chatCore/completionToClaude.js
+++ b/open-sse/handlers/chatCore/completionToClaude.js
@@ -1,0 +1,57 @@
+import { FORMATS } from "../../translator/formats.js";
+import { fromOpenAIFinish } from "../../translator/concerns/finishReason.js";
+
+function parseToolArguments(value) {
+  if (!value) return {};
+  if (typeof value === "object") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Convert an OpenAI Chat Completions body into an Anthropic Message.
+ * Shared by the non-streaming path and the forced-SSE→JSON path so a Claude
+ * client gets the same body whichever route the request took.
+ */
+export function openAICompletionToClaudeMessage(responseBody) {
+  if (!responseBody?.choices?.[0]) return responseBody;
+  const choice = responseBody.choices[0];
+  const message = choice.message || {};
+  const content = [];
+
+  const reasoning = message.reasoning_content || message.provider_specific_fields?.reasoning_content || "";
+  if (reasoning) {
+    content.push({ type: "thinking", thinking: reasoning });
+  }
+  if (typeof message.content === "string" && message.content.length > 0) {
+    content.push({ type: "text", text: message.content });
+  }
+  for (const toolCall of message.tool_calls || []) {
+    const fn = toolCall.function || {};
+    content.push({
+      type: "tool_use",
+      id: toolCall.id || `toolu_${Date.now()}_${content.length}`,
+      name: fn.name || toolCall.name || "",
+      input: parseToolArguments(fn.arguments || toolCall.arguments),
+    });
+  }
+  if (content.length === 0) content.push({ type: "text", text: "" });
+
+  const usage = responseBody.usage || {};
+  return {
+    id: String(responseBody.id || `msg_${Date.now()}`).replace(/^chatcmpl-/, ""),
+    type: "message",
+    role: "assistant",
+    model: responseBody.model || "unknown",
+    content,
+    stop_reason: fromOpenAIFinish(choice.finish_reason, FORMATS.CLAUDE),
+    stop_sequence: null,
+    usage: {
+      input_tokens: usage.prompt_tokens || usage.input_tokens || 0,
+      output_tokens: usage.completion_tokens || usage.output_tokens || 0,
+    },
+  };
+}

--- a/open-sse/handlers/chatCore/completionToClaude.js
+++ b/open-sse/handlers/chatCore/completionToClaude.js
@@ -16,7 +16,7 @@ function parseToolArguments(value) {
  * Shared by the non-streaming path and the forced-SSE→JSON path so a Claude
  * client gets the same body whichever route the request took.
  */
-export function openAICompletionToClaudeMessage(responseBody) {
+export function openAICompletionToClaudeMessage(responseBody, requestModel = null) {
   if (!responseBody?.choices?.[0]) return responseBody;
   const choice = responseBody.choices[0];
   const message = choice.message || {};
@@ -44,7 +44,10 @@ export function openAICompletionToClaudeMessage(responseBody) {
     id: String(responseBody.id || `msg_${Date.now()}`).replace(/^chatcmpl-/, ""),
     type: "message",
     role: "assistant",
-    model: responseBody.model || "unknown",
+    // Echo the model the client asked for; the provider body carries the
+    // upstream model (e.g. glm-5.3), which Anthropic clients can't restore
+    // as a session model (issue #3692).
+    model: requestModel || responseBody.model || "unknown",
     content,
     stop_reason: fromOpenAIFinish(choice.finish_reason, FORMATS.CLAUDE),
     stop_sequence: null,

--- a/open-sse/handlers/chatCore/completionToClaude.js
+++ b/open-sse/handlers/chatCore/completionToClaude.js
@@ -38,7 +38,6 @@ export function openAICompletionToClaudeMessage(responseBody) {
       input: parseToolArguments(fn.arguments || toolCall.arguments),
     });
   }
-  if (content.length === 0) content.push({ type: "text", text: "" });
 
   const usage = responseBody.usage || {};
   return {

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -1,6 +1,5 @@
 import { FORMATS } from "../../translator/formats.js";
 import { needsTranslation } from "../../translator/index.js";
-import { fromOpenAIFinish } from "../../translator/concerns/finishReason.js";
 import { ollamaBodyToOpenAI } from "../../translator/response/ollama-to-openai.js";
 import { addBufferToUsage, filterUsageForFormat } from "../../utils/usageTracking.js";
 import { createErrorResult } from "../../utils/error.js";
@@ -9,57 +8,8 @@ import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
+import { openAICompletionToClaudeMessage } from "./completionToClaude.js";
 import { ROLE, RESPONSES_ITEM } from "../../translator/schema/index.js";
-
-function parseToolArguments(value) {
-  if (!value) return {};
-  if (typeof value === "object") return value;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return {};
-  }
-}
-
-function openAICompletionToClaudeMessage(responseBody) {
-  if (!responseBody?.choices?.[0]) return responseBody;
-  const choice = responseBody.choices[0];
-  const message = choice.message || {};
-  const content = [];
-
-  const reasoning = message.reasoning_content || message.provider_specific_fields?.reasoning_content || "";
-  if (reasoning) {
-    content.push({ type: "thinking", thinking: reasoning });
-  }
-  if (typeof message.content === "string" && message.content.length > 0) {
-    content.push({ type: "text", text: message.content });
-  }
-  for (const toolCall of message.tool_calls || []) {
-    const fn = toolCall.function || {};
-    content.push({
-      type: "tool_use",
-      id: toolCall.id || `toolu_${Date.now()}_${content.length}`,
-      name: fn.name || toolCall.name || "",
-      input: parseToolArguments(fn.arguments || toolCall.arguments),
-    });
-  }
-  if (content.length === 0) content.push({ type: "text", text: "" });
-
-  const usage = responseBody.usage || {};
-  return {
-    id: String(responseBody.id || `msg_${Date.now()}`).replace(/^chatcmpl-/, ""),
-    type: "message",
-    role: "assistant",
-    model: responseBody.model || "unknown",
-    content,
-    stop_reason: fromOpenAIFinish(choice.finish_reason, FORMATS.CLAUDE),
-    stop_sequence: null,
-    usage: {
-      input_tokens: usage.prompt_tokens || usage.input_tokens || 0,
-      output_tokens: usage.completion_tokens || usage.output_tokens || 0,
-    },
-  };
-}
 
 /**
  * Convert an OpenAI Chat Completions non-streaming response body into the

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -5,6 +5,7 @@ import { FORMATS } from "../../translator/formats.js";
 import { PROVIDERS } from "../../config/providers.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { ROLE, RESPONSES_ITEM } from "../../translator/schema/index.js";
+import { openAICompletionToClaudeMessage } from "./completionToClaude.js";
 
 // Responses-API providers (e.g. codex) may emit SSE without content-type + use Responses output shape
 const isResponsesProvider = (p) => PROVIDERS[p]?.format === FORMATS.OPENAI_RESPONSES;
@@ -103,6 +104,58 @@ function chatCompletionToResponses(responseBody, customToolNames = null) {
       total_tokens: usage.total_tokens || (usage.prompt_tokens || 0) + (usage.completion_tokens || 0),
     },
   };
+}
+
+/**
+ * Convert a Responses API body into an Anthropic Message. A Claude client that
+ * retried without streaming against a Responses-API provider (e.g. codex) must
+ * still get a `type: "message"` body back.
+ */
+function responsesToClaudeMessage(jsonResponse, fallbackModel) {
+  const content = [];
+
+  for (const item of jsonResponse?.output || []) {
+    if (item?.type === RESPONSES_ITEM.MESSAGE) {
+      const text = textFromResponsesMessageItem(item);
+      if (text.length > 0) content.push({ type: "text", text });
+    } else if (item?.type === RESPONSES_ITEM.FUNCTION_CALL) {
+      content.push({
+        type: "tool_use",
+        id: item.call_id || item.id || `toolu_${Date.now()}_${content.length}`,
+        name: item.name || "",
+        input: parseResponsesToolInput(item.arguments),
+      });
+    }
+  }
+  if (content.length === 0) content.push({ type: "text", text: "" });
+
+  const usage = jsonResponse?.usage || {};
+  const hasToolUse = content.some((block) => block.type === "tool_use");
+  return {
+    id: String(jsonResponse?.id || `msg_${Date.now()}`),
+    type: "message",
+    role: ROLE.ASSISTANT,
+    model: jsonResponse?.model || fallbackModel || "unknown",
+    content,
+    stop_reason: hasToolUse ? "tool_use" : "end_turn",
+    stop_sequence: null,
+    usage: {
+      input_tokens: (usage.input_tokens || 0)
+        + (usage.cache_read_input_tokens || usage.cached_tokens || 0)
+        + (usage.cache_creation_input_tokens || 0),
+      output_tokens: usage.output_tokens || 0,
+    },
+  };
+}
+
+function parseResponsesToolInput(argumentsValue) {
+  if (!argumentsValue) return {};
+  if (typeof argumentsValue === "object") return argumentsValue;
+  try {
+    return JSON.parse(argumentsValue);
+  } catch {
+    return {};
+  }
 }
 
 /**
@@ -222,6 +275,13 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
         response: { content: textContent, thinking: null, finish_reason: jsonResponse.status || "unknown" },
         status: "success"
       }, { endpoint: clientRawRequest?.endpoint || null })).catch(() => {});
+
+      // Client is Claude → build an Anthropic Message. Without this the client
+      // gets a chat.completion body on a 200, which it cannot parse.
+      if (sourceFormat === FORMATS.CLAUDE) {
+        const claudeMessage = responsesToClaudeMessage(jsonResponse, model);
+        return { success: true, response: new Response(JSON.stringify(claudeMessage), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
+      }
 
       // Client is Responses API → return as-is
       if (sourceFormat === FORMATS.OPENAI_RESPONSES) {
@@ -347,9 +407,14 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
     // lost on the non-streaming return path. Inlined (not imported from
     // nonStreamingHandler.js) to avoid a circular import: nonStreamingHandler
     // already imports parseSSEToOpenAIResponse from this module.
+    // A Claude client (/v1/messages) reaches this path when it retries without
+    // streaming against a forced-streaming provider. It needs an Anthropic
+    // Message, not the chat.completion body parseSSEToOpenAIResponse produces.
     const finalBody = sourceFormat === FORMATS.OPENAI_RESPONSES
       ? chatCompletionToResponses(parsed, customToolNames)
-      : parsed;
+      : sourceFormat === FORMATS.CLAUDE
+        ? openAICompletionToClaudeMessage(parsed)
+        : parsed;
 
     return { success: true, response: new Response(JSON.stringify(finalBody), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
   } catch (err) {

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -134,7 +134,7 @@ function responsesToClaudeMessage(jsonResponse, fallbackModel) {
     id: String(jsonResponse?.id || `msg_${Date.now()}`),
     type: "message",
     role: ROLE.ASSISTANT,
-    model: jsonResponse?.model || fallbackModel || "unknown",
+    model: fallbackModel || jsonResponse?.model || "unknown",
     content,
     stop_reason: hasToolUse ? "tool_use" : "end_turn",
     stop_sequence: null,
@@ -412,7 +412,7 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
     const finalBody = sourceFormat === FORMATS.OPENAI_RESPONSES
       ? chatCompletionToResponses(parsed, customToolNames)
       : sourceFormat === FORMATS.CLAUDE
-        ? openAICompletionToClaudeMessage(parsed)
+        ? openAICompletionToClaudeMessage(parsed, model)
         : parsed;
 
     return { success: true, response: new Response(JSON.stringify(finalBody), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -127,7 +127,6 @@ function responsesToClaudeMessage(jsonResponse, fallbackModel) {
       });
     }
   }
-  if (content.length === 0) content.push({ type: "text", text: "" });
 
   const usage = jsonResponse?.usage || {};
   const hasToolUse = content.some((block) => block.type === "tool_use");

--- a/tests/unit/claude-client-forced-sse-nonstream.test.js
+++ b/tests/unit/claude-client-forced-sse-nonstream.test.js
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}),
+  saveRequestUsage: vi.fn(async () => {})
+}));
+
+const { FORMATS } = await import("../../open-sse/translator/formats.js");
+const { handleForcedSSEToJson } = await import("../../open-sse/handlers/chatCore/sseToJsonHandler.js");
+
+const encoder = new TextEncoder();
+
+function sseResponse(lines) {
+  return new Response(new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(lines.concat("data: [DONE]", "").join("\n\n")));
+      controller.close();
+    }
+  }), { headers: { "content-type": "text/event-stream" } });
+}
+
+function baseCtx(providerResponse, overrides = {}) {
+  return {
+    providerResponse,
+    sourceFormat: FORMATS.CLAUDE,
+    provider: "op-test-chat",
+    model: "gpt-x",
+    body: { model: "gpt-x", messages: [] },
+    stream: false,
+    requestStartTime: Date.now(),
+    connectionId: "test-connection",
+    clientRawRequest: { endpoint: "/v1/messages" },
+    trackDone: vi.fn(),
+    appendLog: vi.fn(),
+    ...overrides
+  };
+}
+
+const CHAT_SSE = [
+  'data: {"id":"chatcmpl-sse","object":"chat.completion.chunk","created":1700000000,"model":"gpt-x","choices":[{"delta":{"content":"hi"},"finish_reason":null}]}',
+  'data: {"id":"chatcmpl-sse","object":"chat.completion.chunk","created":1700000000,"model":"gpt-x","choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_9","type":"function","function":{"name":"shell","arguments":"{\\"cmd\\":\\"pwd\\"}"}}]},"finish_reason":null}]}',
+  'data: {"id":"chatcmpl-sse","object":"chat.completion.chunk","created":1700000000,"model":"gpt-x","choices":[{"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}'
+];
+
+const RESPONSES_SSE = [
+  'event: response.created\ndata: {"response":{"id":"resp_1","created_at":1700000000}}',
+  'event: response.output_item.done\ndata: {"output_index":0,"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}}',
+  'event: response.output_item.done\ndata: {"output_index":1,"item":{"type":"function_call","call_id":"call_9","name":"shell","arguments":"{\\"cmd\\":\\"pwd\\"}"}}',
+  'event: response.completed\ndata: {"response":{"id":"resp_1","model":"gpt-x","status":"completed","usage":{"input_tokens":10,"output_tokens":5}}}'
+];
+
+describe("forced-SSE JSON path for a Claude client", () => {
+  it("returns an Anthropic Message from a chat-completions upstream", async () => {
+    const result = await handleForcedSSEToJson(
+      baseCtx(sseResponse(CHAT_SSE), { targetFormat: FORMATS.OPENAI })
+    );
+
+    expect(result.success).toBe(true);
+    const json = await result.response.json();
+    expect(json.type).toBe("message");
+    expect(json.object).toBeUndefined();
+    expect(json.role).toBe("assistant");
+    expect(json.stop_reason).toBe("tool_use");
+    expect(json.content).toEqual([
+      { type: "text", text: "hi" },
+      { type: "tool_use", id: "call_9", name: "shell", input: { cmd: "pwd" } }
+    ]);
+    expect(json.usage).toMatchObject({ input_tokens: 10, output_tokens: 5 });
+  });
+
+  it("returns an Anthropic Message from a Responses-API upstream", async () => {
+    const result = await handleForcedSSEToJson(
+      baseCtx(sseResponse(RESPONSES_SSE), { targetFormat: FORMATS.OPENAI_RESPONSES })
+    );
+
+    expect(result.success).toBe(true);
+    const json = await result.response.json();
+    expect(json.type).toBe("message");
+    expect(json.object).toBeUndefined();
+    expect(json.stop_reason).toBe("tool_use");
+    const toolUse = json.content.find((block) => block.type === "tool_use");
+    expect(toolUse).toMatchObject({ id: "call_9", name: "shell", input: { cmd: "pwd" } });
+  });
+
+  it("still returns chat.completion for a plain chat client", async () => {
+    const result = await handleForcedSSEToJson(
+      baseCtx(sseResponse(CHAT_SSE), { sourceFormat: FORMATS.OPENAI, targetFormat: FORMATS.OPENAI })
+    );
+
+    expect(result.success).toBe(true);
+    const json = await result.response.json();
+    expect(json.object).toBe("chat.completion");
+    expect(json.choices[0].message.tool_calls[0].function.name).toBe("shell");
+  });
+});

--- a/tests/unit/claude-client-forced-sse-nonstream.test.js
+++ b/tests/unit/claude-client-forced-sse-nonstream.test.js
@@ -94,3 +94,17 @@ describe("forced-SSE JSON path for a Claude client", () => {
     expect(json.choices[0].message.tool_calls[0].function.name).toBe("shell");
   });
 });
+
+describe("empty completions must not produce empty text blocks", () => {
+  it("returns content: [] when the provider gave neither text nor tool calls", async () => {
+    // Claude Code 400s on re-send if history ever gains {type:"text",text:""}.
+    const res = new Response(
+      'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"glm-5.3","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n',
+      { headers: { "content-type": "text/event-stream" } },
+    );
+    const r = await handleForcedSSEToJson(baseCtx(res, { targetFormat: FORMATS.OPENAI }));
+    expect(r.success).toBe(true);
+    const json = await r.response.json();
+    expect(json.content).toEqual([]);
+  });
+});

--- a/tests/unit/claude-client-forced-sse-nonstream.test.js
+++ b/tests/unit/claude-client-forced-sse-nonstream.test.js
@@ -108,3 +108,14 @@ describe("empty completions must not produce empty text blocks", () => {
     expect(json.content).toEqual([]);
   });
 });
+
+describe("model echo on the non-streaming Claude path", () => {
+  it("prefers the request model when provider chunks carry a different one", async () => {
+    const lines = CHAT_SSE.map(l => l.replace(/"model":"gpt-x"/g, '"model":"glm-5.3"'));
+    const result = await handleForcedSSEToJson(
+      baseCtx(sseResponse(lines), { targetFormat: FORMATS.OPENAI })
+    );
+    const json = await result.response.json();
+    expect(json.model).toBe("gpt-x");
+  });
+});


### PR DESCRIPTION
Fixes #3682.

## Problem

`handleForcedSSEToJson` handles the Responses-API and Gemini clients but has no `FORMATS.CLAUDE` branch, so a Claude client (`/v1/messages`) that retries with `stream: false` against a forced-streaming provider receives an OpenAI `chat.completion` body on HTTP 200 and cannot parse it. Both branches are affected — the Responses-API one builds `object: "chat.completion"`, the chat-completions one returns `parsed` untouched.

Behind Claude Code this ends the session: a failed stream creation triggers an automatic non-streaming retry, which then fails on the body shape.

## Change

- Chat-completions branch: converts with `openAICompletionToClaudeMessage` when `sourceFormat === FORMATS.CLAUDE`.
- Responses-API branch: adds `responsesToClaudeMessage`, which maps `output` items to `text` / `tool_use` blocks and folds the cache counters into `input_tokens` the same way the existing OpenAI branch does.
- `openAICompletionToClaudeMessage` moves out of `nonStreamingHandler.js` into `open-sse/handlers/chatCore/completionToClaude.js` so both paths share one converter and cannot drift. Extraction only — no behaviour change for the existing caller.

Non-Claude clients are untouched: the new code is behind a `sourceFormat === FORMATS.CLAUDE` check on both paths.

## Tests

`tests/unit/claude-client-forced-sse-nonstream.test.js`, following the shape of the existing `openai-responses-nonstream.test.js`:

- Anthropic Message from a chat-completions upstream (text + `tool_use`, `stop_reason: "tool_use"`, Anthropic `usage`)
- Anthropic Message from a Responses-API upstream
- a plain chat client still gets `chat.completion` (guards against over-reach)

Verified red before the fix (the two Claude cases fail, the chat case passes) and green after.

## Regression check

Full suite run before and after on the same checkout, compared by test name:

- fails before: 89
- fails after: 85
- **regressions: 0**

The 4 that flip to green are the 2 new Claude cases plus 2 `xai-oauth-service` cases, which are the network-dependent flakes documented in `CLAUDE.md`. `npx eslint` is clean on the touched files.