### PR TITLE
Echo the requested model in Claude-format streaming responses

### DIFF
--- a/open-sse/translator/response/openai-to-claude.js
+++ b/open-sse/translator/response/openai-to-claude.js
@@ -118,7 +118,11 @@ export function openaiToClaudeResponse(chunk, state) {
         chunk.extend_fields?.traceId ||
         `msg_${Date.now()}`;
     }
-    state.model = chunk.model || MODEL_FALLBACK;
+    // The state was seeded with the model the CLIENT asked for (see
+    // createSSEStream). Echoing the upstream provider's chunk.model (e.g.
+    // "glm-5.3" behind a claude-* combo) makes Anthropic-format clients save
+    // that name as the session model and fail to restore it on resume.
+    state.model = state.model || chunk.model || MODEL_FALLBACK;
     state.nextBlockIndex = 0;
     results.push({
       type: "message_start",

--- a/tests/unit/response-model-echo.test.js
+++ b/tests/unit/response-model-echo.test.js
@@ -1,0 +1,26 @@
+// The client asked for model X (e.g. claude-opus-5); the upstream provider is
+// model Y (e.g. glm-5.3). Responses must echo X, not Y: Anthropic-format
+// clients (Claude Code) persist message.model into the session and refuse to
+// restore a model they don't recognize.
+import { describe, expect, it } from "vitest";
+import { translateResponse, initState } from "../../open-sse/translator/index.js";
+
+const completion = { model: "glm-5.3" };
+
+describe("model echo (streaming)", () => {
+  it("seeded state.model (client's request) survives provider chunks", () => {
+    const state = { ...initState("claude"), model: "claude-opus-5" };
+    const events = translateResponse("openai", "claude",
+      { id: "chatcmpl-1", object: "chat.completion.chunk", model: "glm-5.3", choices: [{ delta: { content: "hi" } }] }, state);
+    const start = events.find(e => e.type === "message_start");
+    expect(start.message.model).toBe("claude-opus-5");
+  });
+
+  it("falls back to the provider chunk model when state.model is unset", () => {
+    const state = initState("claude");
+    const events = translateResponse("openai", "claude",
+      { id: "chatcmpl-1", object: "chat.completion.chunk", model: "glm-5.3", choices: [{ delta: { content: "hi" } }] }, state);
+    const start = events.find(e => e.type === "message_start");
+    expect(start.message.model).toBe("glm-5.3");
+  });
+});


### PR DESCRIPTION
Fixes #3692.

`createSSEStream` already seeds the translation state with the model the client asked for; this PR stops the OpenAI→Claude response translator from overwriting it with the provider chunk's model. `message_start` now echoes the requested model, falling back to the provider name only when the state has none (e.g. executors that build state without a model).

Non-streaming/forced-SSE paths are handled separately in the forced-SSE PR (#3683), which owns the Chat-Completions→Claude conversion code.

- open-sse/translator/response/openai-to-claude.js: `state.model = state.model || chunk.model || MODEL_FALLBACK`
- tests/unit/response-model-echo.test.js: seeded model survives provider chunks; provider model still used when state is unseeded