### PR TITLE
fix(translator): preserve usage and model on synthesized response.completed

### DIFF
--- a/open-sse/transformer/responsesTransformer.js
+++ b/open-sse/transformer/responsesTransformer.js
@@ -225,16 +225,39 @@ export function createResponsesApiTransformStream(logger = null) {
   const sendCompleted = (controller) => {
     if (!state.completedSent) {
       state.completedSent = true;
+      const response = {
+        id: state.responseId,
+        object: "response",
+        created_at: state.created,
+        status: "completed",
+        background: false,
+        error: null
+      };
+      // Omit when the upstream never sent one — same conditional as
+      // usage, so no null/empty field can leak into the event.
+      if (state.model) {
+        response.model = state.model;
+      }
+      // Map the chat chunk's usage into the Responses shape:
+      // consumers (codex CLI and everything billing behind it) read
+      // token counts from response.completed — omitting them made
+      // every run through this proxy report 0 tokens.
+      if (state.usage) {
+        const input = Number(state.usage.prompt_tokens) || 0;
+        const output = Number(state.usage.completion_tokens) || 0;
+        const cached = Number(state.usage.prompt_tokens_details?.cached_tokens) || 0;
+        const reasoning = Number(state.usage.completion_tokens_details?.reasoning_tokens) || 0;
+        response.usage = {
+          input_tokens: input,
+          input_tokens_details: { cached_tokens: cached },
+          output_tokens: output,
+          output_tokens_details: { reasoning_tokens: reasoning },
+          total_tokens: Number(state.usage.total_tokens) || input + output
+        };
+      }
       emit(controller, "response.completed", {
         type: "response.completed",
-        response: {
-          id: state.responseId,
-          object: "response",
-          created_at: state.created,
-          status: "completed",
-          background: false,
-          error: null
-        }
+        response
       });
     }
   };
@@ -264,6 +287,15 @@ export function createResponsesApiTransformStream(logger = null) {
           continue;
         }
 
+        // The include_usage final chunk carries `usage` with EMPTY
+        // choices — capture it BEFORE the choices guard skips it.
+        if (parsed.usage && typeof parsed.usage === "object") {
+          state.usage = parsed.usage;
+        }
+        // Chunks carry `model` on every chunk (first wins, the rest are
+        // identical) — mirror it onto the synthesized response, whose
+        // schema requires it (upstream issue #1681's other half).
+        if (parsed.model) state.model = parsed.model;
         if (!parsed.choices?.length) continue;
         
         const choice = parsed.choices[0];
@@ -414,12 +446,16 @@ export function createResponsesApiTransformStream(logger = null) {
           }
         }
 
-        // Handle finish_reason
+        // Handle finish_reason: close items but DON'T complete yet —
+        // with stream_options.include_usage the usage chunk arrives
+        // AFTER finish_reason (empty choices), and response.completed
+        // is the protocol's final event: emitting it here would lock
+        // in usage:0 before the evidence lands (the ordering bug
+        // upstream issue #1700 describes). flush() completes.
         if (choice.finish_reason) {
           for (const i in state.msgItemAdded) closeMessage(controller, i);
           closeReasoning(controller);
           for (const i in state.funcCallIds) closeToolCall(controller, i);
-          sendCompleted(controller);
         }
       }
     },

--- a/open-sse/translator/formats/responsesApi.js
+++ b/open-sse/translator/formats/responsesApi.js
@@ -137,5 +137,13 @@ export function convertResponsesApiFormat(body) {
   delete result.store;
   delete result.reasoning;
 
+  // Ask chat-completions upstreams to report usage on the final chunk:
+  // without include_usage most upstreams never send token counts, and
+  // the Responses translation below then completes with no usage —
+  // every consumer (codex CLI, billing systems) reads 0 tokens.
+  if (result.stream !== false) {
+    result.stream_options = { ...(result.stream_options || {}), include_usage: true };
+  }
+
   return result;
 }

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -195,6 +195,14 @@ export function translateResponse(targetFormat, sourceFormat, chunk, state) {
     }
   }
 
+  // Flush cascade: a null chunk (stream flush) must reach the
+  // source-format flush even when the target→openai flush returns nothing
+  // (claude→openai returns null), or 2-hop chains never emit their
+  // terminal event — response.completed was silently dropped at flush.
+  if (chunk === null && results.length === 0 && sourceFormat !== FORMATS.OPENAI) {
+    results = [null];
+  }
+
   // Step 2: openai -> source (if source is not openai)
   if (sourceFormat !== FORMATS.OPENAI) {
     const fromOpenAI = responseRegistry.get(`${FORMATS.OPENAI}:${sourceFormat}`);

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -246,6 +246,14 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
   delete result.reasoning;
   delete result.client_metadata;
 
+  // Ask chat-completions upstreams to report usage on the final chunk:
+  // without include_usage most upstreams never send token counts, and the
+  // response translation below then completes with no usage — every
+  // consumer (codex CLI, billing systems) reads 0 tokens.
+  if (result.stream !== false) {
+    result.stream_options = { ...(result.stream_options || {}), include_usage: true };
+  }
+
   return result;
 }
 

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -18,7 +18,14 @@ export function openaiToOpenAIResponsesResponse(chunk, state) {
   if (!chunk) {
     return flushEvents(state);
   }
-  
+
+  // The include_usage final chunk carries `usage` with EMPTY choices —
+  // capture usage and model BEFORE the choices guard skips it. Chunks
+  // carry `model` on every chunk (first wins, the rest are identical).
+  if (chunk.usage && typeof chunk.usage === "object") {
+    state.usage = chunk.usage;
+  }
+  if (chunk.model) state.model = chunk.model;
   if (!chunk.choices?.length) return [];
   
   const events = [];
@@ -107,12 +114,16 @@ export function openaiToOpenAIResponsesResponse(chunk, state) {
     }
   }
 
-  // Handle finish_reason
+  // Handle finish_reason: close items but DON'T complete yet —
+  // with stream_options.include_usage the usage chunk arrives AFTER
+  // finish_reason (empty choices), and response.completed is the
+  // protocol's final event: emitting it here would lock in usage:0
+  // before the evidence lands. flushEvents() (the stream.js flush)
+  // completes.
   if (choice.finish_reason) {
     for (const i in state.msgItemAdded) closeMessage(state, emit, i);
     closeReasoning(state, emit);
     for (const i in state.funcCallIds) closeToolCall(state, emit, i);
-    sendCompleted(state, emit);
   }
 
   return events;
@@ -368,16 +379,39 @@ function closeToolCall(state, emit, idx) {
 function sendCompleted(state, emit) {
   if (!state.completedSent) {
     state.completedSent = true;
+    const response = {
+      id: state.responseId,
+      object: "response",
+      created_at: state.created,
+      status: "completed",
+      background: false,
+      error: null
+    };
+    // Omit when the upstream never sent one — same conditional as
+    // usage, so no null/empty field can leak into the event.
+    if (state.model) {
+      response.model = state.model;
+    }
+    // Map the chat chunk's usage into the Responses shape: consumers
+    // (codex CLI and everything billing behind it) read token counts
+    // from response.completed — omitting them made every run through
+    // this proxy report 0 tokens.
+    if (state.usage) {
+      const input = Number(state.usage.prompt_tokens) || 0;
+      const output = Number(state.usage.completion_tokens) || 0;
+      const cached = Number(state.usage.prompt_tokens_details?.cached_tokens) || 0;
+      const reasoning = Number(state.usage.completion_tokens_details?.reasoning_tokens) || 0;
+      response.usage = {
+        input_tokens: input,
+        input_tokens_details: { cached_tokens: cached },
+        output_tokens: output,
+        output_tokens_details: { reasoning_tokens: reasoning },
+        total_tokens: Number(state.usage.total_tokens) || input + output
+      };
+    }
     emit("response.completed", {
       type: "response.completed",
-      response: {
-        id: state.responseId,
-        object: "response",
-        created_at: state.created,
-        status: "completed",
-        background: false,
-        error: null
-      }
+      response
     });
   }
 }

--- a/tests/unit/openai-responses-translator-usage-model.test.js
+++ b/tests/unit/openai-responses-translator-usage-model.test.js
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+
+import { initState, translateResponse } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import {
+  openaiResponsesToOpenAIRequest,
+} from "../../open-sse/translator/request/openai-responses.js";
+import {
+  openaiToOpenAIResponsesResponse,
+} from "../../open-sse/translator/response/openai-responses.js";
+
+// The LIVE /v1/responses path for a chat-completions upstream runs through
+// these translators (stream.js → translateResponse/translateRequest), NOT
+// the legacy responsesHandler transformer. Assert the same billing
+// evidence here: response.completed carries model + usage, usage chunk
+// captured before completion, completion deferred to flush.
+
+const MODEL = "z-ai/glm-5.3-flash";
+
+const USAGE = {
+  prompt_tokens: 9452,
+  prompt_tokens_details: { cached_tokens: 1280 },
+  completion_tokens: 32,
+  completion_tokens_details: { reasoning_tokens: 7 },
+  total_tokens: 9484
+};
+
+function runTranslator(chunks) {
+  const state = { ...initState(FORMATS.OPENAI_RESPONSES) };
+  const batches = chunks.map((chunk) => openaiToOpenAIResponsesResponse(chunk, state));
+  const flushBatch = openaiToOpenAIResponsesResponse(null, state); // stream.js flush
+  return { batches, flushBatch };
+}
+
+function completedFrom(batch) {
+  const ev = (batch || []).find((item) => item?.event === "response.completed");
+  return ev ? ev.data : null;
+}
+
+function streamWithUsage({ withModel = true, withUsage = true } = {}) {
+  const chunks = [
+    {
+      ...(withModel ? { model: MODEL } : {}),
+      id: "chatcmpl-gate",
+      object: "chat.completion.chunk",
+      choices: [{ index: 0, delta: { role: "assistant", content: "Hello" }, finish_reason: null }]
+    },
+    {
+      ...(withModel ? { model: MODEL } : {}),
+      id: "chatcmpl-gate",
+      object: "chat.completion.chunk",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }]
+    }
+  ];
+  if (withUsage) {
+    // include_usage final chunk: usage with EMPTY choices, AFTER finish_reason.
+    chunks.push({
+      ...(withModel ? { model: MODEL } : {}),
+      id: "chatcmpl-gate",
+      object: "chat.completion.chunk",
+      choices: [],
+      usage: USAGE
+    });
+  }
+  return chunks;
+}
+
+describe("live-path translator usage + model evidence", () => {
+  it("request translation asks the upstream for include_usage when streaming", () => {
+    const body = {
+      model: "daiserver",
+      instructions: "sys",
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }],
+      stream: true
+    };
+    const out = openaiResponsesToOpenAIRequest("glm/glm-5.3-flash", body, true, {});
+    expect(out.stream_options).toEqual({ include_usage: true });
+    expect(out.messages[0]).toEqual({ role: "system", content: "sys" });
+  });
+
+  it("request translation leaves non-streaming requests untouched", () => {
+    const body = {
+      model: "daiserver",
+      instructions: "sys",
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }],
+      stream: false
+    };
+    const out = openaiResponsesToOpenAIRequest("glm/glm-5.3-flash", body, false, {});
+    expect(out.stream_options).toBeUndefined();
+  });
+
+  it("response.completed (at flush) carries model and the full mapped usage", () => {
+    const { batches, flushBatch } = runTranslator(streamWithUsage());
+
+    // Completion is deferred past finish_reason: no completed event until flush.
+    for (const batch of batches) {
+      expect(completedFrom(batch)).toBeNull();
+    }
+    const completed = completedFrom(flushBatch);
+    expect(completed).not.toBeNull();
+    expect(completed.response.model).toBe(MODEL);
+    expect(completed.response.usage).toEqual({
+      input_tokens: 9452,
+      input_tokens_details: { cached_tokens: 1280 },
+      output_tokens: 32,
+      output_tokens_details: { reasoning_tokens: 7 },
+      total_tokens: 9484
+    });
+  });
+
+  it("upstream ignoring include_usage still completes cleanly, usage omitted, model present", () => {
+    const { batches, flushBatch } = runTranslator(streamWithUsage({ withUsage: false }));
+    for (const batch of batches) {
+      expect(completedFrom(batch)).toBeNull();
+    }
+    const completed = completedFrom(flushBatch);
+    expect(completed).not.toBeNull();
+    expect(completed.response.model).toBe(MODEL);
+    expect(completed.response.usage).toBeUndefined();
+  });
+
+  it("upstream never sending model omits the field — no null/empty leak", () => {
+    const { flushBatch } = runTranslator(streamWithUsage({ withModel: false }));
+    const completed = completedFrom(flushBatch);
+    expect(completed).not.toBeNull();
+    expect(completed.response.usage).toBeDefined();
+    expect(completed.response.model).toBeUndefined();
+    expect(JSON.stringify(completed.response)).not.toMatch(/"model"\s*:\s*(null|"")/);
+  });
+});
+
+// The production glm connection speaks the CLAUDE transport, so the live
+// wire is a 2-hop translation claude→openai→responses through the hub.
+// This is the path the deployed gateway actually serves.
+describe("live-path claude→responses 2-hop (production glm transport)", () => {
+  it("flush cascades through the openai hub: completed carries model+usage", () => {
+    const state = { ...initState(FORMATS.OPENAI_RESPONSES) };
+    const claudeChunks = [
+      { type: "message_start", message: { id: "msg_g", model: "glm-5.3-flash", usage: { input_tokens: 9000, cache_read_input_tokens: 1280 } } },
+      { type: "content_block_start", index: 0, content_block: { type: "text" } },
+      { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ready" } },
+      { type: "content_block_stop", index: 0 },
+      { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 32 } },
+      { type: "message_stop" }
+    ];
+
+    const batches = claudeChunks.map((c) =>
+      translateResponse(FORMATS.CLAUDE, FORMATS.OPENAI_RESPONSES, c, state));
+
+    // Completion deferred: nothing terminal until the flush call.
+    for (const batch of batches) {
+      expect((batch || []).find((i) => i?.event === "response.completed")).toBeUndefined();
+    }
+
+    const flush = translateResponse(FORMATS.CLAUDE, FORMATS.OPENAI_RESPONSES, null, state);
+    const ev = (flush || []).find((i) => i?.event === "response.completed");
+    expect(ev).toBeTruthy();
+    expect(ev.data.response.model).toBe("glm-5.3-flash");
+    // prompt side = input + cache_read (claude semantics), mapped via
+    // toOpenAIUsage → prompt_tokens_details.cached_tokens.
+    expect(ev.data.response.usage.input_tokens).toBe(10280);
+    expect(ev.data.response.usage.input_tokens_details.cached_tokens).toBe(1280);
+    expect(ev.data.response.usage.output_tokens).toBe(32);
+    expect(ev.data.response.usage.total_tokens).toBe(10312);
+  });
+});

--- a/tests/unit/openai-responses-usage-model.test.js
+++ b/tests/unit/openai-responses-usage-model.test.js
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import { createResponsesApiTransformStream } from "../../open-sse/transformer/responsesTransformer.js";
+
+// Drive the chat-completions → Responses transformer the way
+// responsesHandler.js wires it (createResponsesApiTransformStream(null),
+// upstream SSE piped through) and assert the synthesized
+// response.completed preserves the billing evidence: usage AND model.
+
+const MODEL = "z-ai/glm-5.3-flash";
+
+const USAGE = {
+  prompt_tokens: 9452,
+  prompt_tokens_details: { cached_tokens: 1280 },
+  completion_tokens: 32,
+  completion_tokens_details: { reasoning_tokens: 7 },
+  total_tokens: 9484
+};
+
+function chatEvent(obj) {
+  return `data: ${JSON.stringify(obj)}\n\n`;
+}
+
+async function runTransform(events) {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(events.join("")));
+      controller.close();
+    }
+  });
+
+  const reader = stream.pipeThrough(createResponsesApiTransformStream(null)).getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+
+  text += decoder.decode();
+  return text;
+}
+
+function completedPayload(output) {
+  for (const block of output.split("\n\n")) {
+    const m = block.match(/^data: (.+)$/m);
+    if (!m) continue;
+    try {
+      const parsed = JSON.parse(m[1]);
+      if (parsed.type === "response.completed") return parsed;
+    } catch {
+      // not JSON — ignore
+    }
+  }
+  return null;
+}
+
+function streamWithUsage({ withModel = true, withUsage = true } = {}) {
+  const events = [
+    chatEvent({
+      ...(withModel ? { model: MODEL } : {}),
+      id: "chatcmpl-usage",
+      object: "chat.completion.chunk",
+      choices: [{ index: 0, delta: { content: "Hello" }, finish_reason: null }]
+    }),
+    chatEvent({
+      ...(withModel ? { model: MODEL } : {}),
+      id: "chatcmpl-usage",
+      object: "chat.completion.chunk",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }]
+    })
+  ];
+  if (withUsage) {
+    // include_usage final chunk: usage with EMPTY choices, AFTER
+    // finish_reason — the ordering the flush fix exists for.
+    events.push(chatEvent({
+      ...(withModel ? { model: MODEL } : {}),
+      id: "chatcmpl-usage",
+      choices: [],
+      usage: USAGE
+    }));
+  }
+  events.push("data: [DONE]\n\n");
+  return events;
+}
+
+describe("responsesTransformer usage + model evidence", () => {
+  it("response.completed carries the chunk's model and the full mapped usage, emitted at flush", async () => {
+    const output = await runTransform(streamWithUsage());
+    const completed = completedPayload(output);
+
+    expect(completed).not.toBeNull();
+    expect(completed.response.model).toBe(MODEL);
+    expect(completed.response.usage).toEqual({
+      input_tokens: 9452,
+      input_tokens_details: { cached_tokens: 1280 },
+      output_tokens: 32,
+      output_tokens_details: { reasoning_tokens: 7 },
+      total_tokens: 9484
+    });
+
+    // Flush ordering: exactly one response.completed, after the last
+    // output_item.done (so the late usage chunk was captured first)
+    // and before the final [DONE].
+    expect(output.match(/event: response\.completed/g)).toHaveLength(1);
+    expect(output.indexOf("event: response.completed"))
+      .toBeGreaterThan(output.indexOf("event: response.output_item.done"));
+    expect(output.indexOf("event: response.completed"))
+      .toBeLessThan(output.indexOf("data: [DONE]"));
+  });
+
+  it("upstream ignoring include_usage still completes cleanly, usage omitted, model present", async () => {
+    const output = await runTransform(streamWithUsage({ withUsage: false }));
+    const completed = completedPayload(output);
+
+    expect(completed).not.toBeNull();
+    expect(completed.response.model).toBe(MODEL);
+    expect(completed.response.usage).toBeUndefined();
+    expect(output).toContain("data: [DONE]");
+    expect(output).not.toContain("event: response.failed");
+  });
+
+  it("upstream never sending model omits the field — no null/empty leak", async () => {
+    const output = await runTransform(streamWithUsage({ withModel: false }));
+    const completed = completedPayload(output);
+
+    expect(completed).not.toBeNull();
+    expect(completed.response.usage).toBeDefined();
+    expect(completed.response.model).toBeUndefined();
+    expect(JSON.stringify(completed.response)).not.toMatch(/"model"\s*:\s*(null|"")/);
+  });
+});


### PR DESCRIPTION
## Symptom

Every Responses-API consumer behind the proxy reads **0 tokens** on every streaming run. Two visible reports of this in the wild:

- Claude Code users see `Ctx: 0` for the whole session — reported upstream as [router-for-me/CLIProxyAPI#1700](https://github.com/router-for-me/CLIProxyAPI/issues/1700) (`/v1/messages` streaming: message_start emits `input_tokens=0`).
- Any Responses-API client (e.g. codex CLI, or anything billing on token counts) gets a `response.completed` event with **no `response.usage` and no `response.model`** — the schema-invalid chunk class reported in [router-for-me/CLIProxyAPI#1681](https://github.com/router-for-me/CLIProxyAPI/issues/1681).

Both are the same bug family on this codebase's chat-completions → Responses translation, with two root causes:

1. **No usage is requested or captured.** The request conversion never sets `stream_options.include_usage`, so most chat-completions upstreams never send token counts; and even when they do, the final `include_usage` chunk arrives with **empty `choices`**, so the `if (!chunk.choices?.length) return` guard skips it before usage can be read.
2. **Completion is emitted too early.** `response.completed` is sent the moment `finish_reason` is seen. As #1700's analysis puts it, the terminal event is emitted *before receiving upstream usage* — with `include_usage` the usage chunk lands **after** `finish_reason`, so even a captured usage would race the completion. `response.completed` is the protocol's final event; once sent, nothing can be added.

## Fix

- **Request translation** (`translator/formats/responsesApi.js`, `translator/request/openai-responses.js`): set `stream_options.include_usage = true` on streaming conversions.
- **Response translation** (`translator/response/openai-responses.js`, and mirrored on the legacy `transformer/responsesTransformer.js`): capture `usage` and `model` **before** the empty-choices guard; map the chat usage into the Responses shape (`input_tokens`, cached/reasoning details, `total_tokens`) and emit it on the synthesized `response.completed`; capture `model` on every chunk (first wins) so the completed response carries the schema-required `response.model` (#1681's other half). Completion is **deferred to stream flush** — settlement ordering fixed the way #1700 describes.
- **Translator hub** (`translator/index.js`): a null-chunk (stream flush) must cascade to the source-format flush even when the target→openai flush returns nothing (e.g. claude→openai returns null), otherwise 2-hop chains never emit their terminal event — `response.completed` was silently dropped at flush.

Both `model` and `usage` are added conditionally (omitted when the upstream never sent one), so no null/empty field can leak into the event.

## Tests

Two synthetic-stream tests drive a full chat-completions SSE sequence through both code paths:

- `tests/unit/openai-responses-translator-usage-model.test.js` — the live translator path (`translateResponse` / `openaiToOpenAIResponsesResponse`): asserts completion is deferred to flush and carries `model` + `usage`, parametrized over with/without-model and with/without-usage chunks.
- `tests/unit/openai-responses-usage-model.test.js` — the `createResponsesApiTransformStream` transformer path: same assertions via piped SSE.

All 21 tests in the usage suites pass; the full `unit` + `translator` suites show a failure set byte-identical to `master`'s (no regressions).

## Why this PR is here and not on CLIProxyAPI

The JS files this touches exist only in 9router; the Go original's analogous code lives under `internal/translator/**`, which (per the note in CLIProxyAPI #1681 / PR #1680) has a path guard blocking external PRs. Both #1700 and #1681 are also closed there without a fix, so 9router — where these exact paths live — is the contribution target. Crediting both issues for the original reports and the flush-ordering analysis.
