### PR TITLE
fix(providers): config-driven test fallback for Venice AI, 5m quota-poll cadence

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -43,6 +43,10 @@ import { ConfirmModal, EditConnectionModal } from "@/shared/components";
 import { USAGE_SUPPORTED_PROVIDERS } from "@/shared/constants/providers";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 
+// Countdown display ticks in seconds; derive from REFRESH_INTERVAL_MS so it can't
+// drift out of sync with the actual auto-refresh cadence (was hardcoded to 60).
+const REFRESH_INTERVAL_S = REFRESH_INTERVAL_MS / 1000;
+
 // Maps the stored providerSpecificData.authMethod to a human label for Kiro.
 // Values come from the Kiro connect flows: builder-id/idc (device code),
 // google/github (social), imported (refresh-token paste), api_key (headless).
@@ -135,7 +139,7 @@ export default function ProviderLimits() {
   const [lastUpdated, setLastUpdated] = useState(null);
   const [hasHydratedAutoRefresh, setHasHydratedAutoRefresh] = useState(false);
   const [refreshingAll, setRefreshingAll] = useState(false);
-  const [countdown, setCountdown] = useState(60);
+  const [countdown, setCountdown] = useState(REFRESH_INTERVAL_S);
   const [connectionsLoading, setConnectionsLoading] = useState(true);
   const [deletingId, setDeletingId] = useState(null);
   const [togglingId, setTogglingId] = useState(null);
@@ -467,7 +471,7 @@ export default function ProviderLimits() {
     if (refreshingAll) return;
 
     setRefreshingAll(true);
-    setCountdown(60);
+    setCountdown(REFRESH_INTERVAL_S);
 
     // Throttle Claude: poll its quota every Nth auto-tick (manual force bypasses)
     const tick = (tickCountRef.current += 1);
@@ -646,7 +650,7 @@ export default function ProviderLimits() {
     // Countdown interval
     countdownRef.current = setInterval(() => {
       setCountdown((prev) => {
-        if (prev <= 1) return 60;
+        if (prev <= 1) return REFRESH_INTERVAL_S;
         return prev - 1;
       });
     }, 1000);
@@ -673,7 +677,7 @@ export default function ProviderLimits() {
         // Resume auto-refresh when tab becomes visible
         intervalRef.current = setInterval(() => refreshAll(), REFRESH_INTERVAL_MS);
         countdownRef.current = setInterval(() => {
-          setCountdown((prev) => (prev <= 1 ? 60 : prev - 1));
+          setCountdown((prev) => (prev <= 1 ? REFRESH_INTERVAL_S : prev - 1));
         }, 1000);
       }
     };

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -2,7 +2,7 @@ import { getModelsByProviderId } from "open-sse/config/providerModels.js";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 export const QUOTA_CACHE_KEY = "quotaCacheData";
-export const REFRESH_INTERVAL_MS = 60000;
+export const REFRESH_INTERVAL_MS = 300000;
 // Claude usage/quota endpoint rate-limits; poll it less often than other providers
 export const CLAUDE_REFRESH_INTERVAL_MS = 600000;
 export const DEPLETED_QUOTA_THRESHOLD = 5;

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -471,7 +471,8 @@ async function fetchWithConnectionProxy(url, options = {}, effectiveProxy = null
   });
 }
 
-async function testApiKeyConnection(connection, effectiveProxy = null) {
+// Exported for unit tests.
+export async function testApiKeyConnection(connection, effectiveProxy = null) {
   if (isOpenAICompatibleProvider(connection.provider)) {
     const modelsBase = connection.providerSpecificData?.baseUrl;
     if (!modelsBase) return { valid: false, error: "Missing base URL" };

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -815,8 +815,40 @@ case "llm7": {
         }, effectiveProxy);
         return { valid: res.ok, error: res.ok ? null : "Invalid API key", refreshed: false };
       }
-      default:
+      default: {
+        // Generic config-driven fallback (mirrors /api/providers/validate's default branch)
+        // — closes the gap where a provider only declares transport.validateUrl/baseUrl in
+        // the registry but has no hand-written case here (e.g. Venice AI: "Provider test
+        // not supported" on re-test even though /api/providers/validate accepts it on add).
+        const cfg = PROVIDERS[connection.provider];
+        if (!cfg) return { valid: false, error: "Provider test not supported" };
+        if (cfg.noAuth) return { valid: true, error: null };
+
+        const headers = { "Content-Type": "application/json", ...(cfg.headers || {}) };
+        if (cfg.authHeader === "x-api-key") headers["x-api-key"] = connection.apiKey;
+        else headers["Authorization"] = `Bearer ${connection.apiKey}`;
+
+        if (cfg.validateUrl) {
+          const res = await fetchWithConnectionProxy(cfg.validateUrl, { headers }, effectiveProxy);
+          const valid = res.status !== 401 && res.status !== 403;
+          return { valid, error: valid ? null : "Invalid API key" };
+        }
+        if (cfg.format === "openai" && cfg.baseUrl) {
+          const modelsUrl = cfg.baseUrl.replace(/\/chat\/completions$/, "/models").replace(/\/chatbot$/, "/models");
+          const probeRes = await fetchWithConnectionProxy(modelsUrl, { headers }, effectiveProxy);
+          if (probeRes.status === 401 || probeRes.status === 403) return { valid: false, error: "Invalid API key" };
+          if (probeRes.ok) return { valid: true, error: null };
+          // /models absent or ambiguous — fall back to a minimal chat probe
+          const chatRes = await fetchWithConnectionProxy(cfg.baseUrl, {
+            method: "POST",
+            headers,
+            body: JSON.stringify({ model: getDefaultModel(connection.provider) || "test", messages: [{ role: "user", content: "ping" }], max_tokens: 1 }),
+          }, effectiveProxy);
+          const valid = chatRes.status !== 401 && chatRes.status !== 403;
+          return { valid, error: valid ? null : "Invalid API key" };
+        }
         return { valid: false, error: "Provider test not supported" };
+      }
     }
   } catch (err) {
     return { valid: false, error: err.message };

--- a/tests/unit/provider-limits-refresh-interval.test.js
+++ b/tests/unit/provider-limits-refresh-interval.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { REFRESH_INTERVAL_MS, CLAUDE_REFRESH_INTERVAL_MS } from "../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js";
+
+// Locks in the 60s -> 5min cadence relax (backend-load reduction ahead of
+// more providers gaining quota tracking). The dashboard's own countdown
+// display derives its reset value from REFRESH_INTERVAL_MS directly (see
+// ProviderLimits/index.js), so this constant is the single source of truth
+// for both the poll cadence and what the visible countdown counts down from.
+describe("Provider Limits refresh interval", () => {
+  it("defaults to 5 minutes, not the old 60 seconds", () => {
+    expect(REFRESH_INTERVAL_MS).toBe(300000);
+  });
+
+  it("keeps Claude's effective cadence at 10 minutes via the tick-ratio computation", () => {
+    const claudeEvery = Math.round(CLAUDE_REFRESH_INTERVAL_MS / REFRESH_INTERVAL_MS);
+    expect(claudeEvery * REFRESH_INTERVAL_MS).toBe(CLAUDE_REFRESH_INTERVAL_MS);
+    expect(CLAUDE_REFRESH_INTERVAL_MS).toBe(600000);
+  });
+});

--- a/tests/unit/provider-test-fallback.test.js
+++ b/tests/unit/provider-test-fallback.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Regression coverage for the generic config-driven fallback added to
+// testApiKeyConnection's `default` case: re-testing a saved connection for
+// any provider that isn't hand-cased in the switch (Venice AI included) used
+// to always return "Provider test not supported", even though
+// /api/providers/validate already accepted the same provider on first add
+// via PROVIDERS[id].validateUrl.
+//
+// vi.mock is hoisted above all imports regardless of source position, so it
+// applies file-wide; the mock only adds synthetic "fallback-test-*" entries
+// (spread over the real registry) used by the second describe block below —
+// the first describe block's real "venice" data passes through unchanged.
+vi.mock("open-sse/config/providers.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    PROVIDERS: {
+      ...actual.PROVIDERS,
+      "fallback-test-noauth": { noAuth: true },
+      "fallback-test-openai-models": { format: "openai", baseUrl: "https://example.test/v1/chat/completions" },
+      "fallback-test-xapikey": { validateUrl: "https://example.test/v1/models", authHeader: "x-api-key" },
+    },
+  };
+});
+
+const { testApiKeyConnection } = await import("../../src/app/api/providers/[id]/test/testUtils.js");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("testApiKeyConnection: generic validateUrl fallback (real registry data)", () => {
+  it("Venice AI: valid key against the real registry validateUrl", async () => {
+    global.fetch = vi.fn(async (url) => {
+      expect(url).toBe("https://api.venice.ai/api/v1/models");
+      return new Response("{}", { status: 200 });
+    });
+
+    const result = await testApiKeyConnection({ provider: "venice", apiKey: "test-key" }, null);
+    expect(result).toEqual({ valid: true, error: null });
+  });
+
+  it("Venice AI: invalid key (401) is reported, not 'Provider test not supported'", async () => {
+    global.fetch = vi.fn(async () => new Response("{}", { status: 401 }));
+
+    const result = await testApiKeyConnection({ provider: "venice", apiKey: "bad-key" }, null);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("Invalid API key");
+    expect(result.error).not.toBe("Provider test not supported");
+  });
+
+  it("an unknown provider with no registry entry still reports 'not supported'", async () => {
+    global.fetch = vi.fn();
+    const result = await testApiKeyConnection({ provider: "totally-made-up-provider", apiKey: "x" }, null);
+    expect(result).toEqual({ valid: false, error: "Provider test not supported" });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("testApiKeyConnection: generic fallback branches (mocked registry)", () => {
+  it("cfg.noAuth short-circuits to valid without a network call", async () => {
+    global.fetch = vi.fn();
+    const result = await testApiKeyConnection({ provider: "fallback-test-noauth", apiKey: "" }, null);
+    expect(result).toEqual({ valid: true, error: null });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a /models probe for a config-driven openai-format provider with no validateUrl", async () => {
+    global.fetch = vi.fn(async (url) => {
+      expect(url).toBe("https://example.test/v1/models");
+      return new Response("{}", { status: 200 });
+    });
+    const result = await testApiKeyConnection({ provider: "fallback-test-openai-models", apiKey: "k" }, null);
+    expect(result).toEqual({ valid: true, error: null });
+  });
+
+  it("falls back further to a chat probe when the /models probe is ambiguous (non-401/403, non-ok)", async () => {
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce(new Response("not found", { status: 404 }))
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
+    const result = await testApiKeyConnection({ provider: "fallback-test-openai-models", apiKey: "k" }, null);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(global.fetch.mock.calls[1][0]).toBe("https://example.test/v1/chat/completions");
+    expect(result).toEqual({ valid: true, error: null });
+  });
+
+  it("uses x-api-key auth header when the provider config declares it", async () => {
+    global.fetch = vi.fn(async (url, options) => {
+      expect(options.headers["x-api-key"]).toBe("k");
+      expect(options.headers["Authorization"]).toBeUndefined();
+      return new Response("{}", { status: 200 });
+    });
+    await testApiKeyConnection({ provider: "fallback-test-xapikey", apiKey: "k" }, null);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Two small, unrelated-but-adjacent provider-health fixes from #3700, bundled because they're both one-line-of-intent changes touching quota/connection testing:

1. **Venice AI: "Provider test not supported" on re-test.** `testApiKeyConnection()` in `src/app/api/providers/[id]/test/testUtils.js` re-tests an already-saved connection through a hardcoded `switch`, falling through to `default: "Provider test not supported"` for any provider without an explicit case — Venice included. `/api/providers/validate` (used when a connection is first *added*) already has a generic, config-driven fallback for exactly this situation: it walks `PROVIDERS[id].validateUrl` (declared in `open-sse/providers/registry/venice.js` as `transport.validateUrl`) and probes it directly. This PR ports that same fallback logic into `testApiKeyConnection`'s `default` case, so re-testing a saved connection and validating a new one behave consistently — for Venice, and for any future provider that only declares `validateUrl`/`baseUrl` without a hand-written case in this file.

2. **Quota-poll cadence.** `REFRESH_INTERVAL_MS` in `ProviderLimits/utils.js` defaulted to 60s, auto-polling every connected provider's quota endpoint every minute. Bumped to 5 minutes to reduce backend load, especially as more providers gain quota tracking (see #3701). Claude's poll interval is computed as a tick-ratio of this constant (`claudeEvery = CLAUDE_REFRESH_INTERVAL_MS / REFRESH_INTERVAL_MS`), so its effective 10-minute cadence is unchanged by this bump.

   While making that change I found the countdown-timer display (`ProviderLimits/index.js`) was hardcoded to reset at `60` (seconds), independent of `REFRESH_INTERVAL_MS`. Left as-is, the visible countdown would have silently desynced from the real refresh cadence the moment the interval changed. Derived it from the same constant (`REFRESH_INTERVAL_S = REFRESH_INTERVAL_MS / 1000`) instead, at all 4 call sites.

## Why

Filed and explained in more detail in #3700.

## Validation

- `node --check` passes on all three changed files (Dockerized `node:22-alpine`, no host Node install used).
- Reviewed all other `REFRESH_INTERVAL_MS` usages (`ProviderTopology.js`'s `FE_ACTIVE_TICK_MS`, etc.) — no other hardcoded assumptions about the old 60s value found.
- Did not touch any of the ~40 already-cased providers in `testApiKeyConnection`'s switch — the new fallback only activates in the pre-existing `default` branch, so behavior for every provider with an explicit case is unchanged.

## Test plan

- [ ] Re-test a saved Venice AI connection from the Providers page and confirm it now validates instead of returning "Provider test not supported".
- [ ] Confirm the Provider Limits panel auto-refreshes every 5 minutes and the visible countdown counts down from 300s (not 60s) before looping.
- [ ] `cd tests && npx vitest run` — no new failures introduced (this PR doesn't touch anything in the existing 26-entry `known-fails.txt`).

Fixes #3700 (partial — Gemini CLI UI treatment and stale-model demotion remain open there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
