### PR TITLE
test(combo): add coverage for account-selection fallback loop

### DIFF
--- a/tests/unit/account-fallback-rules.test.js
+++ b/tests/unit/account-fallback-rules.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+
+import { checkFallbackError, getQuotaCooldown } from "../../open-sse/services/accountFallback.js";
+
+// checkFallbackError is the single decision point both the per-account loop
+// (src/sse/handlers/chat.js) and the per-combo-candidate loop (open-sse/services/combo.js)
+// call to decide "try the next account/model" vs "stop and surface this error".
+describe("checkFallbackError decision matrix", () => {
+  it("429 with no matching text triggers status-based backoff, escalating per attempt", () => {
+    const first = checkFallbackError(429, "Too Many Requests", 0);
+    expect(first).toEqual({ shouldFallback: true, cooldownMs: getQuotaCooldown(1), newBackoffLevel: 1 });
+
+    const second = checkFallbackError(429, "Too Many Requests", first.newBackoffLevel);
+    expect(second).toEqual({ shouldFallback: true, cooldownMs: getQuotaCooldown(2), newBackoffLevel: 2 });
+    expect(second.cooldownMs).toBeGreaterThan(first.cooldownMs);
+  });
+
+  it("text-based rate-limit phrasing triggers backoff even when the status code doesn't match (e.g. 200 wrapping an error body)", () => {
+    const r = checkFallbackError(200, "Rate limit exceeded, please retry later", 0);
+    expect(r.shouldFallback).toBe(true);
+    expect(r.newBackoffLevel).toBe(1);
+  });
+
+  it("text rules are matched before status rules (order = priority)", () => {
+    // 401 alone would hit the status-based long cooldown; "quota exceeded" text should win first.
+    const r = checkFallbackError(401, "quota exceeded for this key", 0);
+    expect(r.shouldFallback).toBe(true);
+    expect(r.newBackoffLevel).toBe(1); // backoff path, not the fixed long-cooldown 401 path
+  });
+
+  it("401/402/403/404 use a fixed long cooldown, not exponential backoff", () => {
+    for (const status of [401, 402, 403, 404]) {
+      const r = checkFallbackError(status, "some upstream message", 3);
+      expect(r.shouldFallback).toBe(true);
+      expect(r.newBackoffLevel).toBeUndefined();
+      expect(r.cooldownMs).toBe(2 * 60 * 1000);
+    }
+  });
+
+  it("falls back to a 30s transient cooldown for unclassified 5xx errors", () => {
+    for (const status of [500, 502, 503, 504]) {
+      const r = checkFallbackError(status, "upstream had a bad day", 0);
+      expect(r).toEqual({ shouldFallback: true, cooldownMs: 30 * 1000 });
+    }
+  });
+
+  // Documents current behavior rather than asserting a requirement: there is no rule
+  // anywhere in this file that ever returns shouldFallback:false. A malformed-request
+  // 400 (a client-side bug that will reproduce identically on every other account/model)
+  // is classified exactly like a transient 503. See PR description "Findings for
+  // maintainer triage" — this is flagged, not fixed, per this PR's test-only scope.
+  it("a definitively non-retryable 400 (malformed request) is currently classified the same as a transient error", () => {
+    const malformed = checkFallbackError(400, "Invalid schema: 'tool_choice' is not supported for this model", 0);
+    const transient503 = checkFallbackError(503, "upstream had a bad day", 0);
+    expect(malformed.shouldFallback).toBe(true);
+    expect(malformed.cooldownMs).toBe(transient503.cooldownMs);
+  });
+
+  it("never returns shouldFallback:false for any status/text combination it classifies", () => {
+    const samples = [
+      [400, "bad request"], [401, "unauthorized"], [402, "payment required"],
+      [403, "forbidden"], [404, "not found"], [429, "too many requests"],
+      [500, "server error"], [503, "unavailable"], [200, "quota exceeded"],
+    ];
+    for (const [status, text] of samples) {
+      expect(checkFallbackError(status, text, 0).shouldFallback).toBe(true);
+    }
+  });
+
+  it("backoff level is capped at BACKOFF_CONFIG.maxLevel (15)", () => {
+    const r = checkFallbackError(429, "rate limit", 999);
+    expect(r.newBackoffLevel).toBe(15);
+  });
+
+  it("getQuotaCooldown is capped at the configured max (5 minutes)", () => {
+    expect(getQuotaCooldown(20)).toBe(5 * 60 * 1000);
+  });
+});

--- a/tests/unit/chat-account-selection-loop.test.js
+++ b/tests/unit/chat-account-selection-loop.test.js
@@ -1,0 +1,286 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Coverage for the account-selection / combo-fallback loop described in
+// CLAUDE.md as "the thing to understand first": src/sse/handlers/chat.js
+// drives (a) a per-model account retry loop and (b) recurses into itself once
+// per combo candidate via open-sse/services/combo.js's handleComboChat. This
+// file exercises both loops together with mocked credentials/handleChatCore,
+// no live provider calls.
+//
+// open-sse/services/combo.js is intentionally left un-mocked: it's the real
+// candidate-iteration logic under test (part of #3702's priority #1 slice).
+
+const mocks = vi.hoisted(() => ({
+  getProviderCredentials: vi.fn(),
+  markAccountUnavailable: vi.fn(),
+  clearAccountError: vi.fn(),
+  extractApiKey: vi.fn(() => null),
+  isValidApiKey: vi.fn(),
+  getSettings: vi.fn(),
+  getModelInfo: vi.fn(),
+  getComboModels: vi.fn(),
+  handleChatCore: vi.fn(),
+  checkAndRefreshToken: vi.fn(),
+  updateProviderCredentials: vi.fn(),
+  handleAntigravityQuotaError: vi.fn(),
+}));
+
+vi.mock("@/sse/services/auth.js", () => ({
+  getProviderCredentials: mocks.getProviderCredentials,
+  markAccountUnavailable: mocks.markAccountUnavailable,
+  clearAccountError: mocks.clearAccountError,
+  extractApiKey: mocks.extractApiKey,
+  isValidApiKey: mocks.isValidApiKey,
+}));
+
+vi.mock("@/sse/services/antigravityQuota.js", () => ({
+  handleAntigravityQuotaError: mocks.handleAntigravityQuotaError,
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getSettings: mocks.getSettings,
+}));
+
+vi.mock("@/sse/services/model.js", () => ({
+  getModelInfo: mocks.getModelInfo,
+  getComboModels: mocks.getComboModels,
+}));
+
+vi.mock("open-sse/handlers/chatCore.js", () => ({
+  handleChatCore: mocks.handleChatCore,
+}));
+
+vi.mock("@/sse/services/tokenRefresh.js", () => ({
+  checkAndRefreshToken: mocks.checkAndRefreshToken,
+  updateProviderCredentials: mocks.updateProviderCredentials,
+}));
+
+vi.mock("@/sse/utils/logger.js", () => ({
+  info: vi.fn(),
+  debug: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  maskKey: vi.fn(() => "masked"),
+}));
+
+const { handleChat } = await import("../../src/sse/handlers/chat.js");
+
+function chatRequest(body, headers = {}) {
+  return new Request("http://localhost/v1/chat/completions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// getModelInfo in real code resolves aliases via the DB; here every candidate
+// is already "provider/model" shaped so a plain split reproduces its output.
+function parseAsModelInfo(modelStr) {
+  const [provider, model] = modelStr.split("/");
+  return { provider, model };
+}
+
+describe("chat.js account-selection loop (single model)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSettings.mockResolvedValue({});
+    mocks.getModelInfo.mockImplementation(async (m) => parseAsModelInfo(m));
+    mocks.getComboModels.mockResolvedValue(null);
+    mocks.checkAndRefreshToken.mockImplementation(async (_provider, creds) => creds);
+  });
+
+  it("falls back to the next account on a retryable failure and returns the second account's success", async () => {
+    const credA = { connectionId: "conn-a", connectionName: "Acct A", accessToken: "tok-a" };
+    const credB = { connectionId: "conn-b", connectionName: "Acct B", accessToken: "tok-b" };
+    mocks.getProviderCredentials
+      .mockResolvedValueOnce(credA)
+      .mockResolvedValueOnce(credB);
+    mocks.markAccountUnavailable.mockResolvedValueOnce({ shouldFallback: true, cooldownMs: 30000 });
+    mocks.handleChatCore
+      .mockResolvedValueOnce({ success: false, status: 500, error: "upstream boom", response: jsonResponse({ error: { message: "upstream boom" } }, 500) })
+      .mockImplementationOnce(async (params) => {
+        await params.onRequestSuccess();
+        return { success: true, response: jsonResponse({ choices: [{ message: { content: "hi" } }] }) };
+      });
+
+    const res = await handleChat(chatRequest({ model: "openai/gpt-4o", messages: [{ role: "user", content: "hi" }] }));
+
+    expect(res.status).toBe(200);
+    expect(mocks.handleChatCore).toHaveBeenCalledTimes(2);
+    expect(mocks.getProviderCredentials).toHaveBeenCalledTimes(2);
+
+    // Second attempt excludes the first (failed) connection.
+    const secondCallExcludeSet = mocks.getProviderCredentials.mock.calls[1][1];
+    expect(secondCallExcludeSet.has("conn-a")).toBe(true);
+
+    expect(mocks.markAccountUnavailable).toHaveBeenCalledWith("conn-a", 500, "upstream boom", "openai", "gpt-4o", undefined);
+    // onRequestSuccess clears the account that actually served the response (B), not A.
+    expect(mocks.clearAccountError).toHaveBeenCalledWith("conn-b", expect.objectContaining({ connectionId: "conn-b" }), "gpt-4o");
+  });
+
+  it("stops immediately without trying another account when the fallback decision says not to", async () => {
+    const credA = { connectionId: "conn-a", connectionName: "Acct A" };
+    mocks.getProviderCredentials.mockResolvedValueOnce(credA);
+    mocks.markAccountUnavailable.mockResolvedValueOnce({ shouldFallback: false, cooldownMs: 0 });
+    const failureResponse = jsonResponse({ error: { message: "malformed request" } }, 400);
+    mocks.handleChatCore.mockResolvedValueOnce({ success: false, status: 400, error: "malformed request", response: failureResponse });
+
+    const res = await handleChat(chatRequest({ model: "openai/gpt-4o", messages: [{ role: "user", content: "hi" }] }));
+
+    expect(res).toBe(failureResponse);
+    expect(mocks.handleChatCore).toHaveBeenCalledTimes(1);
+    expect(mocks.getProviderCredentials).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces an unavailableResponse once every account is rate-limited, using the last observed error/status", async () => {
+    const credA = { connectionId: "conn-a", connectionName: "Acct A" };
+    mocks.getProviderCredentials
+      .mockResolvedValueOnce(credA)
+      .mockResolvedValueOnce({
+        allRateLimited: true,
+        retryAfter: new Date(Date.now() + 45000).toISOString(),
+        retryAfterHuman: "reset after 45s",
+        lastError: "stale error from DB",
+        lastErrorCode: 999,
+      });
+    mocks.markAccountUnavailable.mockResolvedValueOnce({ shouldFallback: true, cooldownMs: 30000 });
+    mocks.handleChatCore.mockResolvedValueOnce({
+      success: false, status: 429, error: "rate limited",
+      response: jsonResponse({ error: { message: "rate limited" } }, 429),
+    });
+
+    const res = await handleChat(chatRequest({ model: "openai/gpt-4o", messages: [{ role: "user", content: "hi" }] }));
+    const body = await res.json();
+
+    // Uses the loop's own lastStatus/lastError (429/"rate limited") in preference
+    // to the stale values on the allRateLimited sentinel.
+    expect(res.status).toBe(429);
+    expect(body.error.message).toContain("rate limited");
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  it("returns 404 immediately when the provider has no credentials configured at all", async () => {
+    mocks.getProviderCredentials.mockResolvedValueOnce(null);
+
+    const res = await handleChat(chatRequest({ model: "openai/gpt-4o", messages: [{ role: "user", content: "hi" }] }));
+
+    expect(res.status).toBe(404);
+    expect(mocks.handleChatCore).not.toHaveBeenCalled();
+  });
+
+  it("dispatches to chatCore with the refreshed credentials, not the pre-refresh ones", async () => {
+    const stale = { connectionId: "conn-a", accessToken: "stale-token" };
+    const refreshed = { connectionId: "conn-a", accessToken: "fresh-token" };
+    mocks.getProviderCredentials.mockResolvedValueOnce(stale);
+    mocks.checkAndRefreshToken.mockResolvedValueOnce(refreshed);
+    mocks.handleChatCore.mockResolvedValueOnce({ success: true, response: jsonResponse({ ok: true }) });
+
+    await handleChat(chatRequest({ model: "openai/gpt-4o", messages: [{ role: "user", content: "hi" }] }));
+
+    const dispatchedCredentials = mocks.handleChatCore.mock.calls[0][0].credentials;
+    expect(dispatchedCredentials.accessToken).toBe("fresh-token");
+  });
+
+  it("wires chatCore's onCredentialsRefreshed callback to persist the new token against the ORIGINAL connection", async () => {
+    const original = { connectionId: "conn-a", accessToken: "old", providerSpecificData: { foo: "bar" } };
+    mocks.getProviderCredentials.mockResolvedValueOnce(original);
+    mocks.handleChatCore.mockImplementationOnce(async (params) => {
+      await params.onCredentialsRefreshed({ accessToken: "rotated" });
+      return { success: true, response: jsonResponse({ ok: true }) };
+    });
+
+    await handleChat(chatRequest({ model: "openai/gpt-4o", messages: [{ role: "user", content: "hi" }] }));
+
+    expect(mocks.updateProviderCredentials).toHaveBeenCalledWith("conn-a", {
+      accessToken: "rotated",
+      existingProviderSpecificData: { foo: "bar" },
+      testStatus: "active",
+    });
+  });
+});
+
+describe("chat.js combo fallback (multiple candidates, real open-sse/services/combo.js)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSettings.mockResolvedValue({});
+    mocks.getModelInfo.mockImplementation(async (m) => parseAsModelInfo(m));
+    mocks.checkAndRefreshToken.mockImplementation(async (_provider, creds) => creds);
+  });
+
+  it("rolls to the next combo candidate once the first candidate exhausts its own accounts (regression class for #3619)", async () => {
+    mocks.getComboModels.mockImplementation(async (m) => (m === "mixed-combo" ? ["vxp/model-a", "openrouter/model-b"] : null));
+
+    mocks.getProviderCredentials
+      .mockResolvedValueOnce({ connectionId: "conn-vxp", connectionName: "VXP" }) // vxp attempt 1
+      .mockResolvedValueOnce(null)                                                // vxp: no more accounts
+      .mockResolvedValueOnce({ connectionId: "conn-or", connectionName: "OpenRouter" }); // openrouter attempt 1
+
+    mocks.markAccountUnavailable.mockResolvedValueOnce({ shouldFallback: true, cooldownMs: 30000 });
+
+    mocks.handleChatCore
+      .mockResolvedValueOnce({
+        success: false, status: 429, error: "rate limit exceeded",
+        response: jsonResponse({ error: { message: "rate limit exceeded" } }, 429),
+      })
+      .mockResolvedValueOnce({ success: true, response: jsonResponse({ choices: [{ message: { content: "answer" } }] }) });
+
+    const res = await handleChat(chatRequest({ model: "mixed-combo", messages: [{ role: "user", content: "hi" }] }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.choices[0].message.content).toBe("answer");
+    expect(mocks.handleChatCore).toHaveBeenCalledTimes(2);
+    expect(mocks.getModelInfo).toHaveBeenCalledWith("vxp/model-a");
+    expect(mocks.getModelInfo).toHaveBeenCalledWith("openrouter/model-b");
+    expect(mocks.markAccountUnavailable).toHaveBeenCalledWith("conn-vxp", 429, "rate limit exceeded", "vxp", "model-a", undefined);
+  });
+
+  it("returns a well-formed terminal error (never empty/hangs) when every combo candidate exhausts its accounts", async () => {
+    mocks.getComboModels.mockImplementation(async (m) => (m === "mixed-combo" ? ["vxp/model-a", "openrouter/model-b"] : null));
+
+    mocks.getProviderCredentials
+      .mockResolvedValueOnce({ connectionId: "conn-vxp" })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ connectionId: "conn-or" })
+      .mockResolvedValueOnce(null);
+
+    mocks.markAccountUnavailable
+      .mockResolvedValueOnce({ shouldFallback: true, cooldownMs: 30000 })
+      .mockResolvedValueOnce({ shouldFallback: true, cooldownMs: 30000 });
+
+    mocks.handleChatCore
+      .mockResolvedValueOnce({
+        success: false, status: 500, error: "vxp translation error",
+        response: jsonResponse({ error: { message: "vxp translation error" } }, 500),
+      })
+      .mockResolvedValueOnce({
+        // Deliberately avoids any ERROR_RULES text match (e.g. "overloaded", "rate limit")
+        // so this stays on the default-transient (30s, no-wait) path — a message like
+        // "...overloaded" would hit combo.js's short-cooldown retry-with-wait branch and
+        // add a real multi-second sleep to this test.
+        success: false, status: 503, error: "openrouter had a bad response",
+        response: jsonResponse({ error: { message: "openrouter had a bad response" } }, 503),
+      });
+
+    const res = await handleChat(chatRequest({ model: "mixed-combo", messages: [{ role: "user", content: "hi" }] }));
+    const body = await res.json();
+
+    // Every candidate failed, but the client still gets a real status + a non-empty
+    // JSON error body — this is the contract a client like VS Code Copilot needs to
+    // render an actual message instead of "Sorry, no response was returned" (#3619).
+    expect(res.ok).toBe(false);
+    expect(typeof res.status).toBe("number");
+    expect(body.error.message).toBeTruthy();
+    // Terminal status reflects the FIRST candidate's failure status, not the last —
+    // current (documented, not asserted-as-ideal) behavior of open-sse/services/combo.js.
+    expect(res.status).toBe(500);
+    expect(body.error.message).toBe("openrouter had a bad response");
+  });
+});


### PR DESCRIPTION
## Summary

Part of #3702 — this is the first slice: real, focused test coverage for the **combo/account-selection fallback loop** (priority #1 in that issue). The translator direct-route and provider-registry-baseline priorities are separate fast-follow scope and are not touched here.

This is test-only. No runtime code is changed.

- `tests/unit/account-fallback-rules.test.js` — locks in the decision matrix of `checkFallbackError` (`open-sse/services/accountFallback.js`), the single function both the per-account loop and the per-combo-candidate loop call to decide "try the next account/model" vs. "stop here": status-based rules (401/402/403/404 fixed cooldown, 429 exponential backoff), text-based rules taking priority over status rules, the 30s default for unclassified 5xx, and backoff-level capping.
- `tests/unit/chat-account-selection-loop.test.js` — drives the real `handleChat` (`src/sse/handlers/chat.js`) with mocked credentials/`handleChatCore`/upstream responses (no live provider calls), covering:
  - per-account fallback on a retryable failure, including that the *excluded* connection set grows correctly and `clearAccountError` fires for the account that actually served the response;
  - the loop honoring `shouldFallback: false` by stopping immediately instead of trying another account;
  - the terminal `allRateLimited` path (`unavailableResponse` with `Retry-After`);
  - the "no credentials configured at all" 404 path;
  - that `handleChatCore` is dispatched with the **refreshed** credentials, and that its `onCredentialsRefreshed` callback persists against the *original* connection's `providerSpecificData`;
  - combo-candidate rollover once a candidate's own accounts are exhausted (real `open-sse/services/combo.js`, not mocked) — modeled directly on the mixed VXP/OpenRouter/AG failure pattern in #3619;
  - the full-exhaustion terminal case: every combo candidate fails, and the loop still returns a well-formed, non-empty JSON error with a real status code — the contract a client needs to render an actual message instead of the opaque "Sorry, no response was returned" symptom reported in #3619.

## Why this scope

`chat.js`'s account-selection loop + its recursion into `handleComboChat` is called out in this repo's `CLAUDE.md` as "the thing to understand first," but had no direct test coverage — the existing `combo-*.test.js` files cover round-robin rotation, capability-based reordering, and fusion, and one other test (`gemini-native-endpoint.test.js`) mocks `handleChat` itself rather than exercising its internals. `checkFallbackError` (the shared retry/fallback classifier) had no dedicated tests at all. This PR fills exactly that gap without touching the translator or provider-registry priorities from #3702.

## Findings for maintainer triage (not fixed here, by design)

Per this PR's test-only scope, these are flagged for you to decide on rather than fixed:

1. **No distinction between a retryable and a non-retryable upstream error.** `checkFallbackError` (`open-sse/services/accountFallback.js`) has no rule that ever returns `shouldFallback: false` for an error it classifies — a 400 "malformed request" (e.g. a translator bug producing an invalid payload, which will fail identically on every other account *and* every other combo candidate) is bucketed into the same 30s "transient" default as an unclassified 5xx. `tests/unit/account-fallback-rules.test.js` documents this as current behavior. This is directly relevant to #3619's failure class: a bad request to one candidate cascades through every account and every other combo model before surfacing a generic terminal error, rather than failing fast with a message that points at the real (translation) bug.
2. **Terminal combo status is the *first* failing candidate's status, not the last.** When every combo candidate fails, `handleComboChat`'s `lastStatus` is set only once (`if (!lastStatus) lastStatus = result.status`) and never updated afterward, so the status code returned to the client reflects whichever candidate failed first, not necessarily the most recent or most representative failure. Covered/asserted as current behavior in the new "full-exhaustion" test rather than changed.

Neither of these is a crash or a silent failure — they're both classification/reporting nuances worth a deliberate decision rather than an incidental fix bundled into a test PR.

## Test plan

- [x] `node --check` on both new test files — syntax verified clean.
- [x] Every assertion was hand-traced against the actual current source (`src/sse/handlers/chat.js`, `open-sse/services/combo.js`, `open-sse/services/accountFallback.js`) line-by-line, including exact call counts, argument shapes, and which `ERROR_RULES` entry each mocked error message/status would hit.
- [ ] **Not yet run against a live `vitest` install.** Three separate `docker run … npm install` attempts (root deps, then `tests/` deps, per this repo's Docker-first tooling convention) each stalled for 10+ minutes without completing in this sandbox, most likely due to contention from other concurrent containers on the same host rather than anything specific to this change. A local host run was also attempted as a fallback and hit a pre-existing, unrelated problem: the checked-out `tests/node_modules` has a platform-mismatched optional native binding for `@rolldown/binding-*` (vitest 4's bundler), which is a known npm optional-deps issue (https://github.com/npm/cli/issues/4828) and reproduces even for the pre-existing test suite, not just these new files.
- [ ] Given the above, **please run `cd tests && npx vitest run unit/account-fallback-rules.test.js unit/chat-account-selection-loop.test.js` (or let CI run the full suite) before merging** to confirm these pass for real. Happy to fix anything that surfaces — flagging this explicitly rather than claiming a green run I couldn't actually produce.
- [ ] Full `tests/` suite baseline comparison via `tests/__baseline__/verify-no-regression.mjs` once the above confirms — not expected to be affected, since no runtime files are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)