### PR TITLE
fix: return 503 for rate-limited providers + bundle node-machine-id in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ COPY --from=builder /app/node_modules/next ./node_modules/next
 # sql.js loads dist/sql-wasm.wasm by path at runtime; tracing only follows JS imports,
 # so the last-resort DB driver would abort with ENOENT on the missing binary.
 COPY --from=builder /app/node_modules/sql.js ./node_modules/sql.js
+# node-machine-id is createRequire-loaded at runtime; tracing omits it.
+COPY --from=builder /app/node_modules/node-machine-id ./node_modules/node-machine-id
 
 RUN mkdir -p /app/data && chown -R node:node /app && \
   mkdir -p /app/data-home && chown node:node /app/data-home && \

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -232,7 +232,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     if (!credentials || credentials.allRateLimited) {
       if (credentials?.allRateLimited) {
         const errorMsg = lastError || credentials.lastError || "Unavailable";
-        const status = lastStatus || Number(credentials.lastErrorCode) || HTTP_STATUS.SERVICE_UNAVAILABLE;
+        const status = HTTP_STATUS.SERVICE_UNAVAILABLE;
         log.warn("CHAT", `[${provider}/${model}] ${errorMsg} (${credentials.retryAfterHuman})`);
         return unavailableResponse(status, `[${provider}/${model}] ${errorMsg}`, credentials.retryAfter, credentials.retryAfterHuman);
       }


### PR DESCRIPTION
## Summary
- chat handler: allRateLimited accounts no longer echo stale errorCode from DB (500) — always return 503 Service Unavailable
- Dockerfile: explicit COPY node-machine-id (createRequire runtime load missed by Next.js standalone tracing)

## Why
Dashboard `/api/models/test` ping was returning HTTP 500 from a stale `errorCode` stored in DB instead of the correct 503 status. Separately, `node-machine-id` was missing in the standalone Docker image, breaking runtime token-refresh and CLI-token paths.

## Testing
- Manual ping path verified root cause (500 → 503 semantic fix)
- chat.js syntax checked via `node --check`
- Dockerfile COPY syntax verified

## Risks / Limitations
Minimal; status-code semantic change only — callers relying on exact status code will now see 503 instead of a stale 500.

## Update
This PR contains two fixes, both validated in production:
1. **Dockerfile** — bundles the missing `node-machine-id` module (its absence caused systemic `HTTP 500` crashes in the standalone image).
2. **chat.js** — returns `503` for genuinely rate-limited providers instead of echoing a stale `500` status.