### PR TITLE
fix(antigravity): clean empty parts and merge adjacent turns to prevent 400 INVALID_ARGUMENT

### DIFF
--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -188,35 +188,49 @@ export class AntigravityExecutor extends BaseExecutor {
     }
 
     // ─── Standard (non-image) request ───
-    // Fix contents for Claude models via Antigravity
-    const contents = body.request?.contents?.map(c => {
+    const rawContents = body.request?.contents || [];
+    const cleanedContents = [];
+
+    for (const c of rawContents) {
       let role = c.role;
-      // functionResponse must be role "user" for Claude models
       if (c.parts?.some(p => p.functionResponse)) {
         role = "user";
       }
-      // Strip thought-only parts, keep thoughtSignature on functionCall parts (Gemini 3+ requires it)
-      const parts = c.parts?.filter(p => {
-        if (p.thought && !p.functionCall) return false;
-        if (p.thoughtSignature && !p.functionCall && !p.text) return false;
-        return true;
-      });
-      // Gemini 3+ rejects functionCall parts without thoughtSignature. Clients (Claude Code, IDE)
-      // don't persist thoughtSignature in their history, so backfill the default signature on any
-      // functionCall part that arrives without one.
-      const needsBackfill = parts?.some(p => p.functionCall && !p.thoughtSignature) ?? false;
-      if (role !== c.role || parts?.length !== c.parts?.length || needsBackfill) {
-        return {
-          ...c, role,
-          parts: needsBackfill
-            ? parts.map(p => (p.functionCall && !p.thoughtSignature)
-                ? { ...p, thoughtSignature: DEFAULT_THINKING_AG_SIGNATURE }
-                : p)
-            : parts,
-        };
+
+      const validParts = (c.parts || [])
+        .filter(p => {
+          if (p.thought && !p.functionCall) return false;
+          if (p.thoughtSignature && !p.functionCall && (!p.text || p.text === "")) return false;
+          if (p.text === "") return false;
+          return true;
+        })
+        .map(p => {
+          if (p.functionCall && !p.thoughtSignature) {
+            return { ...p, thoughtSignature: DEFAULT_THINKING_AG_SIGNATURE };
+          }
+          return p;
+        });
+
+      if (validParts.length > 0) {
+        cleanedContents.push({ role, parts: validParts });
       }
-      return c;
-    });
+    }
+
+    const mergedContents = [];
+    for (const turn of cleanedContents) {
+      const last = mergedContents.at(-1);
+      if (last && last.role === turn.role) {
+        last.parts.push(...turn.parts);
+      } else {
+        mergedContents.push({ ...turn, parts: [...turn.parts] });
+      }
+    }
+
+    if (mergedContents.length === 0) {
+      mergedContents.push({ role: "user", parts: [{ text: "..." }] });
+    }
+
+    const contents = mergedContents;
 
     // Sanitize tool schemas and function names before sending to Antigravity.
     let tools = body.request?.tools;

--- a/open-sse/translator/formats/gemini.js
+++ b/open-sse/translator/formats/gemini.js
@@ -47,10 +47,12 @@ export function convertOpenAIContentToParts(content) {
   const parts = [];
 
   if (typeof content === "string") {
-    parts.push({ text: content });
+    if (content.trim() !== "") {
+      parts.push({ text: content });
+    }
   } else if (Array.isArray(content)) {
     for (const item of content) {
-      if (item.type === OPENAI_BLOCK.TEXT) {
+      if (item.type === OPENAI_BLOCK.TEXT && item.text && item.text.trim() !== "") {
         parts.push({ text: item.text });
       } else if (item.type === OPENAI_BLOCK.IMAGE_URL && item.image_url?.url?.startsWith("data:")) {
         const url = item.image_url.url;

--- a/open-sse/translator/request/openai-to-claude.js
+++ b/open-sse/translator/request/openai-to-claude.js
@@ -1,6 +1,7 @@
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
 import { CLAUDE_SYSTEM_PROMPT } from "../../config/appConstants.js";
+import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../../config/defaultThinkingSignature.js";
 import { adjustMaxTokens } from "../formats/maxTokens.js";
 import { safeParseJSON } from "../concerns/json.js";
 import { parseDataUri } from "../concerns/image.js";
@@ -253,6 +254,13 @@ function getContentBlocksFromMessage(msg, toolNameMap = new Map()) {
       }
     }
   } else if (msg.role === ROLE.ASSISTANT) {
+    if (msg.reasoning_content) {
+      blocks.push({
+        type: CLAUDE_BLOCK.THINKING,
+        thinking: msg.reasoning_content,
+        signature: DEFAULT_THINKING_CLAUDE_SIGNATURE
+      });
+    }
     if (Array.isArray(msg.content)) {
       for (const part of msg.content) {
         if (part.type === OPENAI_BLOCK.TEXT && part.text) {

--- a/open-sse/translator/request/openai-to-gemini.js
+++ b/open-sse/translator/request/openai-to-gemini.js
@@ -126,7 +126,7 @@ function openaiToGeminiBase(model, body, stream, signature = DEFAULT_THINKING_AG
 
         if (content) {
           const text = typeof content === "string" ? content : extractTextContent(content);
-          if (text) {
+          if (text && text.trim() !== "") {
             parts.push({ text });
           }
         }

--- a/tests/translator/bugs-antigravity.test.js
+++ b/tests/translator/bugs-antigravity.test.js
@@ -136,4 +136,62 @@ describe("Antigravity executor", () => {
     expect(system).not.toContain(ANTIGRAVITY_DEFAULT_SYSTEM);
     expect(system).not.toContain("Please ignore the following [ignore]");
   });
+
+  it("handles multi-turn with reasoning-only assistant turn without emitting empty parts or invalid contents", () => {
+    const geminiReq = openaiToAntigravityRequest("gemini-3.7-flash-high", {
+      messages: [
+        { role: "user", content: "Step 1" },
+        { role: "assistant", reasoning_content: "I am thinking about step 1...", content: "" },
+        { role: "user", content: "Continue" },
+      ],
+    }, true, { projectId: "project-1", connectionId: "conn-1" });
+
+    const out = new AntigravityExecutor().transformRequest("gemini-3.7-flash-high", geminiReq, true, { projectId: "project-1", connectionId: "conn-1" });
+
+    const contents = out.request.contents;
+    expect(Array.isArray(contents)).toBe(true);
+    expect(contents.length).toBeGreaterThan(0);
+
+    for (const turn of contents) {
+      expect(Array.isArray(turn.parts)).toBe(true);
+      expect(turn.parts.length, `Found empty parts array in turn with role ${turn.role}`).toBeGreaterThan(0);
+      for (const part of turn.parts) {
+        if ("text" in part) {
+          expect(part.text, "Found empty text in part").not.toBe("");
+        }
+      }
+    }
+
+    for (let i = 0; i < contents.length - 1; i++) {
+      expect(contents[i].role, `Consecutive duplicate role at index ${i}`).not.toBe(contents[i + 1].role);
+    }
+  });
+
+  it("handles multi-turn tool call sequence without emitting empty parts or adjacent duplicate roles", () => {
+    const geminiReq = openaiToAntigravityRequest("gemini-3.7-flash-high", {
+      messages: [
+        { role: "user", content: "Calculate" },
+        {
+          role: "assistant",
+          reasoning_content: "Calling tool",
+          tool_calls: [{ id: "call_1", type: "function", function: { name: "calc", arguments: "{}" } }],
+        },
+        { role: "tool", tool_call_id: "call_1", content: '{"result": 42}' },
+        { role: "user", content: "Great, now continue" },
+      ],
+    }, true, { projectId: "project-1", connectionId: "conn-1" });
+
+    const out = new AntigravityExecutor().transformRequest("gemini-3.7-flash-high", geminiReq, true, { projectId: "project-1", connectionId: "conn-1" });
+
+    const contents = out.request.contents;
+    expect(contents.length).toBeGreaterThan(0);
+
+    for (const turn of contents) {
+      expect(turn.parts.length, `Empty parts in ${turn.role} turn`).toBeGreaterThan(0);
+    }
+
+    for (let i = 0; i < contents.length - 1; i++) {
+      expect(contents[i].role, `Consecutive duplicate role at index ${i}`).not.toBe(contents[i + 1].role);
+    }
+  });
 });


### PR DESCRIPTION
### Problem
When converting multi-turn conversations (especially conversations with reasoning/thinking turns or tool response sequences) to Google Antigravity format:
1. Thought-only and thoughtSignature parts are stripped during `transformRequest`. If an assistant message contained only `reasoning_content` or empty text, its `parts` became empty (`parts: []`).
2. Google Antigravity / Gemini API rejects payloads containing any content with `parts: []` or `text: ""` with `400 Request contains an invalid argument: INVALID_ARGUMENT`.
3. Converting `functionResponse` parts into `user` role resulted in consecutive `user` turns that were not merged before sending to Antigravity.

### Solution
1. In `open-sse/executors/antigravity.js`: Filter out empty text parts and empty turns after thought stripping, then normalize and merge consecutive turns with the same role. Ensure `contents` is never empty.
2. In `open-sse/translator/formats/gemini.js` & `open-sse/translator/request/openai-to-gemini.js`: Prevent empty string text parts from being created.
3. In `open-sse/translator/request/openai-to-claude.js`: Preserve assistant `reasoning_content` as Claude thinking block.
4. Added regression unit tests in `tests/translator/bugs-antigravity.test.js` covering multi-turn reasoning-only assistant turns and tool sequences.

## Real-world verification (OpenCode against a patched instance)

Tested end-to-end by running a **separate, patched 9router instance on port 20129** (independent from the default running instance on 20128, driven by the client actually used in production: **OpenCode**).

A dedicated OpenCode process was pointed at the patched instance's `/v1` endpoint via the `lightweight` model (which routes to `ag/gemini-3.7-flash-high` — the exact model/combo that produced the original `400 invalid argument`).

1. **Reasoning-only assistant turn** — multi-turn request with `reasoning_content` + empty `content` assistant message → returned 200 OK streaming response with `reasoning_content` + `content` deltas. **No 400.**
2. **Combo `lightweight` model** — routed to `ag/gemini-3.7-flash-high`, multi-turn with reasoning → 200 OK. **No 400.**
3. **Tool call sequence** — assistant `reasoning_content` + `tool_calls`, then `tool` response, then user follow-up → 200 OK. **No 400.**
4. **Real agentic OpenCode session** — `opencode run --agent build` against the patched instance on `lightweight`, executing actual `bash` and `read` tool calls over a **continued multi-turn session** (2+ turns, reasoning tokens and tool results persisted in conversation history) → completed cleanly, file created, read back, confirmed. **No 400, no empty-parts payloads.**

All four scenarios reproduced the previously-failing pattern (long-running, tool-using, reasoning multi-turn conversation) and completed without `Request contains an invalid argument`. Unit tests in `tests/translator/bugs-antigravity.test.js` pass.
