### PR TITLE
fix: preserve Antigravity identity on model catalog requests

### DIFF
--- a/src/mitm/antigravityIdeVersion.js
+++ b/src/mitm/antigravityIdeVersion.js
@@ -1,8 +1,8 @@
 "use strict";
 
-// Rewrite Antigravity IDE markers so upstream AG 2.x backend accepts the request.
-// User-Agent header (antigravity/<old>) and body.metadata.ideVersion are forced
-// to a known-good IDE version. Hardcoded MVP — toggle/version configurable later.
+// Rewrite Antigravity IDE markers on generation requests so upstream AG 2.x
+// backend accepts them. Catalog and other passthrough requests retain the
+// client's current identity. Hardcoded MVP — toggle/version configurable later.
 
 const ANTIGRAVITY_IDE_VERSION = "1.23.2";
 const ANTIGRAVITY_IDE_VERSION_OVERRIDE_ENABLED = true;
@@ -19,8 +19,10 @@ function rewriteAntigravityUserAgent(userAgent, version) {
   return userAgent.replace(/antigravity\/[^\s]+/, `antigravity/${version}`);
 }
 
-function applyAntigravityIdeVersionOverride(bodyBuffer, headers) {
-  if (!ANTIGRAVITY_IDE_VERSION_OVERRIDE_ENABLED) {
+function applyAntigravityIdeVersionOverride(bodyBuffer, headers, requestUrl) {
+  const isGenerationEndpoint = requestUrl?.includes(":generateContent") ||
+    requestUrl?.includes(":streamGenerateContent");
+  if (!ANTIGRAVITY_IDE_VERSION_OVERRIDE_ENABLED || !isGenerationEndpoint) {
     return { bodyBuffer, headers, applied: false, version: ANTIGRAVITY_IDE_VERSION };
   }
 

--- a/src/mitm/server.js
+++ b/src/mitm/server.js
@@ -132,7 +132,7 @@ async function passthrough(req, res, bodyBuffer, onResponse) {
 
   const tool = getToolForHost(req.headers.host);
   const versionOverride = tool === "antigravity"
-    ? applyAntigravityIdeVersionOverride(bodyBuffer, req.headers)
+    ? applyAntigravityIdeVersionOverride(bodyBuffer, req.headers, req.url)
     : { bodyBuffer, headers: req.headers };
   const bodyForForwarding = versionOverride.bodyBuffer;
   const headersForForwarding = { ...versionOverride.headers, host: targetHost };

--- a/tests/unit/antigravity-ide-version.test.js
+++ b/tests/unit/antigravity-ide-version.test.js
@@ -1,0 +1,89 @@
+import { createRequire } from "module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const {
+  ANTIGRAVITY_IDE_VERSION,
+  applyAntigravityIdeVersionOverride,
+} = require("../../src/mitm/antigravityIdeVersion.js");
+
+const CURRENT_VERSION = "2.11.0";
+
+function makeRequest(metadata = { ideName: "antigravity", ideVersion: CURRENT_VERSION }) {
+  const bodyBuffer = Buffer.from(JSON.stringify({ metadata, request: { contents: [] } }));
+  const headers = {
+    "content-type": "application/json",
+    "content-length": String(bodyBuffer.length),
+    "user-agent": `antigravity/${CURRENT_VERSION}`,
+  };
+  return { bodyBuffer, headers };
+}
+
+describe("Antigravity IDE version override", () => {
+  it("preserves catalog request identity and bytes", () => {
+    const { bodyBuffer, headers } = makeRequest();
+
+    const result = applyAntigravityIdeVersionOverride(
+      bodyBuffer,
+      headers,
+      "/v1internal:fetchAvailableModels"
+    );
+
+    expect(result.applied).toBe(false);
+    expect(result.bodyBuffer).toBe(bodyBuffer);
+    expect(result.headers).toBe(headers);
+    expect(result.headers["user-agent"]).toBe(`antigravity/${CURRENT_VERSION}`);
+    expect(JSON.parse(result.bodyBuffer.toString()).metadata.ideVersion).toBe(CURRENT_VERSION);
+    expect(result.headers["content-length"]).toBe(String(bodyBuffer.length));
+  });
+
+  it.each([":generateContent", ":streamGenerateContent"])(
+    "rewrites identity for %s requests",
+    (endpoint) => {
+      const { bodyBuffer, headers } = makeRequest();
+
+      const result = applyAntigravityIdeVersionOverride(
+        bodyBuffer,
+        headers,
+        `/v1internal/models/gemini-3.7-flash-tiered${endpoint}`
+      );
+
+      expect(result.applied).toBe(true);
+      expect(result.bodyBuffer).not.toBe(bodyBuffer);
+      expect(result.headers["user-agent"]).toBe(`antigravity/${ANTIGRAVITY_IDE_VERSION}`);
+      expect(JSON.parse(result.bodyBuffer.toString()).metadata.ideVersion).toBe(ANTIGRAVITY_IDE_VERSION);
+    }
+  );
+
+  it("preserves malformed non-generation request content byte-for-byte", () => {
+    const bodyBuffer = Buffer.from([0xff, 0x00, 0x7b, 0x6e, 0x6f, 0x74, 0x2d, 0x6a, 0x73, 0x6f, 0x6e]);
+    const headers = {
+      "content-type": "application/octet-stream",
+      "content-length": String(bodyBuffer.length),
+      "user-agent": `antigravity/${CURRENT_VERSION}`,
+    };
+
+    const result = applyAntigravityIdeVersionOverride(bodyBuffer, headers, "/v1internal:loadCodeAssist");
+
+    expect(result.applied).toBe(false);
+    expect(result.bodyBuffer).toBe(bodyBuffer);
+    expect(result.headers).toBe(headers);
+  });
+
+  it("does not synthesize missing Antigravity identity", () => {
+    const bodyBuffer = Buffer.from(JSON.stringify({ metadata: {}, request: { contents: [] } }));
+    const headers = { "content-type": "application/json", "content-length": String(bodyBuffer.length) };
+
+    const result = applyAntigravityIdeVersionOverride(
+      bodyBuffer,
+      headers,
+      "/v1internal/models/gemini-3.7-flash-tiered:generateContent"
+    );
+
+    expect(result.applied).toBe(false);
+    expect(result.bodyBuffer).toBe(bodyBuffer);
+    expect(result.headers).toEqual(headers);
+    expect(result.headers).not.toHaveProperty("user-agent");
+    expect(JSON.parse(result.bodyBuffer.toString()).metadata).not.toHaveProperty("ideVersion");
+  });
+});


### PR DESCRIPTION
Antigravity exposes Gemini 3.7 Flash when connected directly, but the model disappears from its selector when 9router MITM is enabled. Adding the Gemini 3.7 tiers to the dashboard mapping catalog in PR #3382 did not fix the native Antigravity catalog returned through the proxy. The MITM passthrough currently rewrites every Antigravity request to the hardcoded IDE version `1.23.2`, including non-chat model-catalog calls from newer Antigravity releases. This gives the issue a concrete local cause consistent with the reporter's reproduction on Antigravity 2.11.0.

## Summary

Restrict the legacy Antigravity IDE-version override in `src/mitm/antigravityIdeVersion.js` to generation endpoints that need the existing upstream compatibility workaround. Pass the request URL from `src/mitm/server.js` into that decision so model-catalog and other non-chat passthrough requests retain their original `User-Agent`, metadata, body bytes, and content length. Keep the existing chat-request rewrite behavior intact to avoid reopening the compatibility failure the override was introduced to handle.

## Tests

- A `fetchAvailableModels` or equivalent non-generation request with an Antigravity 2.11.0 identity is returned unchanged, preserving both the original `User-Agent` and `metadata.ideVersion` so current models remain eligible upstream.
- A `generateContent` and a `streamGenerateContent` request still applies the known-good legacy version override and returns the rewritten body for forwarding.
- A non-chat request with malformed or non-JSON content remains byte-for-byte unchanged and does not acquire a rewritten identity.
- A request without an Antigravity `User-Agent` or metadata identity remains unchanged instead of synthesizing identity fields.

Fixes #3414
