### PR TITLE
fix(i18n): translate combo vision adapter label

### DIFF
--- a/public/i18n/literals/zh-CN.json
+++ b/public/i18n/literals/zh-CN.json
@@ -235,6 +235,7 @@
   "Codex CLI not installed": "Codex CLI 未安装",
   "Codex Reset Credit Expiry": "Codex 重置信用有效期",
   "Codex uses": "Codex 使用",
+  "Combo & Vision Adapter": "组合与视觉适配器",
   "Combo Name": "组合名称",
   "Combo Round Robin": "组合轮询",
   "Combo Sticky Limit": "组合粘性限制",


### PR DESCRIPTION
## 变更
- 为简体中文词典补充 `Combo & Vision Adapter` 翻译
- 修复组合菜单在中文界面显示英文的问题

## 验证
- 已通过 JSON 解析校验
- 仅修改 `public/i18n/literals/zh-CN.json`