### PR TITLE
fix(translator): route Gemini thinking through reasoning_effort on OpenAI-compatible wire

### DIFF
--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -105,12 +105,16 @@ export function extractThinking(body) {
 // at the call-site where intent is snapshotted before format translation.
 export const captureThinking = extractThinking;
 
-// Resolve thinking format: provider override > capability > derive(targetFormat).
+const NATIVE_ONLY_FORMATS = new Set(["gemini-level", "gemini-budget", "claude-budget", "claude-adaptive", "kiro"]);
+
 function resolveFormat(targetFormat, model, provider) {
   const providerFmt = provider ? PROVIDERS[provider]?.thinkingFormat : null;
   if (providerFmt) return providerFmt;
   const caps = getCapabilitiesForModel(provider, model);
-  if (caps.thinkingFormat) return caps.thinkingFormat;
+  const isOpenAIWire = targetFormat === "openai" || targetFormat === "openai-responses";
+  if (caps.thinkingFormat && !(isOpenAIWire && NATIVE_ONLY_FORMATS.has(caps.thinkingFormat))) {
+    return caps.thinkingFormat;
+  }
   return FORMAT_TO_NATIVE[targetFormat] || "openai";
 }
 

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -215,6 +215,26 @@ describe("applyThinking per provider format", () => {
     const out = apply("openai", "gpt-5.6-sol", { reasoning_effort: "max" }, "kiro");
     expect(out.reasoning_effort).toBe("xhigh");
   });
+  it.each([
+    ["gemini-3.5-flash-lite"],
+    ["gemini-3.7-flash"],
+    ["gemini-3-pro"],
+  ])("Gemini 3.x model %s (gemini-level) over a custom OpenAI-compatible provider → reasoning_effort, not generationConfig (regression: #3718)", (model) => {
+    const out = apply("openai", model, { reasoning_effort: "medium" }, "my-custom-gemini-openai");
+    expect(out.reasoning_effort).toBe("medium");
+    expect(out.generationConfig).toBeUndefined();
+    expect(out.thinkingConfig).toBeUndefined();
+  });
+  it("Gemini 2.5 model (gemini-budget) over a custom OpenAI-compatible provider → reasoning_effort, not generationConfig (regression: #3718)", () => {
+    const out = apply("openai", "gemini-2.5-flash", { reasoning_effort: "high" }, "my-custom-gemini-openai");
+    expect(out.reasoning_effort).toBe("high");
+    expect(out.generationConfig).toBeUndefined();
+    expect(out.thinkingConfig).toBeUndefined();
+  });
+  it("Gemini model over its native format (antigravity/gemini-cli/vertex) still gets generationConfig", () => {
+    const out = apply("gemini-cli", "gemini-3.5-flash-lite", { reasoning_effort: "medium" }, "gemini-cli");
+    expect(out.generationConfig.thinkingConfig.thinkingLevel).toBe("medium");
+  });
 });
 
 describe("extractReasoningText (response shapes)", () => {


### PR DESCRIPTION
## Problem

Custom OpenAI-compatible providers pointed at Google's Gemini OpenAI-compat endpoint (`https://generativelanguage.googleapis.com/v1beta/openai`) fail whenever the client sends a `thinking` parameter (e.g. Claude Code sends this by default for any non-first-party model):

    {
      "error": {
        "code": 400,
        "message": "Invalid JSON payload received. Unknown name \"generationConfig\": Cannot find field."
      }
    }

`resolveFormat()` in `thinkingUnified.js` lets a model's capability-declared native thinking format (`gemini-level`/`gemini-budget`, from the `*gemini-3*`/ `*gemini-2.5*` capability patterns) win over the actual wire target, even when the connection's real `targetFormat` is `openai` (a custom/OpenAI-compatible provider).

The native format nests thinking under `generationConfig`, which Google's OpenAI-compat endpoint doesn't recognize.

## Fix

In `resolveFormat()`, only let a capability's native thinking format (`gemini-level`, `gemini-budget`, `claude-budget`, `claude-adaptive`, `kiro`) win when the wire target actually speaks that native protocol.
When the wire is OpenAI-compatible (`openai`/`openai-responses`), fall through to the OpenAI-shaped default (`reasoning_effort`) instead.

## Tests

Adds 5 cases to `tests/translator/thinking-unified.test.js` covering Gemini 3.x (`gemini-level`) and Gemini 2.5.x (`gemini-budget`) over a custom OpenAI-compatible provider, plus a control case confirming native-format routing (antigravity/gemini-cli/vertex) is unaffected.

- `npx vitest run tests/translator/thinking-unified.test.js` — 59/59 pass
- Full suite before/after diff — 0 regressions (85 pre-existing/environment fails, unchanged)
- Live verification: ran the real `translateRequest()` against an actual
  Google AI Studio API key — translated body now sends `reasoning_effort`
  and gets a real `200 OK` streamed response from Gemini (previously `400`)

Fixes #3718