### PR TITLE
fix(translator): preserve prompt_cache_key across Responses↔Chat conversions

### DIFF
--- a/open-sse/providers/REGISTRY_TEMPLATE.js
+++ b/open-sse/providers/REGISTRY_TEMPLATE.js
@@ -49,7 +49,7 @@ export default {
     // headers: { "User-Agent": "..." },           // static fingerprint (anti-ban) lives here.
     // auth: { header: "x-api-key", scheme: "raw" },
     // forceStream: true, urlSuffix: "?beta=true",
-    // quirks: { dropOutputConfig: true },
+    // quirks: { dropOutputConfig: true, preservePromptCacheKey: true }, // latter: Chat Completions accepts prompt_cache_key on the Responses→Chat hop (default: stripped; currently openai, azure)
     // retry: { 429: { attempts: 6 }, 503: { attempts: 3 } },
     // usage: { url: "https://api.example.com/usage" }, // or { urls: [...] } for multi-call.
     // modelsFetcher: { url: "https://api.example.com/models", type: "openai" }, // dynamic model list.

--- a/open-sse/providers/registry/azure.js
+++ b/open-sse/providers/registry/azure.js
@@ -17,5 +17,6 @@ export default {
   transport: {
     baseUrl: "",
     headers: {},
+    quirks: { preservePromptCacheKey: true },
   },
 };

--- a/open-sse/providers/registry/openai.js
+++ b/open-sse/providers/registry/openai.js
@@ -26,6 +26,7 @@ export default {
   transport: {
     baseUrl: "https://api.openai.com/v1/chat/completions",
     forceStream: true,
+    quirks: { preservePromptCacheKey: true },
   },
   models: [
     { id: "gpt-5.4", name: "GPT-5.4" },

--- a/open-sse/translator/concerns/paramSupport.js
+++ b/open-sse/translator/concerns/paramSupport.js
@@ -1,7 +1,20 @@
 import { getCapabilitiesForModel } from "../../providers/capabilities.js";
+import { PROVIDERS } from "../../providers/index.js";
 
 // Strip request params a given provider/model rejects upstream (e.g. HTTP 400).
 // Config-driven: add a rule instead of scattering `delete body.x` across executors.
+
+// OpenAI Chat Completions extension params that strict OpenAI-compatible endpoints
+// reject as unknown fields — e.g. Groq 400 "property 'prompt_cache_key' is unsupported",
+// Cerebras 422 (zed-industries/zed#36215). Default is to drop; a provider opts back in
+// by declaring the named quirk in providers/registry/{id}.js (openai, azure).
+// Applied only on the Responses→Chat hop (see translator/index.js);
+// Responses API bodies carry these natively and are never touched.
+// GitHub Copilot Chat Completions support is unverified and left to a follow-up;
+// Codex and grok-cli are Responses-native so this Chat-only guard never consults them.
+const CHAT_EXTENSION_PARAMS = [
+  { key: "prompt_cache_key", preserveQuirk: "preservePromptCacheKey" },
+];
 
 // Each rule: optional provider, regex match on model, list of params to drop.
 // A param is removed only when it is present (!== undefined).
@@ -33,6 +46,22 @@ function clampNumber(body, key, ceiling) {
   if (typeof body[key] === "number" && Number.isFinite(body[key]) && body[key] > ceiling) {
     body[key] = ceiling;
   }
+}
+
+// Drop Chat Completions extension params for providers that do not declare support.
+// Mutates body in place; fail-open (never throws); returns body.
+export function stripUnsupportedChatExtensions(provider, body) {
+  if (!body || typeof body !== "object") return body;
+  try {
+    const quirks = PROVIDERS[provider]?.quirks;
+    for (const { key, preserveQuirk } of CHAT_EXTENSION_PARAMS) {
+      if (quirks?.[preserveQuirk]) continue;
+      if (body[key] !== undefined) delete body[key];
+    }
+  } catch {
+    // fail-open: leave the body untouched
+  }
+  return body;
 }
 
 // Remove unsupported params from body in place; returns body.

--- a/open-sse/translator/formats/responsesApi.js
+++ b/open-sse/translator/formats/responsesApi.js
@@ -133,7 +133,6 @@ export function convertResponsesApiFormat(body) {
   delete result.input;
   delete result.instructions;
   delete result.include;
-  delete result.prompt_cache_key;
   delete result.store;
   delete result.reasoning;
 

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -3,6 +3,7 @@ import { ensureToolCallIds, fixMissingToolResponses } from "./concerns/toolCall.
 import { prepareClaudeRequest } from "./formats/claude.js";
 import { cloakClaudeTools, decloakStreamChunk } from "../utils/claudeCloaking.js";
 import { filterToOpenAIFormat } from "./formats/openai.js";
+import { stripUnsupportedChatExtensions } from "./concerns/paramSupport.js";
 import { normalizeThinkingConfig } from "../services/provider.js";
 import { applyThinking, captureThinking } from "./concerns/thinkingUnified.js";
 import { captureSessionId } from "../utils/sessionManager.js";
@@ -125,6 +126,13 @@ export function translateRequest(sourceFormat, targetFormat, model, body, stream
     result = filterToOpenAIFormat(result, {
       preserveCacheControl: !!PROVIDERS[provider]?.quirks?.preserveCacheControl,
     });
+    // Chat Completions clients have always had prompt_cache_key forwarded
+    // verbatim. Only the Responses→Chat hop newly exposes the field, so
+    // scope the strict-endpoint guard to that direction; providers opt in
+    // via the preservePromptCacheKey quirk.
+    if (sourceFormat === FORMATS.OPENAI_RESPONSES) {
+      stripUnsupportedChatExtensions(provider, result);
+    }
   }
 
   // Final step: prepare request for Claude format endpoints

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -238,7 +238,9 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
   delete result.input;
   delete result.instructions;
   delete result.include;
-  delete result.prompt_cache_key;
+  // prompt_cache_key is intentionally kept: Chat Completions accepts it on
+  // api.openai.com/Azure and it seeds the stable Codex/Grok cache id. Providers
+  // that reject it are handled by the config-driven guard in translator/index.js.
   delete result.store;
   if (typeof result.reasoning?.effort === "string") {
     result.reasoning_effort = result.reasoning.effort;

--- a/tests/unit/prompt-cache-key-provider-guard.test.js
+++ b/tests/unit/prompt-cache-key-provider-guard.test.js
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { translateRequest } from "../../open-sse/translator/index.js";
+import { stripUnsupportedChatExtensions } from "../../open-sse/translator/concerns/paramSupport.js";
+
+const KEY = "stable-cache-key";
+
+const chatBody = () => ({
+  model: "example-model",
+  messages: [{ role: "user", content: "hello" }],
+  prompt_cache_key: KEY,
+});
+
+const responsesBody = () => ({
+  model: "example-model",
+  input: [{ role: "user", content: [{ type: "input_text", text: "hello" }] }],
+  prompt_cache_key: KEY,
+});
+
+describe("prompt_cache_key provider-boundary guard (Responses → Chat hop only)", () => {
+  it("responses → chat keeps the key for a provider declaring preservePromptCacheKey (openai)", () => {
+    const out = translateRequest(FORMATS.OPENAI_RESPONSES, FORMATS.OPENAI, "gpt-4o", responsesBody(), true, {}, "openai");
+
+    expect(out.prompt_cache_key).toBe(KEY);
+    expect(out.messages?.[0]?.role).toBe("user");
+  });
+
+  it("responses → chat strips the key for a provider without the quirk (groq)", () => {
+    const out = translateRequest(FORMATS.OPENAI_RESPONSES, FORMATS.OPENAI, "llama-3.3-70b", responsesBody(), true, {}, "groq");
+
+    expect(out.prompt_cache_key).toBeUndefined();
+    expect(out.messages?.[0]?.role).toBe("user");
+  });
+
+  it("responses → chat strips the key for github until Copilot Chat Completions support is verified", () => {
+    const out = translateRequest(FORMATS.OPENAI_RESPONSES, FORMATS.OPENAI, "gpt-5.4", responsesBody(), true, {}, "github");
+
+    expect(out.prompt_cache_key).toBeUndefined();
+    expect(out.messages?.[0]?.role).toBe("user");
+  });
+
+  it("chat → chat retains the key for a non-quirk provider", () => {
+    const out = translateRequest(FORMATS.OPENAI, FORMATS.OPENAI, "any", chatBody(), true, {}, "opencode");
+
+    expect(out.prompt_cache_key).toBe(KEY);
+  });
+
+  it("chat → chat retains the key for openai-compatible-* nodes", () => {
+    const out = translateRequest(FORMATS.OPENAI, FORMATS.OPENAI, "any", chatBody(), true, {}, "openai-compatible-chat-abc");
+
+    expect(out.prompt_cache_key).toBe(KEY);
+  });
+
+  it("leaves Responses-target bodies untouched regardless of provider", () => {
+    const passthrough = translateRequest(FORMATS.OPENAI_RESPONSES, FORMATS.OPENAI_RESPONSES, "any", responsesBody(), true, {}, "openai-compatible-custom");
+    expect(passthrough.prompt_cache_key).toBe(KEY);
+
+    const chatToResponses = translateRequest(FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, "any", chatBody(), true, {}, "groq");
+    expect(chatToResponses.prompt_cache_key).toBe(KEY);
+  });
+
+  it("stripUnsupportedChatExtensions is fail-open on unknown provider and null/non-object bodies", () => {
+    expect(stripUnsupportedChatExtensions("no-such-provider", null)).toBeNull();
+    expect(stripUnsupportedChatExtensions(undefined, undefined)).toBeUndefined();
+    expect(stripUnsupportedChatExtensions("groq", "text")).toBe("text");
+    expect(() => stripUnsupportedChatExtensions("no-such-provider", { prompt_cache_key: KEY })).not.toThrow();
+  });
+});

--- a/tests/unit/responses-api-format.test.js
+++ b/tests/unit/responses-api-format.test.js
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { convertResponsesApiFormat } from "../../open-sse/translator/formats/responsesApi.js";
+
+describe("convertResponsesApiFormat", () => {
+  it("preserves prompt_cache_key", () => {
+    const result = convertResponsesApiFormat({
+      input: "Hello",
+      prompt_cache_key: "conversation-123",
+    });
+
+    expect(result.prompt_cache_key).toBe("conversation-123");
+  });
+});

--- a/tests/unit/responses-prompt-cache-key-3216.test.js
+++ b/tests/unit/responses-prompt-cache-key-3216.test.js
@@ -27,13 +27,27 @@ describe("#3216 prompt_cache_key across the chat/responses translation", () => {
     expect(out.prompt_cache_key).toBeUndefined();
   });
 
-  it("still drops the key on the responses → chat direction", () => {
+  it("preserves the key on the responses → chat direction", () => {
     const out = openaiResponsesToOpenAIRequest(
       "example-model",
       {
         model: "example-model",
         input: [{ role: "user", content: [{ type: "input_text", text: "hello" }] }],
         prompt_cache_key: "stable-cache-key",
+      },
+      true,
+      {},
+    );
+
+    expect(out.prompt_cache_key).toBe("stable-cache-key");
+  });
+
+  it("does not invent a key on the responses → chat direction", () => {
+    const out = openaiResponsesToOpenAIRequest(
+      "example-model",
+      {
+        model: "example-model",
+        input: [{ role: "user", content: [{ type: "input_text", text: "hello" }] }],
       },
       true,
       {},


### PR DESCRIPTION
## Problem

Clients send `prompt_cache_key` so the provider can reuse a cached prompt prefix (cheaper, faster follow-up turns). 9Router was deleting that key when converting a Responses API request into Chat Completions format.

That hits any tool talking to `/v1/responses` — Codex CLI, Cursor, Copilot, OpenCode, and similar.

The drop happened in two converters:

- `convertResponsesApiFormat()` (Workers)
- `openaiResponsesToOpenAIRequest()` (app `/v1/responses` path)

The opposite direction (Chat → Responses) already keeps the key (`70ba0024`, #3216). This PR covers the missing Responses → Chat direction.

## Evidence

- `prompt_cache_key` is a normal OpenAI field on both APIs.
- Codex CLI always sends it on `POST /responses`.
- On a live Codex route, cached tokens went to **zero** while the key was being stripped.
- Some Chat Completions servers reject the field: Groq 400, Cerebras 422 ([zed#36215](https://github.com/zed-industries/zed/issues/36215)).

## Fix

**Responses → Chat** means the client sent `/v1/responses` and 9Router rewrites it to Chat Completions. That rewrite was deleting `prompt_cache_key`.
**Chat → Chat** means the client already sent `/v1/chat/completions`; 9Router already forwards the key. This PR does not change that.

1. Stop deleting the key in both converters.
2. When converting Responses → Chat, strip it by default, and keep it only for providers that are known to accept it: **OpenAI** and **Azure**.
3. Do not change Chat → Chat requests, or providers that already speak Responses (Codex, Grok CLI).

GitHub Copilot Chat Completions is **not** opted in here. Copilot’s own client only sends this field on Responses; Chat support is unconfirmed. That can be a follow-up PR.

## Tests

- Direct converter test: key is kept.
- #3216 test: Responses → Chat now keeps the key (still does not invent one).
- Guard tests: keep for OpenAI, strip for Groq and GitHub, Chat → Chat unchanged.

## Verification

- [x] `cd tests && npx vitest run unit/prompt-cache-key-provider-guard.test.js unit/responses-prompt-cache-key-3216.test.js unit/responses-api-format.test.js --config vitest.config.js`
- [x] `git diff --check`

Related to #3216.
