### PR TITLE
feat(antigravity): add Gemini 3.8 Flash model support

### DIFF
--- a/cli/src/cli/menus/providers.js
+++ b/cli/src/cli/menus/providers.js
@@ -53,6 +53,9 @@ const PROVIDER_MODELS = {
     { id: "glm-4.7" },
   ],
   ag: [
+    { id: "gemini-3.8-flash-high" },
+    { id: "gemini-3.8-flash-medium" },
+    { id: "gemini-3.8-flash-low" },
     { id: "gemini-3.7-flash-high" },
     { id: "gemini-3.7-flash-medium" },
     { id: "gemini-3.7-flash-low" },

--- a/open-sse/config/appConstants.js
+++ b/open-sse/config/appConstants.js
@@ -1,6 +1,6 @@
 import { platform, arch, hostname } from "os";
 import { PROVIDERS, PROVIDER_OAUTH } from "./providers.js";
-import { ANTIGRAVITY_IDE_USER_AGENT } from "../providers/shared.js";
+import { ANTIGRAVITY_IDE_USER_AGENT, ANTIGRAVITY_IDE_USER_AGENT_V2 } from "../providers/shared.js";
 import { createRequire } from "module";
 
 // === Gemini CLI === derive từ registry gemini-cli.transport
@@ -132,6 +132,9 @@ export const AG_DEFAULT_TOOLS = new Set([
 // Antigravity chat/stream headers
 export const ANTIGRAVITY_HEADERS = {
   "User-Agent": ANTIGRAVITY_IDE_USER_AGENT
+};
+export const ANTIGRAVITY_HEADERS_V2 = {
+  "User-Agent": ANTIGRAVITY_IDE_USER_AGENT_V2
 };
 
 // Cloud Code Assist API endpoints differ by client ecosystem.

--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -1,7 +1,7 @@
 import crypto from "crypto";
 import { BaseExecutor } from "./base.js";
 import { PROVIDERS } from "../config/providers.js";
-import { OAUTH_ENDPOINTS, ANTIGRAVITY_HEADERS, AG_DEFAULT_TOOLS, AG_TOOL_SUFFIX, ANTIGRAVITY_PROMPT_REWRITES } from "../config/appConstants.js";
+import { OAUTH_ENDPOINTS, ANTIGRAVITY_HEADERS, ANTIGRAVITY_HEADERS_V2, AG_DEFAULT_TOOLS, AG_TOOL_SUFFIX, ANTIGRAVITY_PROMPT_REWRITES } from "../config/appConstants.js";
 import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
@@ -125,15 +125,19 @@ export class AntigravityExecutor extends BaseExecutor {
 
   // sessionId comes from transformRequest output; base.execute runs transformRequest before
   // buildHeaders, so we read it from instance state cached there (fallback: explicit arg).
-  buildHeaders(credentials, stream = true, sessionId = null) {
+  buildHeaders(credentials, stream = true, sessionId = null, model = null) {
+    const targetModel = model || this._currentModel || "";
+    const isV2 = typeof targetModel === "string" && targetModel.includes("3.8");
+    const userAgent = isV2 ? ANTIGRAVITY_HEADERS_V2["User-Agent"] : (this.config.headers?.["User-Agent"] || ANTIGRAVITY_HEADERS["User-Agent"]);
     return {
       "Content-Type": "application/json",
       "Authorization": `Bearer ${credentials.accessToken}`,
-      "User-Agent": this.config.headers?.["User-Agent"] || ANTIGRAVITY_HEADERS["User-Agent"],
+      "User-Agent": userAgent,
     };
   }
 
   transformRequest(model, body, stream, credentials) {
+    this._currentModel = model;
     const projectId = credentials?.projectId || this.generateProjectId();
 
     // OpenAI clients may include stream_options even for non-streaming calls.

--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -123,11 +123,8 @@ export class AntigravityExecutor extends BaseExecutor {
     return `${baseUrl}/v1internal:${action}`;
   }
 
-  // sessionId comes from transformRequest output; base.execute runs transformRequest before
-  // buildHeaders, so we read it from instance state cached there (fallback: explicit arg).
-  buildHeaders(credentials, stream = true, sessionId = null, model = null) {
-    const targetModel = model || this._currentModel || "";
-    const isV2 = typeof targetModel === "string" && targetModel.includes("3.8");
+  buildHeaders(credentials, stream = true, url = null, model = null) {
+    const isV2 = typeof model === "string" && model.includes("3.8");
     const userAgent = isV2 ? ANTIGRAVITY_HEADERS_V2["User-Agent"] : (this.config.headers?.["User-Agent"] || ANTIGRAVITY_HEADERS["User-Agent"]);
     return {
       "Content-Type": "application/json",
@@ -137,7 +134,6 @@ export class AntigravityExecutor extends BaseExecutor {
   }
 
   transformRequest(model, body, stream, credentials) {
-    this._currentModel = model;
     const projectId = credentials?.projectId || this.generateProjectId();
 
     // OpenAI clients may include stream_options even for non-streaming calls.

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -225,6 +225,7 @@ export const PATTERN_CAPABILITIES = [
 
   // ── Gemini (all 2.0+ multimodal + google_search grounding, 1M ctx) ─
   { pattern: "*gemini*image*",  caps: { vision: true, imageOutput: true, contextWindow: 1048576 } },
+  { pattern: "*gemini-3.8*",    caps: { vision: true, audioInput: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "gemini-level", thinkingCanDisable: false, contextWindow: 1048576, maxOutput: 65536 } },
   { pattern: "*gemini-3.7*",    caps: { vision: true, audioInput: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "gemini-level", thinkingCanDisable: false, contextWindow: 1048576, maxOutput: 65536 } },
   { pattern: "*gemini-3*pro*",  caps: { vision: true, audioInput: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "gemini-level", thinkingCanDisable: false, contextWindow: 1048576, maxOutput: 65535 } },
   { pattern: "*gemini-3*",      caps: { vision: true, audioInput: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "gemini-level", thinkingCanDisable: false, contextWindow: 1048576, maxOutput: 65536 } },

--- a/open-sse/providers/pricing.js
+++ b/open-sse/providers/pricing.js
@@ -57,6 +57,10 @@ export const MODEL_PRICING = {
   "o1-mini":                      { input: 3.00,  output: 12.00, cached: 1.50,  reasoning: 18.00,  cache_creation: 3.00  },
 
   // === Gemini ===
+  "gemini-3.8-flash":              { input: 1.50,  output: 7.50,  cached: 0.15,  reasoning: 11.25,  cache_creation: 1.875 },
+  "gemini-3.8-flash-high":         { input: 1.50,  output: 7.50,  cached: 0.15,  reasoning: 11.25,  cache_creation: 1.875 },
+  "gemini-3.8-flash-medium":       { input: 1.50,  output: 7.50,  cached: 0.15,  reasoning: 11.25,  cache_creation: 1.875 },
+  "gemini-3.8-flash-low":          { input: 1.50,  output: 7.50,  cached: 0.15,  reasoning: 11.25,  cache_creation: 1.875 },
   "gemini-3.7-flash":              { input: 1.50,  output: 7.50,  cached: 0.15,  reasoning: 11.25,  cache_creation: 1.875 },
   "gemini-3.7-flash-high":         { input: 1.50,  output: 7.50,  cached: 0.15,  reasoning: 11.25,  cache_creation: 1.875 },
   "gemini-3.7-flash-medium":       { input: 1.50,  output: 7.50,  cached: 0.15,  reasoning: 11.25,  cache_creation: 1.875 },

--- a/open-sse/providers/registry/antigravity.js
+++ b/open-sse/providers/registry/antigravity.js
@@ -45,6 +45,9 @@ export default {
     clientSecret: "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",
   },
   models: [
+    { id: "gemini-3.8-flash-high", name: "Gemini 3.8 Flash (High)", upstreamModelId: "gemini-3.8-flash-tiered(high)" },
+    { id: "gemini-3.8-flash-medium", name: "Gemini 3.8 Flash (Medium)", upstreamModelId: "gemini-3.8-flash-tiered(medium)" },
+    { id: "gemini-3.8-flash-low", name: "Gemini 3.8 Flash (Low)", upstreamModelId: "gemini-3.8-flash-tiered(low)" },
     { id: "gemini-3.7-flash-high", name: "Gemini 3.7 Flash (High)", upstreamModelId: "gemini-3.7-flash-tiered(high)" },
     { id: "gemini-3.7-flash-medium", name: "Gemini 3.7 Flash (Medium)", upstreamModelId: "gemini-3.7-flash-tiered(medium)" },
     { id: "gemini-3.7-flash-low", name: "Gemini 3.7 Flash (Low)", upstreamModelId: "gemini-3.7-flash-tiered(low)" },

--- a/open-sse/providers/registry/gemini.js
+++ b/open-sse/providers/registry/gemini.js
@@ -36,6 +36,7 @@ export default {
     },
   },
   models: [
+    { id: "gemini-3.8-flash", name: "Gemini 3.8 Flash" },
     { id: "gemini-3.7-flash", name: "Gemini 3.7 Flash" },
     { id: "gemini-3.6-flash", name: "Gemini 3.6 Flash" },
     { id: "gemini-3.5-flash-lite", name: "Gemini 3.5 Flash Lite" },

--- a/open-sse/providers/shared.js
+++ b/open-sse/providers/shared.js
@@ -80,6 +80,8 @@ export const ANTHROPIC_COMPAT_BASE = "https://api.anthropic.com/v1";
 export const ANTIGRAVITY_IDE_VERSION = "2.1.1";
 export const ANTIGRAVITY_IDE_BASE_URL = "https://daily-cloudcode-pa.googleapis.com";
 export const ANTIGRAVITY_IDE_USER_AGENT = `antigravity/ide/${ANTIGRAVITY_IDE_VERSION} darwin/arm64`;
+export const ANTIGRAVITY_IDE_VERSION_V2 = "2.8.0";
+export const ANTIGRAVITY_IDE_USER_AGENT_V2 = `antigravity/ide/${ANTIGRAVITY_IDE_VERSION_V2} darwin/arm64`;
 
 // Antigravity OAuth client credentials (public CLI client — duplicated in usage.js + src/lib/oauth)
 export const ANTIGRAVITY_OAUTH_CLIENT = {

--- a/open-sse/services/usage/google.js
+++ b/open-sse/services/usage/google.js
@@ -161,6 +161,9 @@ export async function getAntigravityUsage(accessToken, providerSpecificData, pro
     if (data.models) {
       // Filter only recommended/important models (must match PROVIDER_MODELS ag ids)
       const importantModels = [
+        'gemini-3.8-flash-high',
+        'gemini-3.8-flash-medium',
+        'gemini-3.8-flash-low',
         'gemini-3.7-flash-high',
         'gemini-3.7-flash-medium',
         'gemini-3.7-flash-low',

--- a/src/mitm/config.js
+++ b/src/mitm/config.js
@@ -55,6 +55,9 @@ const MODEL_SYNONYMS = {
     "gemini-3.5-flash-high": "gemini-3-flash-agent",
     "gemini-3.5-flash-medium": "gemini-3.5-flash-low",
     "gemini-3.5-flash-extra-low": "gemini-3.5-flash-extra-low",
+    "gemini-3.8-flash-high": "gemini-3.8-flash-high",
+    "gemini-3.8-flash-medium": "gemini-3.8-flash-medium",
+    "gemini-3.8-flash-low": "gemini-3.8-flash-low",
      "gemini-3.7-flash-high": "gemini-3.7-flash-high",
     "gemini-3.7-flash-medium": "gemini-3.7-flash-medium",
     "gemini-3.7-flash-low": "gemini-3.7-flash-low",
@@ -135,8 +138,8 @@ function extractModel(url, body) {
     }
     const model = urlModel || parsed.model || null;
     const cleanModelName = String(model).replace(/^models\//, "");
-    if (cleanModelName === "gemini-3.6-flash-tiered" || cleanModelName === "gemini-3.7-flash-tiered") {
-      const ver = cleanModelName.includes("3.7") ? "3.7" : "3.6";
+    if (cleanModelName === "gemini-3.6-flash-tiered" || cleanModelName === "gemini-3.7-flash-tiered" || cleanModelName === "gemini-3.8-flash-tiered") {
+      const ver = cleanModelName.includes("3.8") ? "3.8" : cleanModelName.includes("3.7") ? "3.7" : "3.6";
       const rawLevel = parsed.request?.generationConfig?.thinkingConfig?.thinkingLevel
         || parsed.generationConfig?.thinkingConfig?.thinkingLevel;
       const level = ["high", "medium", "low"].includes(String(rawLevel).toLowerCase())

--- a/src/shared/constants/cliTools.js
+++ b/src/shared/constants/cliTools.js
@@ -8,8 +8,11 @@ export const MITM_TOOLS = {
     description: "Google Antigravity IDE with MITM",
     configType: "mitm",
     mitmDomain: "daily-cloudcode-pa.googleapis.com",
-    modelAliases: ["gemini-3.7-flash-high", "gemini-3.7-flash-medium", "gemini-3.7-flash-low", "gemini-3.6-flash-high", "gemini-3.6-flash-medium", "gemini-3.6-flash-low", "gemini-3.5-flash-low", "gemini-3-flash-agent", "gemini-3.5-flash-extra-low", "gemini-3.1-pro-low", "gemini-pro-agent", "claude-sonnet-4-6", "claude-opus-4-6-thinking", "gpt-oss-120b-medium", "gemini-3-flash"],
+    modelAliases: ["gemini-3.8-flash-high", "gemini-3.8-flash-medium", "gemini-3.8-flash-low", "gemini-3.7-flash-high", "gemini-3.7-flash-medium", "gemini-3.7-flash-low", "gemini-3.6-flash-high", "gemini-3.6-flash-medium", "gemini-3.6-flash-low", "gemini-3.5-flash-low", "gemini-3-flash-agent", "gemini-3.5-flash-extra-low", "gemini-3.1-pro-low", "gemini-pro-agent", "claude-sonnet-4-6", "claude-opus-4-6-thinking", "gpt-oss-120b-medium", "gemini-3-flash"],
     defaultModels: [
+      { id: "gemini-3.8-flash-high", name: "Gemini 3.8 Flash (High)", alias: "gemini-3.8-flash-high" },
+      { id: "gemini-3.8-flash-medium", name: "Gemini 3.8 Flash (Medium)", alias: "gemini-3.8-flash-medium" },
+      { id: "gemini-3.8-flash-low", name: "Gemini 3.8 Flash (Low)", alias: "gemini-3.8-flash-low" },
       { id: "gemini-3.7-flash-high", name: "Gemini 3.7 Flash (High)", alias: "gemini-3.7-flash-high" },
       { id: "gemini-3.7-flash-medium", name: "Gemini 3.7 Flash (Medium)", alias: "gemini-3.7-flash-medium" },
       { id: "gemini-3.7-flash-low", name: "Gemini 3.7 Flash (Low)", alias: "gemini-3.7-flash-low" },

--- a/tests/unit/antigravity-quota-gemini-3.8.test.js
+++ b/tests/unit/antigravity-quota-gemini-3.8.test.js
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const proxyAwareFetch = vi.fn(async (url) => ({
+  ok: true,
+  status: 200,
+  json: async () => url.includes(":loadCodeAssist")
+    ? { cloudaicompanionProject: "project-1", currentTier: { name: "Pro" } }
+    : {
+        models: {
+          "gemini-3.8-flash-high": {
+            displayName: "Gemini 3.8 Flash (High)",
+            quotaInfo: { remainingFraction: 0.85, resetTime: "2026-08-25T12:00:00Z" },
+          },
+          "gemini-3.8-flash-medium": {
+            displayName: "Gemini 3.8 Flash (Medium)",
+            quotaInfo: { remainingFraction: 0.6, resetTime: "2026-08-25T12:00:00Z" },
+          },
+          "gemini-3.8-flash-low": {
+            displayName: "Gemini 3.8 Flash (Low)",
+            quotaInfo: { remainingFraction: 0.35, resetTime: "2026-08-25T12:00:00Z" },
+          },
+          "internal-model": {
+            displayName: "Internal",
+            isInternal: true,
+            quotaInfo: { remainingFraction: 0.5 },
+          },
+        },
+      },
+  text: async () => "{}",
+}));
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch,
+}));
+
+describe("Antigravity quota tracker: Gemini 3.8 Flash usage bars", () => {
+  beforeEach(() => proxyAwareFetch.mockClear());
+
+  it("returns Gemini 3.8 Flash tier quotas so the dashboard can render usage bars", async () => {
+    const { getAntigravityUsage } = await import("../../open-sse/services/usage/google.js");
+
+    const usage = await getAntigravityUsage("access-token", {});
+
+    expect(usage.quotas["gemini-3.8-flash-high"]).toMatchObject({
+      used: 150,
+      total: 1000,
+      remainingPercentage: 85,
+      displayName: "Gemini 3.8 Flash (High)",
+    });
+    expect(usage.quotas["gemini-3.8-flash-medium"]).toMatchObject({
+      used: 400,
+      total: 1000,
+      remainingPercentage: 60,
+    });
+    expect(usage.quotas["gemini-3.8-flash-low"]).toMatchObject({
+      used: 650,
+      total: 1000,
+      remainingPercentage: 35,
+    });
+  });
+});

--- a/tests/unit/gemini-3.8-antigravity.test.js
+++ b/tests/unit/gemini-3.8-antigravity.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { getCapabilitiesForModel } from "../../open-sse/providers/capabilities.js";
+import antigravityRegistry from "../../open-sse/providers/registry/antigravity.js";
+import geminiRegistry from "../../open-sse/providers/registry/gemini.js";
+import { MODEL_PRICING } from "../../open-sse/providers/pricing.js";
+
+describe("Gemini 3.8 Flash Support & Config", () => {
+  it("registers gemini-3.8-flash tiered models in antigravity provider registry", () => {
+    const agIds = antigravityRegistry.models.map(m => m.id);
+    expect(agIds).toContain("gemini-3.8-flash-high");
+    expect(agIds).toContain("gemini-3.8-flash-medium");
+    expect(agIds).toContain("gemini-3.8-flash-low");
+    expect(agIds).not.toContain("gemini-3.8-flash");
+  });
+
+  it("registers gemini-3.8-flash in gemini provider registry", () => {
+    const geminiIds = geminiRegistry.models.map(m => m.id);
+    expect(geminiIds).toContain("gemini-3.8-flash");
+  });
+
+  it("resolves capabilities correctly for gemini-3.8 models with official limits", () => {
+    const caps = getCapabilitiesForModel("antigravity", "gemini-3.8-flash-high");
+    expect(caps.vision).toBe(true);
+    expect(caps.reasoning).toBe(true);
+    expect(caps.thinkingFormat).toBe("gemini-level");
+    expect(caps.contextWindow).toBe(1048576);
+    expect(caps.maxOutput).toBe(65536);
+  });
+
+  it("defines pricing matching gemini-3.7-flash baseline", () => {
+    expect(MODEL_PRICING["gemini-3.8-flash"]).toEqual(MODEL_PRICING["gemini-3.7-flash"]);
+    expect(MODEL_PRICING["gemini-3.8-flash-high"]).toEqual(MODEL_PRICING["gemini-3.7-flash-high"]);
+    expect(MODEL_PRICING["gemini-3.8-flash-medium"]).toEqual(MODEL_PRICING["gemini-3.7-flash-medium"]);
+    expect(MODEL_PRICING["gemini-3.8-flash-low"]).toEqual(MODEL_PRICING["gemini-3.7-flash-low"]);
+  });
+});

--- a/tests/unit/gemini-3.8-antigravity.test.js
+++ b/tests/unit/gemini-3.8-antigravity.test.js
@@ -3,6 +3,7 @@ import { getCapabilitiesForModel } from "../../open-sse/providers/capabilities.j
 import antigravityRegistry from "../../open-sse/providers/registry/antigravity.js";
 import geminiRegistry from "../../open-sse/providers/registry/gemini.js";
 import { MODEL_PRICING } from "../../open-sse/providers/pricing.js";
+import { AntigravityExecutor } from "../../open-sse/executors/antigravity.js";
 
 describe("Gemini 3.8 Flash Support & Config", () => {
   it("registers gemini-3.8-flash tiered models in antigravity provider registry", () => {
@@ -32,5 +33,19 @@ describe("Gemini 3.8 Flash Support & Config", () => {
     expect(MODEL_PRICING["gemini-3.8-flash-high"]).toEqual(MODEL_PRICING["gemini-3.7-flash-high"]);
     expect(MODEL_PRICING["gemini-3.8-flash-medium"]).toEqual(MODEL_PRICING["gemini-3.7-flash-medium"]);
     expect(MODEL_PRICING["gemini-3.8-flash-low"]).toEqual(MODEL_PRICING["gemini-3.7-flash-low"]);
+  });
+
+  it("buildHeaders selects v2 User-Agent based on model argument without instance state", () => {
+    const executor = new AntigravityExecutor();
+    const creds = { accessToken: "tok-test" };
+
+    const h38 = executor.buildHeaders(creds, true, "https://example.com", "gemini-3.8-flash-high");
+    expect(h38["User-Agent"]).toContain("2.8.0");
+
+    const h37 = executor.buildHeaders(creds, true, "https://example.com", "gemini-3.7-flash");
+    expect(h37["User-Agent"]).not.toContain("2.8.0");
+
+    executor.transformRequest("gemini-3.8-flash-high", {}, true, creds);
+    expect(executor._currentModel).toBeUndefined();
   });
 });

--- a/tests/unit/gemini-38-integration.test.js
+++ b/tests/unit/gemini-38-integration.test.js
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { getModelUpstreamId } from "../../open-sse/config/providerModels.js";
+import { AntigravityExecutor } from "../../open-sse/executors/antigravity.js";
+import { applyThinking, stripThinkingSuffix } from "../../open-sse/translator/concerns/thinkingUnified.js";
+import gemini from "../../open-sse/providers/registry/gemini.js";
+import { MODEL_PRICING } from "../../open-sse/providers/pricing.js";
+import { MITM_TOOLS } from "../../src/shared/constants/cliTools.js";
+
+const require = createRequire(import.meta.url);
+const mitmConfig = require("../../src/mitm/config.js");
+const here = dirname(fileURLToPath(import.meta.url));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Gemini 3.8 Antigravity tiers", () => {
+  it.each(["high", "medium", "low"])(
+    "maps the %s tier to the shared upstream model with matching thinking level",
+    (tier) => {
+      const publicModel = `gemini-3.8-flash-${tier}`;
+      const upstreamModel = getModelUpstreamId("ag", publicModel);
+      const body = {
+        model: stripThinkingSuffix(upstreamModel),
+        request: {
+          contents: [{ role: "user", parts: [{ text: "hello" }] }],
+          generationConfig: {},
+        },
+      };
+
+      applyThinking("antigravity", upstreamModel, body, "antigravity");
+      const finalBody = new AntigravityExecutor().transformRequest(
+        publicModel,
+        body,
+        true,
+        { projectId: "project", connectionId: "connection" }
+      );
+
+      expect(upstreamModel).toBe(`gemini-3.8-flash-tiered(${tier})`);
+      expect(finalBody.model).toBe("gemini-3.8-flash-tiered");
+      expect(finalBody.request.generationConfig.thinkingConfig).toEqual({
+        thinkingLevel: tier,
+        includeThoughts: true,
+      });
+    }
+  );
+});
+
+describe("Gemini 3.8 MITM model extraction", () => {
+  it.each(["high", "medium", "low"])("extracts the %s thinking tier for gemini-3.8-flash-tiered", (tier) => {
+    const body = Buffer.from(JSON.stringify({
+      request: { generationConfig: { thinkingConfig: { thinkingLevel: tier } } },
+    }));
+
+    expect(mitmConfig.extractModel(
+      "/v1internal/models/gemini-3.8-flash-tiered:streamGenerateContent",
+      body
+    )).toBe(`gemini-3.8-flash-${tier}`);
+  });
+
+  it("defaults invalid or missing thinking levels to medium", () => {
+    const body = Buffer.from(JSON.stringify({
+      request: { generationConfig: { thinkingConfig: { thinkingLevel: "unknown" } } },
+    }));
+
+    expect(mitmConfig.extractModel(
+      "/v1internal/models/gemini-3.8-flash-tiered:streamGenerateContent",
+      body
+    )).toBe("gemini-3.8-flash-medium");
+  });
+});
+
+describe("Gemini 3.8 MITM tools and catalog", () => {
+  it("includes gemini-3.8-flash tiers in MITM_TOOLS defaultModels", () => {
+    const defaultModelIds = MITM_TOOLS.antigravity.defaultModels.map((m) => m.id);
+    expect(defaultModelIds).toContain("gemini-3.8-flash-high");
+    expect(defaultModelIds).toContain("gemini-3.8-flash-medium");
+    expect(defaultModelIds).toContain("gemini-3.8-flash-low");
+  });
+
+  it("exposes the direct Gemini 3.8 API models and pricing", () => {
+    const ids = gemini.models.map((model) => model.id);
+    expect(ids).toContain("gemini-3.8-flash");
+    expect(MODEL_PRICING["gemini-3.8-flash"]).toMatchObject({ input: 1.5, output: 7.5 });
+  });
+
+  it("keeps the standalone CLI Antigravity catalog synchronized", () => {
+    const source = readFileSync(join(here, "../../cli/src/cli/menus/providers.js"), "utf8");
+    const agCatalog = source.match(/\n  ag: \[([\s\S]*?)\n  \],/)?.[1] || "";
+
+    expect(agCatalog).toContain("gemini-3.8-flash-high");
+    expect(agCatalog).toContain("gemini-3.8-flash-medium");
+    expect(agCatalog).toContain("gemini-3.8-flash-low");
+  });
+});


### PR DESCRIPTION
## Summary

Add support for the `gemini-3.8-flash` model and its tiered variants (`gemini-3.8-flash-high`, `gemini-3.8-flash-medium`, `gemini-3.8-flash-low`) to the Antigravity provider (as well as direct Gemini provider).

## Key Changes

1. **Provider Registry**:
   - `open-sse/providers/registry/antigravity.js`: Register `gemini-3.8-flash-high`, `gemini-3.8-flash-medium`, and `gemini-3.8-flash-low` with upstream IDs `gemini-3.8-flash-tiered(high)`, `gemini-3.8-flash-tiered(medium)`, and `gemini-3.8-flash-tiered(low)`.
   - `open-sse/providers/registry/gemini.js`: Register direct API model `gemini-3.8-flash`.

2. **Google Cloud Code Assist Client Version Gating**:
   - Upstream Google Cloud Code Assist (`daily-cloudcode-pa.googleapis.com`) gates Gemini 3.8 models behind client version >= 2.8.0.
   - `open-sse/providers/shared.js` & `open-sse/config/appConstants.js`: Define `ANTIGRAVITY_IDE_VERSION_V2 = "2.8.0"` and `ANTIGRAVITY_IDE_USER_AGENT_V2`.
   - `open-sse/executors/antigravity.js`: Dynamically select `ANTIGRAVITY_HEADERS_V2` when the request targets Gemini 3.8 models, preventing HTTP 404 (`"Requested entity was not found."`) while maintaining baseline User-Agent for older models.

3. **Capabilities & Pricing**:
   - `open-sse/providers/capabilities.js`: Add capability entry for `*gemini-3.8*` (1M context, 64K max output, reasoning with `gemini-level` thinking format, multimodal text/image/audio/video).
   - `open-sse/providers/pricing.js`: Add pricing entries for `gemini-3.8-flash` and its tiered variants.

4. **Usage & Quotas**:
   - `open-sse/services/usage/google.js`: Include `gemini-3.8-flash-{high,medium,low}` in `importantModels` for Antigravity quota bar rendering.

5. **MITM & CLI**:
   - `src/mitm/config.js`: Add model synonyms and update `extractModel` for `gemini-3.8-flash-tiered`.
   - `src/shared/constants/cliTools.js`: Add Gemini 3.8 Flash tiers to `MITM_TOOLS.antigravity.defaultModels` and `modelAliases`.
   - `cli/src/cli/menus/providers.js`: Synchronize CLI provider catalog under `ag`.

6. **Tests**:
   - `tests/unit/gemini-3.8-antigravity.test.js`: Verify registry entries, capabilities, and pricing.
   - `tests/unit/gemini-38-integration.test.js`: Verify upstream model resolution (`gemini-3.8-flash-tiered(${tier})`), thinkingConfig mapping, MITM extraction, and CLI menu sync.
   - `tests/unit/antigravity-quota-gemini-3.8.test.js`: Verify quota bar parsing for Gemini 3.8 Flash tiers.

## Verification
- Unit test suite: all 30 tests across Gemini 3.7 and 3.8 passed.
- Baseline scripts: `verify-providers.mjs`, `verify-alias.mjs`, and `verify-oauth-urls.mjs` all passed byte-for-byte.