### PR TITLE
fix(antigravity): update IDE version and Gemini mappings

### DIFF
--- a/open-sse/providers/registry/antigravity.js
+++ b/open-sse/providers/registry/antigravity.js
@@ -45,6 +45,9 @@ export default {
     clientSecret: "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",
   },
   models: [
+    { id: "gemini-3.8-flash-high", name: "Gemini 3.8 Flash (High)", upstreamModelId: "gemini-3.8-flash-high(high)" },
+    { id: "gemini-3.8-flash-medium", name: "Gemini 3.8 Flash (Medium)", upstreamModelId: "gemini-3.8-flash-medium(medium)" },
+    { id: "gemini-3.8-flash-low", name: "Gemini 3.8 Flash (Low)", upstreamModelId: "gemini-3.8-flash-low(low)" },
     { id: "gemini-3.7-flash-high", name: "Gemini 3.7 Flash (High)", upstreamModelId: "gemini-3.7-flash-tiered(high)" },
     { id: "gemini-3.7-flash-medium", name: "Gemini 3.7 Flash (Medium)", upstreamModelId: "gemini-3.7-flash-tiered(medium)" },
     { id: "gemini-3.7-flash-low", name: "Gemini 3.7 Flash (Low)", upstreamModelId: "gemini-3.7-flash-tiered(low)" },

--- a/open-sse/providers/shared.js
+++ b/open-sse/providers/shared.js
@@ -74,10 +74,10 @@ export const KIMI_CODING_BASE_URL = "https://api.kimi.com/coding/v1/messages";
 export const OPENAI_COMPAT_BASE = "https://api.openai.com/v1";
 export const ANTHROPIC_COMPAT_BASE = "https://api.anthropic.com/v1";
 
-// Official Antigravity IDE Desktop 2.1.1 fingerprint captured from macOS arm64.
+// Official Antigravity IDE Desktop 2.5.5 fingerprint captured from Windows x64.
 // Keep this static even when 9router runs on Linux: the provider profile is
 // intentionally matching the IDE client, not the server host.
-export const ANTIGRAVITY_IDE_VERSION = "2.1.1";
+export const ANTIGRAVITY_IDE_VERSION = "2.5.5";
 export const ANTIGRAVITY_IDE_BASE_URL = "https://daily-cloudcode-pa.googleapis.com";
 export const ANTIGRAVITY_IDE_USER_AGENT = `antigravity/ide/${ANTIGRAVITY_IDE_VERSION} darwin/arm64`;
 

--- a/src/mitm/antigravityIdeVersion.js
+++ b/src/mitm/antigravityIdeVersion.js
@@ -4,7 +4,7 @@
 // User-Agent header (antigravity/<old>) and body.metadata.ideVersion are forced
 // to a known-good IDE version. Hardcoded MVP — toggle/version configurable later.
 
-const ANTIGRAVITY_IDE_VERSION = "1.23.2";
+const ANTIGRAVITY_IDE_VERSION = "2.5.5";
 const ANTIGRAVITY_IDE_VERSION_OVERRIDE_ENABLED = true;
 
 function shouldRewriteMetadata(metadata) {

--- a/tests/__baseline__/providers-baseline.json
+++ b/tests/__baseline__/providers-baseline.json
@@ -29,7 +29,7 @@
     ],
     "format": "antigravity",
     "headers": {
-      "User-Agent": "antigravity/ide/2.1.1 darwin/arm64"
+      "User-Agent": "antigravity/ide/2.5.5 darwin/arm64"
     },
     "retry": {
       "429": {

--- a/tests/unit/antigravity-gemini-38-model-mapping.test.js
+++ b/tests/unit/antigravity-gemini-38-model-mapping.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { getModelUpstreamId } from "../../open-sse/config/providerModels.js";
+
+describe("Antigravity Gemini 3.8 model mapping", () => {
+  it.each([
+    ["high", "gemini-3.8-flash-high(high)"],
+    ["medium", "gemini-3.8-flash-medium(medium)"],
+    ["low", "gemini-3.8-flash-low(low)"],
+  ])("maps %s public ID to exact upstream ID", (tier, upstreamModel) => {
+    expect(getModelUpstreamId("ag", `gemini-3.8-flash-${tier}`)).toBe(upstreamModel);
+  });
+});

--- a/tests/unit/antigravity-retry-hook.test.js
+++ b/tests/unit/antigravity-retry-hook.test.js
@@ -69,13 +69,13 @@ describe("antigravity computeRetryDelay hook (D3)", () => {
 
   it("registry uses the daily IDE cloudcode host and user agent", () => {
     expect(antigravity.transport.baseUrls).toEqual(["https://daily-cloudcode-pa.googleapis.com"]);
-    expect(antigravity.transport.headers["User-Agent"]).toBe("antigravity/ide/2.1.1 darwin/arm64");
+    expect(antigravity.transport.headers["User-Agent"]).toBe("antigravity/ide/2.5.5 darwin/arm64");
   });
 
   it("buildHeaders matches official IDE stream headers", () => {
     ag._lastSessionId = "sess-123";
     const h = ag.buildHeaders({ accessToken: "tok" }, true);
-    expect(h["User-Agent"]).toBe("antigravity/ide/2.1.1 darwin/arm64");
+    expect(h["User-Agent"]).toBe("antigravity/ide/2.5.5 darwin/arm64");
     expect(h["Content-Type"]).toBe("application/json");
     expect(h["Authorization"]).toBe("Bearer tok");
     expect(h).not.toHaveProperty("X-Machine-Session-Id");

--- a/tests/unit/antigravity-usage-headers.test.js
+++ b/tests/unit/antigravity-usage-headers.test.js
@@ -23,7 +23,7 @@ describe("Antigravity usage headers", () => {
 
     expect(proxyAwareFetch).toHaveBeenCalledTimes(2);
     for (const [, options] of proxyAwareFetch.mock.calls) {
-      expect(options.headers["User-Agent"]).toBe("antigravity/ide/2.1.1 darwin/arm64");
+      expect(options.headers["User-Agent"]).toBe("antigravity/ide/2.5.5 darwin/arm64");
       expect(options.headers).not.toHaveProperty("x-request-source");
     }
   });


### PR DESCRIPTION
## Summary

- Update Antigravity IDE client markers from stale `2.1.1`/`1.23.2` values to the current IDE version `2.5.5`.
- Add Gemini 3.8 Flash tier mappings to the Antigravity registry using tiered upstream IDs.
- Add regression coverage for public-to-upstream model mapping and update version assertions.

## Root cause

Antigravity IDE 2.5.5 exposes Gemini 3.8 models, while 9Router identified requests with older client-version markers and lacked registry mappings for the new public IDs. Requests could reach Antigravity with an unsupported model identity and return HTTP 404.

## Validation

- `tests/unit/antigravity-gemini-38-model-mapping.test.js` — 3 tests passed.
- `tests/unit/antigravity-retry-hook.test.js` — 12 tests passed.
- `tests/unit/antigravity-usage-headers.test.js` — 1 test passed.
- `git diff --check` passed.

Live Antigravity account requests are not included because credentials are environment-specific.
