### PR TITLE
fix(opencode): route Muse Spark models to Responses API and declare vision

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -3,7 +3,8 @@ import REGISTRY from "../providers/registry/index.js";
 // PROVIDER_MODELS now built from providers/registry (transport + models co-located)
 import { PROVIDER_MODELS } from "../providers/index.js";
 import { modelQuotaFamily, modelStrip, modelTargetFormat, modelSupportedFormats, normalizeModelId } from "../providers/models/schema.js";
-import { CODEX_REVIEW_SUFFIX } from "../providers/models/helpers.js";
+import { CODEX_REVIEW_SUFFIX, isMuseSparkModel } from "../providers/models/helpers.js";
+import { FORMATS } from "../translator/formats.js";
 export { PROVIDER_MODELS };
 
 
@@ -49,6 +50,9 @@ export function findModelName(aliasOrId, modelId) {
 }
 
 export function getModelTargetFormat(aliasOrId, modelId) {
+  if ((!aliasOrId || aliasOrId === "oc" || aliasOrId === "opencode") && isMuseSparkModel(modelId)) {
+    return FORMATS.OPENAI_RESPONSES;
+  }
   const models = PROVIDER_MODELS[aliasOrId];
   if (!models) return null;
   return modelTargetFormat(findModel(models, modelId, aliasOrId));

--- a/open-sse/executors/opencode.js
+++ b/open-sse/executors/opencode.js
@@ -4,10 +4,14 @@ import { PROVIDERS } from "../config/providers.js";
 import { getThinkingLevels } from "../providers/thinkingLevels.js";
 import { injectReasoningContent } from "../utils/reasoningContentInjector.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
+import { isMuseSparkModel } from "../providers/models/helpers.js";
 
 const OPENCODE_UA = "opencode";
 // Models served by /zen/v1/responses; every other model stays on /chat/completions.
-const RESPONSES_MODELS = new Set(["muse-spark-1.2-contributor-free"]);
+const RESPONSES_MODELS = new Set([
+  "muse-spark-1.2-contributor-free",
+  "muse-spark-1.3-contributor-free",
+]);
 
 function generateRequestId() {
   return `msg_${crypto.randomUUID().replace(/-/g, "")}`;
@@ -23,7 +27,8 @@ function baseModelId(model) {
 }
 
 function isResponsesModel(model) {
-  return RESPONSES_MODELS.has(baseModelId(model));
+  const base = baseModelId(model);
+  return RESPONSES_MODELS.has(base) || isMuseSparkModel(base);
 }
 
 function resolveOpencodeSession(body, credentials) {

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -126,9 +126,10 @@ export const MODEL_CAPABILITIES = {
   "kimi-for-coding-highspeed": { vision: true, videoInput: true, reasoning: true, thinkingFormat: "kimi", thinkingCanDisable: false, contextWindow: 262144, maxOutput: 65536 },
   "kimi-k2.7-code":    { vision: true, videoInput: true, reasoning: true, thinkingFormat: "kimi", thinkingCanDisable: false, contextWindow: 262144, maxOutput: 65536 },
   "kimi-k2.7-code-highspeed": { vision: true, videoInput: true, reasoning: true, thinkingFormat: "kimi", thinkingCanDisable: false, contextWindow: 262144, maxOutput: 65536 },
-  // OpenCode Free Muse Spark — OpenAI Responses reasoning supports up to xhigh.
-  "muse-spark-1.2-contributor-free": { reasoning: true, thinkingFormat: "openai", contextWindow: 1048576, maxOutput: 131072 },
-  "muse-spark-1.3-contributor-free": { reasoning: true, thinkingFormat: "openai", contextWindow: 1048576, maxOutput: 131072 },
+  // OpenCode Free Muse Spark — multimodal (text+image per models.dev meta/muse-spark)
+  // via OpenAI Responses input_image; reasoning supports up to xhigh.
+  "muse-spark-1.2-contributor-free": { vision: true, reasoning: true, thinkingFormat: "openai", contextWindow: 1048576, maxOutput: 131072 },
+  "muse-spark-1.3-contributor-free": { vision: true, reasoning: true, thinkingFormat: "openai", contextWindow: 1048576, maxOutput: 131072 },
 };
 
 const KIRO_GPT_5_6_CAPABILITIES = { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 272000, maxOutput: 128000 };
@@ -337,8 +338,8 @@ export const PATTERN_CAPABILITIES = [
   { pattern: "*laguna*",        caps: { reasoning: true, thinkingFormat: "openai", contextWindow: 200000, maxOutput: 32000 } },
 
 
-  // ── OpenCode Free Muse Spark (OpenAI Responses reasoning supports up to xhigh) ─
-  { pattern: "*muse*spark*",    caps: { reasoning: true, thinkingFormat: "openai", contextWindow: 1048576, maxOutput: 131072 } },
+  // ── OpenCode Free Muse Spark (multimodal text+image; OpenAI Responses reasoning supports up to xhigh) ─
+  { pattern: "*muse*spark*",    caps: { vision: true, reasoning: true, thinkingFormat: "openai", contextWindow: 1048576, maxOutput: 131072 } },
   // ── Others ───────────────────────────────────────────────────────
   { pattern: "*hunyuan*",       caps: { reasoning: true, thinkingFormat: "hunyuan", contextWindow: 262144, maxOutput: 262144 } },
   { pattern: "hy3*",            caps: { reasoning: true, thinkingFormat: "hunyuan", contextWindow: 262144, maxOutput: 262144 } },

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -128,6 +128,7 @@ export const MODEL_CAPABILITIES = {
   "kimi-k2.7-code-highspeed": { vision: true, videoInput: true, reasoning: true, thinkingFormat: "kimi", thinkingCanDisable: false, contextWindow: 262144, maxOutput: 65536 },
   // OpenCode Free Muse Spark — OpenAI Responses reasoning supports up to xhigh.
   "muse-spark-1.2-contributor-free": { reasoning: true, thinkingFormat: "openai", contextWindow: 1048576, maxOutput: 131072 },
+  "muse-spark-1.3-contributor-free": { reasoning: true, thinkingFormat: "openai", contextWindow: 1048576, maxOutput: 131072 },
 };
 
 const KIRO_GPT_5_6_CAPABILITIES = { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 272000, maxOutput: 128000 };
@@ -335,6 +336,9 @@ export const PATTERN_CAPABILITIES = [
   { pattern: "*laguna-s-2.1*",  caps: { reasoning: true, thinkingFormat: "openai", contextWindow: 1000000, maxOutput: 32000 } },
   { pattern: "*laguna*",        caps: { reasoning: true, thinkingFormat: "openai", contextWindow: 200000, maxOutput: 32000 } },
 
+
+  // ── OpenCode Free Muse Spark (OpenAI Responses reasoning supports up to xhigh) ─
+  { pattern: "*muse*spark*",    caps: { reasoning: true, thinkingFormat: "openai", contextWindow: 1048576, maxOutput: 131072 } },
   // ── Others ───────────────────────────────────────────────────────
   { pattern: "*hunyuan*",       caps: { reasoning: true, thinkingFormat: "hunyuan", contextWindow: 262144, maxOutput: 262144 } },
   { pattern: "hy3*",            caps: { reasoning: true, thinkingFormat: "hunyuan", contextWindow: 262144, maxOutput: 262144 } },

--- a/open-sse/providers/models/helpers.js
+++ b/open-sse/providers/models/helpers.js
@@ -18,3 +18,10 @@ export function withCodexReviewModels(models) {
     ];
   });
 }
+
+export function isMuseSparkModel(modelId) {
+  if (!modelId || typeof modelId !== "string") return false;
+  const clean = modelId.replace(/\([^()]+\)\s*$/, "").trim();
+  const base = clean.includes("/") ? clean.split("/").pop() : clean;
+  return /^muse[-_]?spark(?:$|[-_:.\s])/i.test(base);
+}

--- a/open-sse/providers/registry/opencode.js
+++ b/open-sse/providers/registry/opencode.js
@@ -20,9 +20,10 @@ export default {
     noAuth: true,
   },
   models: [
-    // Only this model is served by /zen/v1/responses; the rest stay on
+    // Muse Spark models are served by /zen/v1/responses; the rest stay on
     // /chat/completions, so the format is declared per-model, not per-provider.
     { id: "muse-spark-1.2-contributor-free", name: "Muse Spark 1.2 Contributor Free", targetFormat: "openai-responses" },
+    { id: "muse-spark-1.3-contributor-free", name: "Muse Spark 1.3 Contributor Free", targetFormat: "openai-responses" },
   ],
   modelsFetcher: { url: "https://opencode.ai/zen/v1/models", type: "opencode-free" },
   passthroughModels: true,

--- a/tests/unit/executor-const-guard.test.js
+++ b/tests/unit/executor-const-guard.test.js
@@ -55,12 +55,17 @@ describe("OpenCode Free endpoint routing", () => {
     expect(opencode.transport.format).toBeUndefined();
     const muse = opencode.models.find((m) => m.id === MUSE);
     expect(muse?.targetFormat).toBe("openai-responses");
+    const muse13 = opencode.models.find((m) => m.id === "muse-spark-1.3-contributor-free");
+    expect(muse13?.targetFormat).toBe("openai-responses");
   });
 
   it("routes Muse Spark to /responses and every other model to /chat/completions", () => {
     const executor = new OpenCodeExecutor();
     expect(executor.buildUrl(MUSE)).toBe("https://opencode.ai/zen/v1/responses");
     expect(executor.buildUrl(`${MUSE}(xhigh)`)).toBe("https://opencode.ai/zen/v1/responses");
+    expect(executor.buildUrl("muse-spark-1.3-contributor-free")).toBe("https://opencode.ai/zen/v1/responses");
+    expect(executor.buildUrl("muse-spark-1.4-contributor-free")).toBe("https://opencode.ai/zen/v1/responses");
+    expect(executor.buildUrl("muse-spark-2.0-contributor-free(xhigh)")).toBe("https://opencode.ai/zen/v1/responses");
     expect(executor.buildUrl("big-pickle")).toBe("https://opencode.ai/zen/v1/chat/completions");
     expect(executor.buildUrl("hy3-free")).toBe("https://opencode.ai/zen/v1/chat/completions");
   });

--- a/tests/unit/opencode-muse-spark-thinking.test.js
+++ b/tests/unit/opencode-muse-spark-thinking.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { getCapabilitiesForModel } from "../../open-sse/providers/capabilities.js";
-import { PROVIDER_MODELS } from "../../open-sse/config/providerModels.js";
+import { PROVIDER_MODELS, getModelTargetFormat } from "../../open-sse/config/providerModels.js";
 import { getThinkingLevels } from "../../open-sse/providers/thinkingLevels.js";
 import { FORMATS } from "../../open-sse/translator/formats.js";
 import { OpenCodeExecutor } from "../../open-sse/executors/opencode.js";
@@ -19,25 +19,31 @@ const input = [{
 describe("OpenCode Free Muse Spark thinking", () => {
   it("advertises reasoning and the requested model limits", () => {
     expect(PROVIDER_MODELS.oc?.some((model) => model.id === MODEL)).toBe(true);
-    expect(getCapabilitiesForModel(PROVIDER, MODEL)).toMatchObject({
-      reasoning: true,
-      thinkingFormat: "openai",
-      contextWindow: 1048576,
-      maxOutput: 131072,
-    });
-    expect(getCapabilitiesForModel(PROVIDER, `oc/${MODEL}`)).toMatchObject({
-      reasoning: true,
-      contextWindow: 1048576,
-      maxOutput: 131072,
-    });
-    expect(getThinkingLevels(PROVIDER, MODEL)).toEqual([
-      "none",
-      "minimal",
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-    ]);
+    expect(PROVIDER_MODELS.oc?.some((model) => model.id === "muse-spark-1.3-contributor-free")).toBe(true);
+    for (const m of [MODEL, "muse-spark-1.3-contributor-free", "muse-spark-1.4-contributor-free", "muse-spark-2.0-contributor-free"]) {
+      expect(getCapabilitiesForModel(PROVIDER, m)).toMatchObject({
+        reasoning: true,
+        thinkingFormat: "openai",
+        contextWindow: 1048576,
+        maxOutput: 131072,
+      });
+      expect(getCapabilitiesForModel(PROVIDER, `oc/${m}`)).toMatchObject({
+        reasoning: true,
+        contextWindow: 1048576,
+        maxOutput: 131072,
+      });
+      expect(getThinkingLevels(PROVIDER, m)).toEqual([
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+      ]);
+      expect(getModelTargetFormat("oc", m)).toBe(FORMATS.OPENAI_RESPONSES);
+      expect(getModelTargetFormat("opencode", m)).toBe(FORMATS.OPENAI_RESPONSES);
+      expect(getModelTargetFormat("openrouter", m)).toBeNull();
+    }
   });
 
   it("clamps max to xhigh and emits the Responses reasoning shape", () => {
@@ -90,5 +96,40 @@ describe("OpenCode Free Muse Spark thinking", () => {
     expect(out.reasoning).toEqual({ effort: "xhigh", summary: "auto" });
     expect(out.max_output_tokens).toBe(131072);
     expect(out.max_tokens).toBeUndefined();
+  });
+
+  it("routes muse-spark-1.3-contributor-free and future Muse Spark models to Responses API", () => {
+    const executor = new OpenCodeExecutor();
+    const futureModel = "muse-spark-1.4-contributor-free";
+
+    for (const m of ["muse-spark-1.3-contributor-free", futureModel]) {
+      expect(executor.buildUrl(m)).toBe("https://opencode.ai/zen/v1/responses");
+      expect(executor.buildUrl(`${m}(high)`)).toBe("https://opencode.ai/zen/v1/responses");
+      expect(getModelTargetFormat("oc", m)).toBe("openai-responses");
+
+      const body = {
+        model: `oc/${m}`,
+        messages: [{ role: "user", content: "Hello" }],
+        reasoning_effort: "high",
+        max_tokens: 2048,
+      };
+
+      const translated = translateRequest(
+        FORMATS.OPENAI,
+        FORMATS.OPENAI_RESPONSES,
+        m,
+        body,
+        true,
+        {},
+        PROVIDER,
+      );
+      const out = executor.transformRequest(m, translated, true, {
+        connectionId: "opencode-muse-spark-13-test",
+      });
+
+      expect(out.reasoning).toEqual({ effort: "high", summary: "auto" });
+      expect(out.max_output_tokens).toBe(2048);
+      expect(out.max_tokens).toBeUndefined();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Route all current and future Muse Spark models to the OpenAI Responses API (`/zen/v1/responses`) on OpenCode Free instead of `/zen/v1/chat/completions`, fixing HTTP 500 (`"Internal server error"`) encountered when using `muse-spark-1.3-contributor-free`. Also declare `vision: true` for Muse Spark models so image input is no longer stripped before translation.

> **Note**: This accompanies PR #3736 (`feat(antigravity): add Gemini 3.8 Flash model support`), as Gemini 3.8 Flash and Muse Spark 1.3 were released on the same day.

## Problem

`muse-spark-1.2-contributor-free` succeeded while `muse-spark-1.3-contributor-free` failed with `HTTP 500: [500]: {"type":"error","error":{"type":"error","message":"Internal server error"}}`. OpenCode's `/zen/v1/chat/completions` endpoint rejects Muse Spark models with a 500 internal server error; they are only served by `/zen/v1/responses`. Previously, Responses API routing was hardcoded specifically to `muse-spark-1.2-contributor-free`:
- `open-sse/executors/opencode.js`: `RESPONSES_MODELS` was a `Set` containing only `muse-spark-1.2-contributor-free`. `isResponsesModel` returned `false` for `muse-spark-1.3-contributor-free`, routing it to `/chat/completions`.
- `open-sse/config/providerModels.js`: `getModelTargetFormat` only checked static model definitions; unregistered models fell back to provider default (`"openai"` / Chat Completions).
- `open-sse/providers/capabilities.js`: `MODEL_CAPABILITIES` only had an exact entry for `muse-spark-1.2-contributor-free`.

Additionally, Muse Spark models declared `vision: false`, so `chatCore` stripped every image block to `[image omitted: model has no vision support]` before translation — even though the models accept image input per `models.dev` (`meta/muse-spark` modalities include `image`) via Responses `input_image`. Exact capability entries bypass `refine()`, and the `*muse*spark*` pattern also lacked `vision`, so no fallback rescued it.

## Solution

1. **Model Pattern Matcher (`open-sse/providers/models/helpers.js`)**:
   - Added `isMuseSparkModel(modelId)` to identify all Muse Spark models (stripping thinking suffixes and vendor prefixes):
     ```javascript
     export function isMuseSparkModel(modelId) {
       if (!modelId || typeof modelId !== "string") return false;
       const clean = modelId.replace(/\([^()]+\)\s*$/, "").trim();
       const base = clean.includes("/") ? clean.split("/").pop() : clean;
       return /^muse[-_]?spark(?:$|[-_:.\s])/i.test(base);
     }
     ```

2. **OpenCode-Scoped Target Format (`open-sse/config/providerModels.js`)**:
   - In `getModelTargetFormat(aliasOrId, modelId)`, any Muse Spark model on OpenCode (`!aliasOrId || aliasOrId === "oc" || aliasOrId === "opencode"`) returns `FORMATS.OPENAI_RESPONSES`, ensuring `chatCore` translates requests to the Responses API wire format and translates responses back to the client format.
   - Non-OpenCode providers are not overridden, preserving standard Chat Completions routing for resellers/custom proxies.

3. **OpenCode Executor (`open-sse/executors/opencode.js`)**:
   - Updated `RESPONSES_MODELS` to include `muse-spark-1.3-contributor-free`.
   - Updated `isResponsesModel(model)` to check `RESPONSES_MODELS.has(base) || isMuseSparkModel(base)`.
   - `buildUrl` routes to `${base}/zen/v1/responses` and `transformRequest` normalizes token caps (`max_output_tokens`) and reasoning effort for all Muse Spark models.

4. **Model Registry & Capabilities (`open-sse/providers/registry/opencode.js`, `open-sse/providers/capabilities.js`)**:
   - Registered `muse-spark-1.3-contributor-free` in `opencode.js` models.
   - Added `muse-spark-1.3-contributor-free` to `MODEL_CAPABILITIES` and added `{ pattern: "*muse*spark*", caps: { vision: true, reasoning: true, thinkingFormat: "openai", contextWindow: 1048576, maxOutput: 131072 } }` to `PATTERN_CAPABILITIES`.
   - Declared `vision: true` on both exact entries and the pattern (covers future `1.4`/`2.0`). Scoped to vision only: the Responses translator maps `image_url` <-> `input_image`, but has no file/audio mapping yet.

5. **Tests (`tests/unit/opencode-muse-spark-thinking.test.js`, `tests/unit/executor-const-guard.test.js`)**:
   - Added test coverage for `muse-spark-1.3-contributor-free` and forward-compatible future Muse Spark models (`muse-spark-1.4-contributor-free`, `muse-spark-2.0-contributor-free`), verifying URL routing, capabilities, thinking levels, request transformation, and provider scoping.

## Verification

- `npx vitest run unit/opencode-muse-spark-thinking.test.js`: All 5 tests passed.
- Baseline scripts (`verify-providers.mjs`, `verify-alias.mjs`, `verify-oauth-urls.mjs`): All passed byte-for-byte.
- End-to-end request translation simulation: Verified `muse-spark-1.2-contributor-free`, `muse-spark-1.3-contributor-free`, and future models emit Responses API shape (`input`, `max_output_tokens`, `/zen/v1/responses`) while non-Muse models (`big-pickle`) remain on `/chat/completions`.
- Vision: `getCapabilitiesForModel("opencode", ...)` returns `vision=true` for 1.2/1.3/1.4 (plus `oc` alias); `stripUnsupportedModalities` preserves `image_url` blocks instead of replacing them with the no-vision placeholder.
- Regression: `unit/capabilities.test.js`, `unit/modality-strip.test.js`, `unit/combo-routing.test.js` — all pass (24/24 with the Spark suite).
