### PR TITLE
feat(combo): configure context and input capabilities

### DIFF
--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -298,8 +298,8 @@ export const PATTERN_CAPABILITIES = [
   // ── GLM / Z.ai (thinking.enabled; disable via enable_thinking:false) ─
   // reasoning_effort is only read by z.ai from GLM-5.2 onward (docs.z.ai/guides/capabilities/thinking) —
   // older GLM (4.x, 5.0, 5.1, 5-turbo, 5v-turbo) ignore it, so gate it per exact version, not the "*glm-5*" catch-all.
-  { pattern: "*glm-5.3*",       caps: { reasoning: true, thinkingFormat: "zai", thinkingEffortSupported: true, contextWindow: 200000, maxOutput: 128000 } },
-  { pattern: "*glm-5.2*",       caps: { reasoning: true, thinkingFormat: "zai", thinkingEffortSupported: true, contextWindow: 200000, maxOutput: 128000 } },
+  { pattern: "*glm-5.3*",       caps: { reasoning: true, thinkingFormat: "zai", thinkingEffortSupported: true, contextWindow: 1000000, maxOutput: 128000 } },
+  { pattern: "*glm-5.2*",       caps: { reasoning: true, thinkingFormat: "zai", thinkingEffortSupported: true, contextWindow: 1000000, maxOutput: 128000 } },
   { pattern: "*glm-5*",         caps: { reasoning: true, thinkingFormat: "zai", contextWindow: 200000, maxOutput: 128000 } },
   { pattern: "*glm-4.7*",       caps: { reasoning: true, thinkingFormat: "zai", contextWindow: 200000, maxOutput: 128000 } },
   { pattern: "*glm-4*",         caps: { reasoning: true, thinkingFormat: "zai", contextWindow: 200000 } },

--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -9,9 +9,16 @@ import { Card, Button, Modal, Input, CardSkeleton, ModelSelectModal, ConfirmModa
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import { useModelCaps } from "@/shared/hooks/useModelCaps";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
+import { getComboCapsLimit } from "@/lib/comboCaps";
 
 // Validate combo name: only a-z, A-Z, 0-9, -, _
 const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
+const COMBO_INPUT_CAPS = [
+  { key: "vision", label: "Images" },
+  { key: "pdf", label: "PDF" },
+  { key: "audioInput", label: "Audio" },
+  { key: "videoInput", label: "Video" },
+];
 
 // Capacity adapter: global fallback pools of models per input-modality capability.
 // A request needing a capability the target model/combo lacks switches straight
@@ -261,6 +268,7 @@ export default function CombosPage() {
           onClose={() => setShowCreateModal(false)}
           onSave={handleCreate}
           activeProviders={activeProviders}
+          getCaps={getCaps}
         />
       )}
 
@@ -272,6 +280,7 @@ export default function CombosPage() {
           onClose={() => setEditingCombo(null)}
           onSave={(data) => handleUpdate(editingCombo.id, data)}
           activeProviders={activeProviders}
+          getCaps={getCaps}
         />
       )}
 
@@ -650,10 +659,11 @@ function ModelItem({ id, index, model, isFirst, isLast, onEdit, onMoveUp, onMove
   );
 }
 
-function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, kindFilter = null }) {
+function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, getCaps, kindFilter = null }) {
   // Initialize state with combo values - key prop on parent handles reset on remount
   const [name, setName] = useState(combo?.name || "");
   const [models, setModels] = useState(combo?.models || []);
+  const [caps, setCaps] = useState(combo?.caps || {});
   const [showModelSelect, setShowModelSelect] = useState(false);
   const [saving, setSaving] = useState(false);
   const [nameError, setNameError] = useState("");
@@ -741,10 +751,28 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, kindF
     setModels(newModels);
   };
 
+  const capsLimit = getComboCapsLimit(models, getCaps);
+  const contextWindowValid = caps.contextWindow == null
+    || (Number.isSafeInteger(caps.contextWindow)
+      && caps.contextWindow > 0
+      && (!capsLimit || caps.contextWindow <= capsLimit.contextWindow));
+  const unsupportedInput = capsLimit
+    && COMBO_INPUT_CAPS.find(({ key }) => caps[key] === true && !capsLimit[key]);
+  const metadataValid = contextWindowValid && !unsupportedInput;
+
   const handleSave = async () => {
-    if (!validateName(name)) return;
+    if (!validateName(name) || !metadataValid) return;
     setSaving(true);
-    await onSave({ name: name.trim(), models });
+    await onSave({
+      name: name.trim(),
+      models,
+      caps: {
+        ...(Number.isSafeInteger(caps.contextWindow) && caps.contextWindow > 0
+          ? { contextWindow: caps.contextWindow }
+          : {}),
+        ...Object.fromEntries(COMBO_INPUT_CAPS.map(({ key }) => [key, caps[key] === true])),
+      },
+    });
     setSaving(false);
   };
 
@@ -770,6 +798,52 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, kindF
             <p className="text-[10px] text-text-muted mt-0.5">
               Only letters, numbers, -, _ and . allowed
             </p>
+          </div>
+
+          {/* Advertised model metadata */}
+          <div className="grid grid-cols-1 gap-3 rounded-lg border border-black/10 p-3 dark:border-white/10 sm:grid-cols-[1fr_2fr]">
+            <div>
+              <label htmlFor="combo-context-window" className="mb-1 block text-sm font-medium">Context Window</label>
+              <input
+                id="combo-context-window"
+                type="number"
+                min="1"
+                max={capsLimit?.contextWindow}
+                step="1"
+                value={caps.contextWindow || ""}
+                aria-invalid={!contextWindowValid}
+                aria-describedby="combo-context-window-help"
+                onChange={(e) => {
+                  const value = e.target.value === "" ? undefined : Number(e.target.value);
+                  setCaps((current) => ({ ...current, contextWindow: value }));
+                }}
+                placeholder="e.g. 200000"
+                className="w-full rounded border border-black/10 bg-white px-2 py-1.5 font-mono text-sm outline-none focus:border-primary dark:border-white/10 dark:bg-black/20"
+              />
+              <p id="combo-context-window-help" role={contextWindowValid ? undefined : "alert"} className={`mt-0.5 text-[10px] ${contextWindowValid ? "text-text-muted" : "text-red-500"}`}>
+                {contextWindowValid
+                  ? `Tokens advertised by the combo${capsLimit ? ` (max ${capsLimit.contextWindow.toLocaleString()})` : ""}`
+                  : `Enter a positive whole number${capsLimit ? ` up to ${capsLimit.contextWindow.toLocaleString()}` : ""}`}
+              </p>
+            </div>
+            <fieldset>
+              <legend className="mb-1 text-sm font-medium">Input Capabilities</legend>
+              <div className="grid grid-cols-2 gap-2">
+                {COMBO_INPUT_CAPS.map(({ key, label }) => (
+                  <label key={key} className="flex cursor-pointer items-center gap-2 text-xs text-text-muted">
+                    <Toggle
+                      checked={caps[key] === true}
+                      onChange={(value) => setCaps((current) => ({ ...current, [key]: value }))}
+                      disabled={capsLimit ? !capsLimit[key] && caps[key] !== true : false}
+                    />
+                    <span>{label}</span>
+                  </label>
+                ))}
+              </div>
+              <p role={unsupportedInput ? "alert" : undefined} className={`mt-1 text-[10px] ${unsupportedInput ? "text-red-500" : "text-text-muted"}`}>
+                {unsupportedInput ? `${unsupportedInput.label} is not accepted by every fallback model` : "Only capabilities accepted by every fallback model can be enabled"}
+              </p>
+            </fieldset>
           </div>
 
           {/* Models */}
@@ -827,7 +901,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, kindF
               onClick={handleSave}
               fullWidth
               size="sm"
-              disabled={!name.trim() || !!nameError || saving}
+              disabled={!name.trim() || !!nameError || !metadataValid || saving}
             >
               {saving ? "Saving..." : isEdit ? "Save" : "Create"}
             </Button>

--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -19,6 +19,11 @@ const COMBO_INPUT_CAPS = [
   { key: "audioInput", label: "Audio" },
   { key: "videoInput", label: "Video" },
 ];
+const MODEL_CAPS = [
+  ...COMBO_INPUT_CAPS,
+  { key: "search", label: "Search" },
+  { key: "reasoning", label: "Reasoning" },
+];
 
 // Capacity adapter: global fallback pools of models per input-modality capability.
 // A request needing a capability the target model/combo lacks switches straight
@@ -561,7 +566,7 @@ function CapacityAdapterCap({ cap, entry, onChange, activeProviders, getCaps }) 
   );
 }
 
-function ModelItem({ id, index, model, isFirst, isLast, onEdit, onMoveUp, onMoveDown, onRemove }) {
+function ModelItem({ id, index, model, caps, isFirst, isLast, onEdit, onMoveUp, onMoveDown, onRemove }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useSortable({ id });
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -607,25 +612,44 @@ function ModelItem({ id, index, model, isFirst, isLast, onEdit, onMoveUp, onMove
       {/* Index badge */}
       <span className="text-[10px] font-medium text-text-muted w-3 text-center shrink-0">{index + 1}</span>
 
-      {/* Inline editable model value */}
-      {editing ? (
-        <input
-          autoFocus
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onBlur={commit}
-          onKeyDown={handleKeyDown}
-          className="min-w-0 flex-1 rounded border border-primary/40 bg-white px-1.5 py-0.5 font-mono text-xs text-text-main outline-none dark:bg-black/20"
-        />
-      ) : (
-        <div
-          className="min-w-0 flex-1 cursor-text truncate rounded px-1.5 py-0.5 font-mono text-xs text-text-main hover:bg-black/5 dark:hover:bg-white/5"
-          onClick={() => setEditing(true)}
-          title="Click to edit"
-        >
-          {model}
+      <div className="min-w-0 flex-1">
+        {/* Inline editable model value */}
+        {editing ? (
+          <input
+            autoFocus
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commit}
+            onKeyDown={handleKeyDown}
+            className="w-full min-w-0 rounded border border-primary/40 bg-white px-1.5 py-0.5 font-mono text-xs text-text-main outline-none dark:bg-black/20"
+          />
+        ) : (
+          <div
+            className="min-w-0 cursor-text truncate rounded px-1.5 py-0.5 font-mono text-xs text-text-main hover:bg-black/5 dark:hover:bg-white/5"
+            onClick={() => { setDraft(model); setEditing(true); }}
+            title="Click to edit"
+          >
+            {model}
+          </div>
+        )}
+        <div data-model-capabilities={model} className="mt-1 flex flex-wrap items-center gap-1 px-1.5 text-[10px]">
+          <span
+            aria-label={`Context window: ${caps?.contextWindow?.toLocaleString() || "unknown"} tokens`}
+            className="rounded bg-primary/10 px-1.5 py-0.5 font-medium text-primary"
+          >
+            Context {caps?.contextWindow?.toLocaleString() || "unknown"}
+          </span>
+          {MODEL_CAPS.map(({ key, label }) => (
+            <span
+              key={key}
+              aria-label={`${label}: ${caps?.[key] ? "supported" : "not supported"}`}
+              className={`rounded px-1.5 py-0.5 ${caps?.[key] ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400" : "bg-black/5 text-text-muted/50 line-through dark:bg-white/5"}`}
+            >
+              {label}
+            </span>
+          ))}
         </div>
-      )}
+      </div>
 
       {/* Priority arrows */}
       <div className="flex shrink-0 items-center gap-0.5">
@@ -784,6 +808,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, getCa
         isOpen={isOpen}
         onClose={onClose}
         title={isEdit ? "Edit Combo" : "Create Combo"}
+        size="full"
       >
         <div className="flex flex-col gap-3">
           {/* Name */}
@@ -804,22 +829,33 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, getCa
           <div className="grid grid-cols-1 gap-3 rounded-lg border border-black/10 p-3 dark:border-white/10 sm:grid-cols-[1fr_2fr]">
             <div>
               <label htmlFor="combo-context-window" className="mb-1 block text-sm font-medium">Context Window</label>
-              <input
-                id="combo-context-window"
-                type="number"
-                min="1"
-                max={capsLimit?.contextWindow}
-                step="1"
-                value={caps.contextWindow || ""}
-                aria-invalid={!contextWindowValid}
-                aria-describedby="combo-context-window-help"
-                onChange={(e) => {
-                  const value = e.target.value === "" ? undefined : Number(e.target.value);
-                  setCaps((current) => ({ ...current, contextWindow: value }));
-                }}
-                placeholder="e.g. 200000"
-                className="w-full rounded border border-black/10 bg-white px-2 py-1.5 font-mono text-sm outline-none focus:border-primary dark:border-white/10 dark:bg-black/20"
-              />
+              <div className="flex gap-1.5">
+                <input
+                  id="combo-context-window"
+                  type="number"
+                  min="1"
+                  max={capsLimit?.contextWindow}
+                  step="1"
+                  value={caps.contextWindow || ""}
+                  aria-invalid={!contextWindowValid}
+                  aria-describedby="combo-context-window-help"
+                  onChange={(e) => {
+                    const value = e.target.value === "" ? undefined : Number(e.target.value);
+                    setCaps((current) => ({ ...current, contextWindow: value }));
+                  }}
+                  placeholder="e.g. 200000"
+                  className="min-w-0 flex-1 rounded border border-black/10 bg-white px-2 py-1.5 font-mono text-sm outline-none focus:border-primary dark:border-white/10 dark:bg-black/20"
+                />
+                <button
+                  type="button"
+                  disabled={!capsLimit}
+                  onClick={() => setCaps((current) => ({ ...current, contextWindow: capsLimit.contextWindow }))}
+                  title="Use the maximum context window shared by every model"
+                  className="rounded border border-primary/30 px-2.5 text-xs font-medium text-primary transition-colors hover:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  Max
+                </button>
+              </div>
               <p id="combo-context-window-help" role={contextWindowValid ? undefined : "alert"} className={`mt-0.5 text-[10px] ${contextWindowValid ? "text-text-muted" : "text-red-500"}`}>
                 {contextWindowValid
                   ? `Tokens advertised by the combo${capsLimit ? ` (max ${capsLimit.contextWindow.toLocaleString()})` : ""}`
@@ -858,13 +894,14 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, getCa
             ) : (
             <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} modifiers={[restrictToVerticalAxis, restrictToParentElement]}>
               <SortableContext items={modelItems.map((m) => m.uid)} strategy={verticalListSortingStrategy}>
-                <div className="flex max-h-[55vh] min-w-0 flex-col gap-1 overflow-y-auto sm:max-h-[350px]">
+                <div className="flex max-h-[55vh] min-w-0 flex-col gap-1.5 overflow-y-auto sm:max-h-[420px]">
                   {modelItems.map(({ uid, model }, index) => (
                     <ModelItem
                       key={uid}
                       id={uid}
                       index={index}
                       model={model}
+                      caps={getCaps(model)}
                       isFirst={index === 0}
                       isLast={index === modelItems.length - 1}
                       onEdit={(newVal) => {

--- a/src/app/(dashboard)/dashboard/providers/[id]/CompatibleModelsSection.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/CompatibleModelsSection.js
@@ -4,74 +4,9 @@ import { useState } from "react";
 import PropTypes from "prop-types";
 import { Button } from "@/shared/components";
 import { getProviderCustomModelRows } from "@/shared/utils/providerCustomModels";
-function CompatibleModelRow({ modelId, fullModel, copied, onCopy, onDeleteAlias, onTest, testStatus, isTesting }) {
-  const borderColor = testStatus === "ok"
-    ? "border-green-500/40"
-    : testStatus === "error"
-    ? "border-red-500/40"
-    : "border-border";
+import ModelRow from "./ModelRow";
 
-  const iconColor = testStatus === "ok"
-    ? "#22c55e"
-    : testStatus === "error"
-    ? "#ef4444"
-    : undefined;
-
-  return (
-    <div className={`flex items-center gap-3 p-3 rounded-lg border ${borderColor} hover:bg-sidebar/50`}>
-      <span
-        className="material-symbols-outlined text-base text-text-muted"
-        style={iconColor ? { color: iconColor } : undefined}
-      >
-        {testStatus === "ok" ? "check_circle" : testStatus === "error" ? "cancel" : "smart_toy"}
-      </span>
-      <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium truncate">{modelId}</p>
-        <div className="flex items-center gap-1 mt-1">
-          <code className="text-xs text-text-muted font-mono bg-sidebar px-1.5 py-0.5 rounded">{fullModel}</code>
-          <div className="relative group/btn">
-            <button
-              onClick={() => onCopy(fullModel, `model-${modelId}`)}
-              className="p-0.5 hover:bg-sidebar rounded text-text-muted hover:text-primary"
-            >
-              <span className="material-symbols-outlined text-sm">
-                {copied === `model-${modelId}` ? "check" : "content_copy"}
-              </span>
-            </button>
-            <span className="pointer-events-none absolute top-5 left-1/2 -translate-x-1/2 text-[10px] text-text-muted whitespace-nowrap opacity-0 group-hover/btn:opacity-100 transition-opacity">
-              {copied === `model-${modelId}` ? "Copied!" : "Copy"}
-            </span>
-          </div>
-          {onTest && (
-            <div className="relative group/btn">
-              <button
-                onClick={onTest}
-                disabled={isTesting}
-                className="p-0.5 hover:bg-sidebar rounded text-text-muted hover:text-primary transition-colors"
-              >
-                <span className="material-symbols-outlined text-sm" style={isTesting ? { animation: "spin 1s linear infinite" } : undefined}>
-                  {isTesting ? "progress_activity" : "science"}
-                </span>
-              </button>
-              <span className="pointer-events-none absolute top-5 left-1/2 -translate-x-1/2 text-[10px] text-text-muted whitespace-nowrap opacity-0 group-hover/btn:opacity-100 transition-opacity">
-                {isTesting ? "Testing..." : "Test"}
-              </span>
-            </div>
-          )}
-        </div>
-      </div>
-      <button
-        onClick={onDeleteAlias}
-        className="p-1 hover:bg-red-50 rounded text-red-500"
-        title="Remove model"
-      >
-        <span className="material-symbols-outlined text-sm">delete</span>
-      </button>
-    </div>
-  );
-}
-
-export default function CompatibleModelsSection({ providerStorageAlias, providerDisplayAlias, modelAliases, customModels, copied, onCopy, onDeleteAlias, onAddCustomModel, onDeleteCustomModel, connections, isAnthropic }) {
+export default function CompatibleModelsSection({ providerStorageAlias, providerDisplayAlias, modelAliases, customModels, copied, onCopy, onDeleteAlias, onAddCustomModel, onDeleteCustomModel, connections, isAnthropic, getCaps, onEditContext }) {
   const [newModel, setNewModel] = useState("");
   const [adding, setAdding] = useState(false);
   const [importing, setImporting] = useState(false);
@@ -196,9 +131,9 @@ export default function CompatibleModelsSection({ providerStorageAlias, provider
       {allModels.length > 0 && (
         <div className="flex flex-col gap-3">
           {allModels.map(({ id, alias, source }) => (
-            <CompatibleModelRow
+            <ModelRow
               key={`${source}-${providerStorageAlias}/${id}`}
-              modelId={id}
+              model={{ id, name: id }}
               fullModel={`${providerDisplayAlias}/${id}`}
               copied={copied}
               onCopy={onCopy}
@@ -206,6 +141,9 @@ export default function CompatibleModelsSection({ providerStorageAlias, provider
               onTest={connections.length > 0 ? () => handleTestModel(id) : undefined}
               testStatus={modelTestResults[id]}
               isTesting={testingModelId === id}
+              isCustom
+              caps={getCaps(`${providerStorageAlias}/${id}`)}
+              onEditContext={() => onEditContext(id, getCaps(`${providerStorageAlias}/${id}`))}
             />
           ))}
         </div>
@@ -229,4 +167,6 @@ CompatibleModelsSection.propTypes = {
     isActive: PropTypes.bool,
   })).isRequired,
   isAnthropic: PropTypes.bool,
+  getCaps: PropTypes.func.isRequired,
+  onEditContext: PropTypes.func.isRequired,
 };

--- a/src/app/(dashboard)/dashboard/providers/[id]/ModelRow.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ModelRow.js
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import { CapacityBadges } from "@/shared/components";
 
-export default function ModelRow({ model, fullModel, alias, copied, onCopy, testStatus, isCustom, isFree, onDeleteAlias, onTest, isTesting, onDisable, caps, thinkingSuffix }) {
+export default function ModelRow({ model, fullModel, alias, copied, onCopy, testStatus, isCustom, isFree, onDeleteAlias, onTest, isTesting, onDisable, onEditContext, caps, thinkingSuffix }) {
   const displayModel = thinkingSuffix ? `${fullModel}(${thinkingSuffix})` : fullModel;
   const borderColor = testStatus === "ok"
     ? "border-green-500/40"
@@ -26,9 +26,23 @@ export default function ModelRow({ model, fullModel, alias, copied, onCopy, test
         </span>
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <code className="max-w-[72vw] truncate rounded bg-sidebar px-1.5 py-0.5 font-mono text-xs text-text-muted sm:max-w-[360px]">{displayModel}</code>
-          <span className="flex min-w-0 items-center text-[9px] gap-1 pl-1">
+          <span className="flex min-w-0 flex-wrap items-center text-[9px] gap-1 pl-1">
             {model.name && <span className="truncate text-[9px] italic text-text-muted/70">{model.name}</span>}
             <CapacityBadges caps={caps} colorOverride="text-text-muted/70" size={12} />
+            {caps?.contextWindow && onEditContext && (
+              <button
+                type="button"
+                onClick={onEditContext}
+                className="inline-flex items-center gap-1 rounded-md border border-border/70 bg-surface-2 px-1.5 py-0.5 text-[10px] font-medium text-text-muted transition-colors hover:border-primary/50 hover:text-primary"
+                aria-label={`Override context window for ${model.id}`}
+                title="Override context window"
+                data-model-context={model.id}
+              >
+                <span className="material-symbols-outlined text-[12px]">data_object</span>
+                {caps.contextWindow.toLocaleString()} context
+                <span className="material-symbols-outlined text-[11px]">edit</span>
+              </button>
+            )}
           </span>
         </div>
         {onTest && (
@@ -97,6 +111,7 @@ ModelRow.propTypes = {
   onTest: PropTypes.func,
   isTesting: PropTypes.bool,
   onDisable: PropTypes.func,
+  onEditContext: PropTypes.func,
   caps: PropTypes.object,
   thinkingSuffix: PropTypes.string,
 };

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -13,7 +13,7 @@ import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import { useModelCaps } from "@/shared/hooks/useModelCaps";
 import { translate } from "@/i18n/runtime";
 import { fetchSuggestedModels } from "@/shared/utils/providerModelsFetcher";
-import { getProviderCustomModelRows } from "@/shared/utils/providerCustomModels";
+import { findProviderModelMetadata, getProviderCustomModelRows } from "@/shared/utils/providerCustomModels";
 import ModelRow from "./ModelRow";
 import PassthroughModelsSection from "./PassthroughModelsSection";
 import CompatibleModelsSection from "./CompatibleModelsSection";
@@ -551,13 +551,10 @@ export default function ProviderDetailPage() {
   };
 
   const openContextEditor = (modelId, caps) => {
-    const stored = customModels.find((model) =>
-      model.providerAlias === providerStorageAlias
-      && model.id === modelId
-      && (model.kind || model.type || "llm") === "llm"
-    );
+    const stored = findProviderModelMetadata(customModels, providerStorageAlias, modelId);
     setContextEditor({
       modelId,
+      providerAlias: stored?.providerAlias || providerStorageAlias,
       value: String(caps?.contextWindow || ""),
       hasOverride: Object.prototype.hasOwnProperty.call(stored?.caps || {}, "contextWindow"),
       error: "",
@@ -572,7 +569,7 @@ export default function ProviderDetailPage() {
       return;
     }
     setContextSaving(true);
-    const saved = await handleAddCustomModel(contextEditor.modelId, "llm", providerStorageAlias, { contextWindow });
+    const saved = await handleAddCustomModel(contextEditor.modelId, "llm", contextEditor.providerAlias, { contextWindow });
     setContextSaving(false);
     if (saved) setContextEditor(null);
     else setContextEditor((current) => ({ ...current, error: "Could not save the override. Try again." }));
@@ -580,7 +577,7 @@ export default function ProviderDetailPage() {
 
   const resetContextOverride = async () => {
     setContextSaving(true);
-    const saved = await handleAddCustomModel(contextEditor.modelId, "llm", providerStorageAlias, { contextWindow: null });
+    const saved = await handleAddCustomModel(contextEditor.modelId, "llm", contextEditor.providerAlias, { contextWindow: null });
     setContextSaving(false);
     if (saved) setContextEditor(null);
     else setContextEditor((current) => ({ ...current, error: "Could not reset the override. Try again." }));

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -575,6 +575,7 @@ export default function ProviderDetailPage() {
     const saved = await handleAddCustomModel(contextEditor.modelId, "llm", providerStorageAlias, { contextWindow });
     setContextSaving(false);
     if (saved) setContextEditor(null);
+    else setContextEditor((current) => ({ ...current, error: "Could not save the override. Try again." }));
   };
 
   const resetContextOverride = async () => {
@@ -582,6 +583,7 @@ export default function ProviderDetailPage() {
     const saved = await handleAddCustomModel(contextEditor.modelId, "llm", providerStorageAlias, { contextWindow: null });
     setContextSaving(false);
     if (saved) setContextEditor(null);
+    else setContextEditor((current) => ({ ...current, error: "Could not reset the override. Try again." }));
   };
 
   const handleDeleteCustomModel = async (modelId, type = "llm", providerAliasOverride = providerStorageAlias) => {

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -61,6 +61,8 @@ export default function ProviderDetailPage() {
   const [modelsTestError, setModelsTestError] = useState("");
   const [testingModelIds, setTestingModelIds] = useState(() => new Set());
   const [showAddCustomModel, setShowAddCustomModel] = useState(false);
+  const [contextEditor, setContextEditor] = useState(null);
+  const [contextSaving, setContextSaving] = useState(false);
   const [selectedConnectionIds, setSelectedConnectionIds] = useState([]);
   const [bulkProxyPoolId, setBulkProxyPoolId] = useState("__none__");
   const [bulkUpdatingProxy, setBulkUpdatingProxy] = useState(false);
@@ -537,6 +539,7 @@ export default function ProviderDetailPage() {
       if (res.ok) {
         await fetchCustomModels();
         if (typeof window !== "undefined") window.dispatchEvent(new CustomEvent("customModelChanged"));
+        return true;
       } else {
         const data = await res.json();
         alert(data.error || "Failed to add custom model");
@@ -544,6 +547,41 @@ export default function ProviderDetailPage() {
     } catch (error) {
       console.log("Error adding custom model:", error);
     }
+    return false;
+  };
+
+  const openContextEditor = (modelId, caps) => {
+    const stored = customModels.find((model) =>
+      model.providerAlias === providerStorageAlias
+      && model.id === modelId
+      && (model.kind || model.type || "llm") === "llm"
+    );
+    setContextEditor({
+      modelId,
+      value: String(caps?.contextWindow || ""),
+      hasOverride: Object.prototype.hasOwnProperty.call(stored?.caps || {}, "contextWindow"),
+      error: "",
+    });
+  };
+
+  const saveContextOverride = async (event) => {
+    event.preventDefault();
+    const contextWindow = Number(contextEditor.value);
+    if (!Number.isSafeInteger(contextWindow) || contextWindow <= 0) {
+      setContextEditor((current) => ({ ...current, error: "Enter a positive whole number." }));
+      return;
+    }
+    setContextSaving(true);
+    const saved = await handleAddCustomModel(contextEditor.modelId, "llm", providerStorageAlias, { contextWindow });
+    setContextSaving(false);
+    if (saved) setContextEditor(null);
+  };
+
+  const resetContextOverride = async () => {
+    setContextSaving(true);
+    const saved = await handleAddCustomModel(contextEditor.modelId, "llm", providerStorageAlias, { contextWindow: null });
+    setContextSaving(false);
+    if (saved) setContextEditor(null);
   };
 
   const handleDeleteCustomModel = async (modelId, type = "llm", providerAliasOverride = providerStorageAlias) => {
@@ -1088,6 +1126,8 @@ export default function ProviderDetailPage() {
           onDeleteCustomModel={(modelId) => handleDeleteCustomModel(modelId, "llm", providerStorageAlias)}
           connections={connections}
           isAnthropic={isAnthropicCompatible}
+          getCaps={getCaps}
+          onEditContext={openContextEditor}
         />
       );
     }
@@ -1133,6 +1173,7 @@ export default function ProviderDetailPage() {
             isCustom
             isFree={false}
             caps={getCaps(`${providerId}/${model.id}`)}
+            onEditContext={() => openContextEditor(model.id, getCaps(`${providerId}/${model.id}`))}
             thinkingSuffix={resolveThinkingSuffix(model.id)}
           />
         ))}
@@ -1159,6 +1200,7 @@ export default function ProviderDetailPage() {
               isFree={model.isFree}
               onDisable={() => handleDisableModel(model.id)}
               caps={getCaps(`${providerId}/${model.id}`)}
+              onEditContext={() => openContextEditor(model.id, getCaps(`${providerId}/${model.id}`))}
               thinkingSuffix={resolveThinkingSuffix(model.id)}
             />
           );
@@ -1788,6 +1830,46 @@ export default function ProviderDetailPage() {
           onClose={() => setShowAddCustomModel(false)}
         />
       )}
+
+      <Modal
+        isOpen={!!contextEditor}
+        onClose={() => !contextSaving && setContextEditor(null)}
+        title="Override Context Window"
+      >
+        {contextEditor && (
+          <form className="space-y-4" onSubmit={saveContextOverride}>
+            <div className="rounded-lg border-l-2 border-primary/60 bg-sidebar/40 px-3 py-2">
+              <code className="break-all text-xs text-text-main">{providerDisplayAlias}/{contextEditor.modelId}</code>
+            </div>
+            <Input
+              label="Context window"
+              type="number"
+              min="1"
+              step="1"
+              value={contextEditor.value}
+              onChange={(event) => setContextEditor((current) => ({ ...current, value: event.target.value, error: "" }))}
+              error={contextEditor.error}
+              hint="This local value takes precedence over bundled provider metadata and controls Combo Max."
+              disabled={contextSaving}
+              autoFocus
+              data-context-override-input={contextEditor.modelId}
+            />
+            <div className="flex flex-wrap justify-end gap-2">
+              {contextEditor.hasOverride && (
+                <Button type="button" variant="ghost" onClick={resetContextOverride} disabled={contextSaving}>
+                  Use bundled value
+                </Button>
+              )}
+              <Button type="button" variant="secondary" onClick={() => setContextEditor(null)} disabled={contextSaving}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={contextSaving}>
+                {contextSaving ? "Saving..." : "Save override"}
+              </Button>
+            </div>
+          </form>
+        )}
+      </Modal>
 
       {providerId === "codex" && (
         <BulkImportCodexModal

--- a/src/app/api/combos/[id]/route.js
+++ b/src/app/api/combos/[id]/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
-import { getComboById, updateCombo, deleteCombo, getComboByName } from "@/lib/localDb";
+import { getComboById, updateCombo, deleteCombo, getComboByName, getCustomModels, getProviderConnections } from "@/lib/localDb";
 import { resetComboRotation } from "open-sse/services/combo.js";
+import { createComboCapsResolver, validateComboCaps } from "@/lib/comboCaps";
 
 // Validate combo name: only a-z, A-Z, 0-9, -, _
 const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
@@ -27,6 +28,21 @@ export async function PUT(request, { params }) {
   try {
     const { id } = await params;
     const body = await request.json();
+
+    const prev = await getComboById(id);
+    if (!prev) {
+      return NextResponse.json({ error: "Combo not found" }, { status: 404 });
+    }
+
+    const [customModels, connections] = await Promise.all([getCustomModels(), getProviderConnections()]);
+    const capsError = validateComboCaps(
+      body.caps === undefined ? prev.caps : body.caps,
+      body.models === undefined ? prev.models : body.models,
+      createComboCapsResolver(customModels, connections),
+    );
+    if (capsError) {
+      return NextResponse.json({ error: capsError }, { status: 400 });
+    }
     
     // Validate name format if provided
     if (body.name) {
@@ -41,8 +57,6 @@ export async function PUT(request, { params }) {
       }
     }
     
-    // Capture previous name to invalidate rotation state on rename
-    const prev = await getComboById(id);
     const combo = await updateCombo(id, body);
     
     if (!combo) {

--- a/src/app/api/combos/[id]/route.js
+++ b/src/app/api/combos/[id]/route.js
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getComboById, updateCombo, deleteCombo, getComboByName, getCustomModels, getProviderConnections } from "@/lib/localDb";
+import { getComboById, updateCombo, deleteCombo, getComboByName, getCustomModels, getProviderConnections, getModelAliases } from "@/lib/localDb";
 import { resetComboRotation } from "open-sse/services/combo.js";
 import { createComboCapsResolver, validateComboCaps } from "@/lib/comboCaps";
 
@@ -34,11 +34,11 @@ export async function PUT(request, { params }) {
       return NextResponse.json({ error: "Combo not found" }, { status: 404 });
     }
 
-    const [customModels, connections] = await Promise.all([getCustomModels(), getProviderConnections()]);
+    const [customModels, connections, modelAliases] = await Promise.all([getCustomModels(), getProviderConnections(), getModelAliases()]);
     const capsError = validateComboCaps(
       body.caps === undefined ? prev.caps : body.caps,
       body.models === undefined ? prev.models : body.models,
-      createComboCapsResolver(customModels, connections),
+      createComboCapsResolver(customModels, connections, modelAliases),
     );
     if (capsError) {
       return NextResponse.json({ error: capsError }, { status: 400 });

--- a/src/app/api/combos/route.js
+++ b/src/app/api/combos/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { getCombos, createCombo, getComboByName } from "@/lib/localDb";
+import { getCombos, createCombo, getComboByName, getCustomModels, getProviderConnections } from "@/lib/localDb";
+import { createComboCapsResolver, validateComboCaps } from "@/lib/comboCaps";
 
 export const dynamic = "force-dynamic";
 
@@ -21,7 +22,8 @@ export async function GET() {
 export async function POST(request) {
   try {
     const body = await request.json();
-    const { name, models, kind } = body;
+    const { name, models, kind, caps } = body;
+    const effectiveModels = models === undefined ? [] : models;
 
     if (!name) {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
@@ -32,13 +34,19 @@ export async function POST(request) {
       return NextResponse.json({ error: "Name can only contain letters, numbers, -, _ and ." }, { status: 400 });
     }
 
+    const [customModels, connections] = await Promise.all([getCustomModels(), getProviderConnections()]);
+    const capsError = validateComboCaps(caps, effectiveModels, createComboCapsResolver(customModels, connections));
+    if (capsError) {
+      return NextResponse.json({ error: capsError }, { status: 400 });
+    }
+
     // Check if name already exists
     const existing = await getComboByName(name);
     if (existing) {
       return NextResponse.json({ error: "Combo name already exists" }, { status: 400 });
     }
 
-    const combo = await createCombo({ name, models: models || [], kind: kind || null });
+    const combo = await createCombo({ name, models: effectiveModels, kind: kind || null, caps: caps || {} });
 
     return NextResponse.json(combo, { status: 201 });
   } catch (error) {

--- a/src/app/api/combos/route.js
+++ b/src/app/api/combos/route.js
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getCombos, createCombo, getComboByName, getCustomModels, getProviderConnections } from "@/lib/localDb";
+import { getCombos, createCombo, getComboByName, getCustomModels, getProviderConnections, getModelAliases } from "@/lib/localDb";
 import { createComboCapsResolver, validateComboCaps } from "@/lib/comboCaps";
 
 export const dynamic = "force-dynamic";
@@ -34,8 +34,8 @@ export async function POST(request) {
       return NextResponse.json({ error: "Name can only contain letters, numbers, -, _ and ." }, { status: 400 });
     }
 
-    const [customModels, connections] = await Promise.all([getCustomModels(), getProviderConnections()]);
-    const capsError = validateComboCaps(caps, effectiveModels, createComboCapsResolver(customModels, connections));
+    const [customModels, connections, modelAliases] = await Promise.all([getCustomModels(), getProviderConnections(), getModelAliases()]);
+    const capsError = validateComboCaps(caps, effectiveModels, createComboCapsResolver(customModels, connections, modelAliases));
     if (capsError) {
       return NextResponse.json({ error: capsError }, { status: 400 });
     }

--- a/src/app/api/models/custom/route.js
+++ b/src/app/api/models/custom/route.js
@@ -6,12 +6,18 @@ export const dynamic = "force-dynamic";
 
 // Whitelist capability keys to boolean values — ignore anything else
 function sanitizeCaps(caps) {
-  if (!caps || typeof caps !== "object") return null;
+  if (!caps || typeof caps !== "object" || Array.isArray(caps)) return { caps: null };
   const clean = {};
   for (const key of Object.keys(CAPACITY_META)) {
     if (typeof caps[key] === "boolean") clean[key] = caps[key];
   }
-  return Object.keys(clean).length ? clean : null;
+  if (Object.prototype.hasOwnProperty.call(caps, "contextWindow")) {
+    if (caps.contextWindow !== null && (!Number.isSafeInteger(caps.contextWindow) || caps.contextWindow <= 0)) {
+      return { error: "Context window must be a positive integer or null" };
+    }
+    clean.contextWindow = caps.contextWindow;
+  }
+  return { caps: Object.keys(clean).length ? clean : null };
 }
 
 // GET /api/models/custom - List all custom models
@@ -32,7 +38,8 @@ export async function POST(request) {
     if (!providerAlias || !id) {
       return NextResponse.json({ error: "providerAlias and id required" }, { status: 400 });
     }
-    const cleanCaps = sanitizeCaps(caps);
+    const { caps: cleanCaps, error } = sanitizeCaps(caps);
+    if (error) return NextResponse.json({ error }, { status: 400 });
     const added = await addCustomModel({ providerAlias, id, type: type || "llm", name, ...(cleanCaps ? { caps: cleanCaps } : {}) });
     return NextResponse.json({ success: true, added });
   } catch (error) {

--- a/src/app/api/models/route.js
+++ b/src/app/api/models/route.js
@@ -12,9 +12,14 @@ export async function GET() {
     const modelAliases = await getModelAliases();
     const disabled = await getDisabledModels();
     const allCustomModels = await getCustomModels();
-    const customByFullModel = new Map(allCustomModels
-      .filter((model) => (model.kind || model.type || "llm") === "llm")
-      .map((model) => [`${model.providerAlias}/${model.id}`, model]));
+    const customByFullModel = new Map();
+    for (const model of allCustomModels) {
+      if ((model.kind || model.type || "llm") !== "llm") continue;
+      const fullModel = `${model.providerAlias}/${model.id}`;
+      customByFullModel.set(fullModel, model);
+      const normalizedModel = `${resolveProviderId(model.providerAlias)}/${model.id}`;
+      if (!customByFullModel.has(normalizedModel)) customByFullModel.set(normalizedModel, model);
+    }
 
     const models = AI_MODELS
       .filter((m) => {
@@ -28,7 +33,10 @@ export async function GET() {
         const routedModel = `${providerAlias}/${m.model}`;
         const c = {
           ...getCapabilitiesForModel(resolveProviderId(m.provider), m.model),
-          ...(customByFullModel.get(`${providerAlias}/${m.model}`)?.caps || customByFullModel.get(fullModel)?.caps || {}),
+          ...(customByFullModel.get(`${providerAlias}/${m.model}`)?.caps
+            || customByFullModel.get(fullModel)?.caps
+            || customByFullModel.get(`${resolveProviderId(m.provider)}/${m.model}`)?.caps
+            || {}),
         };
         return {
           ...m,

--- a/src/app/api/models/route.js
+++ b/src/app/api/models/route.js
@@ -11,6 +11,10 @@ export async function GET() {
   try {
     const modelAliases = await getModelAliases();
     const disabled = await getDisabledModels();
+    const allCustomModels = await getCustomModels();
+    const customByFullModel = new Map(allCustomModels
+      .filter((model) => (model.kind || model.type || "llm") === "llm")
+      .map((model) => [`${model.providerAlias}/${model.id}`, model]));
 
     const models = AI_MODELS
       .filter((m) => {
@@ -22,7 +26,10 @@ export async function GET() {
         const fullModel = `${m.provider}/${m.model}`;
         const providerAlias = getProviderAlias(m.provider) || m.provider;
         const routedModel = `${providerAlias}/${m.model}`;
-        const c = getCapabilitiesForModel(resolveProviderId(m.provider), m.model);
+        const c = {
+          ...getCapabilitiesForModel(resolveProviderId(m.provider), m.model),
+          ...(customByFullModel.get(`${providerAlias}/${m.model}`)?.caps || customByFullModel.get(fullModel)?.caps || {}),
+        };
         return {
           ...m,
           fullModel,
@@ -47,7 +54,7 @@ export async function GET() {
     const prefixes = new Map(connections
       .filter((connection) => connection.providerSpecificData?.prefix)
       .map((connection) => [connection.provider, connection.providerSpecificData.prefix]));
-    const customModels = (await getCustomModels()).filter((m) => {
+    const customModels = allCustomModels.filter((m) => {
       if (!m?.id || (m.kind || m.type || "llm") !== "llm") return false;
       return !seenFull.has(`${m.providerAlias}/${m.id}`);
     });

--- a/src/app/api/models/route.js
+++ b/src/app/api/models/route.js
@@ -2,8 +2,9 @@ import { NextResponse } from "next/server";
 import { getModelAliases, setModelAlias, getCustomModels } from "@/models";
 import { getDisabledModels } from "@/lib/disabledModelsDb";
 import { AI_MODELS } from "@/shared/constants/config";
-import { getProviderAlias } from "@/shared/constants/providers";
+import { getProviderAlias, resolveProviderId } from "@/shared/constants/providers";
 import { getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { getProviderConnections } from "@/lib/localDb";
 
 // GET /api/models - Get models with aliases
 export async function GET() {
@@ -21,7 +22,7 @@ export async function GET() {
         const fullModel = `${m.provider}/${m.model}`;
         const providerAlias = getProviderAlias(m.provider) || m.provider;
         const routedModel = `${providerAlias}/${m.model}`;
-        const c = getCapabilitiesForModel(m.provider, m.model);
+        const c = getCapabilitiesForModel(resolveProviderId(m.provider), m.model);
         return {
           ...m,
           fullModel,
@@ -29,6 +30,9 @@ export async function GET() {
           alias: modelAliases[fullModel] || m.model,
           caps: {
             vision: c.vision,
+            pdf: c.pdf,
+            audioInput: c.audioInput,
+            videoInput: c.videoInput,
             search: c.search,
             reasoning: c.reasoning,
             contextWindow: c.contextWindow,
@@ -39,22 +43,30 @@ export async function GET() {
 
     // Custom models ride along; their stored caps override the name heuristic
     const seenFull = new Set(models.map((m) => m.fullModel));
+    const connections = await getProviderConnections();
+    const prefixes = new Map(connections
+      .filter((connection) => connection.providerSpecificData?.prefix)
+      .map((connection) => [connection.provider, connection.providerSpecificData.prefix]));
     const customModels = (await getCustomModels()).filter((m) => {
       if (!m?.id || (m.kind || m.type || "llm") !== "llm") return false;
       return !seenFull.has(`${m.providerAlias}/${m.id}`);
     });
     for (const m of customModels) {
       const fullModel = `${m.providerAlias}/${m.id}`;
-      const c = getCapabilitiesForModel(m.providerAlias, m.id);
+      const routedModel = `${prefixes.get(m.providerAlias) || m.providerAlias}/${m.id}`;
+      const c = getCapabilitiesForModel(resolveProviderId(m.providerAlias), m.id);
       models.push({
         provider: m.providerAlias,
         model: m.id,
         name: m.name || m.id,
         fullModel,
-        routedModel: fullModel,
+        routedModel,
         alias: modelAliases[fullModel] || m.id,
         caps: {
           vision: c.vision,
+          pdf: c.pdf,
+          audioInput: c.audioInput,
+          videoInput: c.videoInput,
           search: c.search,
           reasoning: c.reasoning,
           contextWindow: c.contextWindow,

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -18,6 +18,7 @@ import { resolveZedModels } from "open-sse/shared/zedAuth.js";
 import { updateProviderCredentials } from "@/sse/services/tokenRefresh";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { capabilitiesFromServiceKind, getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { COMBO_INPUT_CAPABILITIES, createComboCapsResolver, getComboCapsLimit } from "@/lib/comboCaps";
 
 // Per-provider live model resolvers. Each receives a connection record and
 // returns { models: [{ id, name? }, ...] } | null on failure.
@@ -291,6 +292,7 @@ export async function buildModelsList(kindFilter, options = {}) {
   }
 
   const models = [];
+  const resolveComboCaps = createComboCapsResolver(customModels, connections);
 
   // Combos first (filtered by kind). Web combos expose `kind` so AI knows search vs fetch.
   for (const combo of combos) {
@@ -304,9 +306,19 @@ export async function buildModelsList(kindFilter, options = {}) {
       entry.kind = combo.kind;
     }
     if (combo.caps && Object.keys(combo.caps).length > 0) {
-      entry.capabilities = combo.caps;
-      if (Number.isSafeInteger(combo.caps.contextWindow) && combo.caps.contextWindow > 0) {
-        entry.context_length = combo.caps.contextWindow;
+      const capabilities = { ...combo.caps };
+      const limit = getComboCapsLimit(combo.models, resolveComboCaps);
+      if (limit) {
+        if (Number.isSafeInteger(capabilities.contextWindow) && capabilities.contextWindow > 0) {
+          capabilities.contextWindow = Math.min(capabilities.contextWindow, limit.contextWindow);
+        }
+        for (const key of COMBO_INPUT_CAPABILITIES) {
+          if (capabilities[key] === true && !limit[key]) capabilities[key] = false;
+        }
+      }
+      entry.capabilities = capabilities;
+      if (Number.isSafeInteger(capabilities.contextWindow) && capabilities.contextWindow > 0) {
+        entry.context_length = capabilities.contextWindow;
       }
     }
     models.push(entry);

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -303,6 +303,12 @@ export async function buildModelsList(kindFilter, options = {}) {
     if (combo.kind === "webSearch" || combo.kind === "webFetch") {
       entry.kind = combo.kind;
     }
+    if (combo.caps && Object.keys(combo.caps).length > 0) {
+      entry.capabilities = combo.caps;
+      if (Number.isSafeInteger(combo.caps.contextWindow) && combo.caps.contextWindow > 0) {
+        entry.context_length = combo.caps.contextWindow;
+      }
+    }
     models.push(entry);
   }
 

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -292,7 +292,7 @@ export async function buildModelsList(kindFilter, options = {}) {
   }
 
   const models = [];
-  const resolveComboCaps = createComboCapsResolver(customModels, connections);
+  const resolveComboCaps = createComboCapsResolver(customModels, connections, modelAliases);
 
   // Combos first (filtered by kind). Web combos expose `kind` so AI knows search vs fetch.
   for (const combo of combos) {

--- a/src/lib/comboCaps.js
+++ b/src/lib/comboCaps.js
@@ -18,10 +18,13 @@ function resolveModelCaps(key) {
 }
 
 export function createComboCapsResolver(customModels = [], providerConnections = []) {
-  const overrides = new Map(customModels.map((model) => [
-    `${model.providerAlias}/${model.id}`,
-    model.caps || {},
-  ]));
+  const overrides = new Map();
+  for (const model of customModels) {
+    if ((model.kind || model.type || "llm") !== "llm") continue;
+    for (const provider of new Set([model.providerAlias, resolveProviderId(model.providerAlias)])) {
+      overrides.set(`${provider}/${model.id}`, model.caps || {});
+    }
+  }
   const providersByPrefix = new Map(providerConnections
     .filter((connection) => connection.providerSpecificData?.prefix)
     .map((connection) => [connection.providerSpecificData.prefix, connection.provider]));
@@ -32,7 +35,7 @@ export function createComboCapsResolver(customModels = [], providerConnections =
     const model = slash === -1 ? key : key.slice(slash + 1);
     return {
       ...getCapabilitiesForModel(provider ? resolveProviderId(provider) : null, model),
-      ...(overrides.get(`${provider}/${model}`) || {}),
+      ...(overrides.get(`${routedProvider}/${model}`) || overrides.get(`${resolveProviderId(provider)}/${model}`) || {}),
     };
   };
 }

--- a/src/lib/comboCaps.js
+++ b/src/lib/comboCaps.js
@@ -1,0 +1,75 @@
+import { getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { resolveProviderId } from "@/shared/constants/providers";
+
+export const COMBO_INPUT_CAPABILITIES = ["vision", "pdf", "audioInput", "videoInput"];
+
+const CAPABILITY_LABELS = {
+  vision: "Vision",
+  pdf: "PDF input",
+  audioInput: "Audio input",
+  videoInput: "Video input",
+};
+
+function resolveModelCaps(key) {
+  const slash = key.indexOf("/");
+  const provider = slash === -1 ? null : resolveProviderId(key.slice(0, slash));
+  const model = slash === -1 ? key : key.slice(slash + 1);
+  return getCapabilitiesForModel(provider, model);
+}
+
+export function createComboCapsResolver(customModels = [], providerConnections = []) {
+  const overrides = new Map(customModels.map((model) => [
+    `${model.providerAlias}/${model.id}`,
+    model.caps || {},
+  ]));
+  const providersByPrefix = new Map(providerConnections
+    .filter((connection) => connection.providerSpecificData?.prefix)
+    .map((connection) => [connection.providerSpecificData.prefix, connection.provider]));
+  return (key) => {
+    const slash = key.indexOf("/");
+    const routedProvider = slash === -1 ? null : key.slice(0, slash);
+    const provider = providersByPrefix.get(routedProvider) || routedProvider;
+    const model = slash === -1 ? key : key.slice(slash + 1);
+    return {
+      ...getCapabilitiesForModel(provider ? resolveProviderId(provider) : null, model),
+      ...(overrides.get(`${provider}/${model}`) || {}),
+    };
+  };
+}
+
+export function getComboCapsLimit(models, resolve = resolveModelCaps) {
+  const resolved = (models || []).filter((model) => typeof model === "string" && model).map(resolve);
+  if (resolved.length === 0) return null;
+  return {
+    contextWindow: Math.min(...resolved.map((caps) => caps.contextWindow)),
+    ...Object.fromEntries(COMBO_INPUT_CAPABILITIES.map((key) => [key, resolved.every((caps) => caps[key] === true)])),
+  };
+}
+
+export function validateComboCaps(caps, models, resolve) {
+  if (!Array.isArray(models) || models.some((model) => typeof model !== "string" || !model.trim())) {
+    return "Models must be an array of non-empty strings";
+  }
+  if (caps == null) return null;
+  if (typeof caps !== "object" || Array.isArray(caps)) return "Capabilities must be an object";
+
+  const allowed = new Set(["contextWindow", ...COMBO_INPUT_CAPABILITIES]);
+  const unknown = Object.keys(caps).find((key) => !allowed.has(key));
+  if (unknown) return `Unknown capability: ${unknown}`;
+  if (caps.contextWindow !== undefined && (!Number.isSafeInteger(caps.contextWindow) || caps.contextWindow <= 0)) {
+    return "Context window must be a positive integer";
+  }
+  for (const key of COMBO_INPUT_CAPABILITIES) {
+    if (caps[key] !== undefined && typeof caps[key] !== "boolean") return `${key} must be boolean`;
+  }
+
+  const limit = getComboCapsLimit(models, resolve);
+  if (!limit) return null;
+  if (caps.contextWindow !== undefined && caps.contextWindow > limit.contextWindow) {
+    return `Context window cannot exceed ${limit.contextWindow}, supported by every fallback model`;
+  }
+  for (const key of COMBO_INPUT_CAPABILITIES) {
+    if (caps[key] === true && !limit[key]) return `${CAPABILITY_LABELS[key]} is not supported by every fallback model`;
+  }
+  return null;
+}

--- a/src/lib/comboCaps.js
+++ b/src/lib/comboCaps.js
@@ -1,4 +1,5 @@
 import { getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { resolveModelAliasFromMap } from "open-sse/services/model.js";
 import { isReservedProviderPrefix, resolveProviderId } from "@/shared/constants/providers";
 
 export const COMBO_INPUT_CAPABILITIES = ["vision", "pdf", "audioInput", "videoInput"];
@@ -17,7 +18,7 @@ function resolveModelCaps(key) {
   return getCapabilitiesForModel(provider, model);
 }
 
-export function createComboCapsResolver(customModels = [], providerConnections = []) {
+export function createComboCapsResolver(customModels = [], providerConnections = [], modelAliases = {}) {
   const overrides = new Map();
   for (const model of customModels) {
     if ((model.kind || model.type || "llm") !== "llm") continue;
@@ -29,10 +30,13 @@ export function createComboCapsResolver(customModels = [], providerConnections =
     .filter((connection) => connection.providerSpecificData?.prefix && !isReservedProviderPrefix(connection.providerSpecificData.prefix))
     .map((connection) => [connection.providerSpecificData.prefix, connection.provider]));
   return (key) => {
-    const slash = key.indexOf("/");
-    const routedProvider = slash === -1 ? null : key.slice(0, slash);
+    // Mirror getModelInfoCore: bare entries may be user model aliases.
+    const aliasTarget = !key.includes("/") ? resolveModelAliasFromMap(key, modelAliases) : null;
+    const effectiveKey = aliasTarget ? `${aliasTarget.provider}/${aliasTarget.model}` : key;
+    const slash = effectiveKey.indexOf("/");
+    const routedProvider = slash === -1 ? null : effectiveKey.slice(0, slash);
     const provider = providersByPrefix.get(routedProvider) || routedProvider;
-    const model = slash === -1 ? key : key.slice(slash + 1);
+    const model = slash === -1 ? effectiveKey : effectiveKey.slice(slash + 1);
     return {
       ...getCapabilitiesForModel(provider ? resolveProviderId(provider) : null, model),
       ...(overrides.get(`${routedProvider}/${model}`) || overrides.get(`${resolveProviderId(provider)}/${model}`) || {}),

--- a/src/lib/comboCaps.js
+++ b/src/lib/comboCaps.js
@@ -1,5 +1,5 @@
 import { getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
-import { resolveProviderId } from "@/shared/constants/providers";
+import { isReservedProviderPrefix, resolveProviderId } from "@/shared/constants/providers";
 
 export const COMBO_INPUT_CAPABILITIES = ["vision", "pdf", "audioInput", "videoInput"];
 
@@ -26,7 +26,7 @@ export function createComboCapsResolver(customModels = [], providerConnections =
     }
   }
   const providersByPrefix = new Map(providerConnections
-    .filter((connection) => connection.providerSpecificData?.prefix)
+    .filter((connection) => connection.providerSpecificData?.prefix && !isReservedProviderPrefix(connection.providerSpecificData.prefix))
     .map((connection) => [connection.providerSpecificData.prefix, connection.provider]));
   return (key) => {
     const slash = key.indexOf("/");

--- a/src/lib/db/index.js
+++ b/src/lib/db/index.js
@@ -78,7 +78,7 @@ export async function exportDb() {
     providerNodes: db.all(`SELECT * FROM providerNodes`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, type: r.type, name: r.name, createdAt: r.createdAt, updatedAt: r.updatedAt })),
     proxyPools: db.all(`SELECT * FROM proxyPools`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, isActive: r.isActive === 1, testStatus: r.testStatus, createdAt: r.createdAt, updatedAt: r.updatedAt })),
     apiKeys: db.all(`SELECT * FROM apiKeys`).map((r) => ({ id: r.id, key: r.key, name: r.name, machineId: r.machineId, isActive: r.isActive === 1, createdAt: r.createdAt })),
-    combos: db.all(`SELECT * FROM combos`).map((r) => ({ id: r.id, name: r.name, kind: r.kind, models: parseJson(r.models, []), createdAt: r.createdAt, updatedAt: r.updatedAt })),
+    combos: db.all(`SELECT * FROM combos`).map((r) => ({ id: r.id, name: r.name, kind: r.kind, models: parseJson(r.models, []), caps: parseJson(r.caps, {}), createdAt: r.createdAt, updatedAt: r.updatedAt })),
     modelAliases: {},
     customModels: [],
     mitmAlias: {},
@@ -143,8 +143,8 @@ export async function importDb(payload) {
     }
     for (const c of payload.combos || []) {
       db.run(
-        `INSERT OR REPLACE INTO combos(id, name, kind, models, createdAt, updatedAt) VALUES(?, ?, ?, ?, ?, ?)`,
-        [c.id, c.name, c.kind || null, stringifyJson(c.models || []), c.createdAt || new Date().toISOString(), c.updatedAt || new Date().toISOString()]
+        `INSERT OR REPLACE INTO combos(id, name, kind, models, caps, createdAt, updatedAt) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+        [c.id, c.name, c.kind || null, stringifyJson(c.models || []), stringifyJson(c.caps || {}), c.createdAt || new Date().toISOString(), c.updatedAt || new Date().toISOString()]
       );
     }
     for (const [a, m] of Object.entries(payload.modelAliases || {})) {

--- a/src/lib/db/migrate.js
+++ b/src/lib/db/migrate.js
@@ -149,8 +149,8 @@ function importLegacyMain(adapter, data) {
 
   importWithAssertion(adapter, "combos", data.combos || [], (c) => {
     adapter.run(
-      `INSERT OR REPLACE INTO combos(id, name, kind, models, createdAt, updatedAt) VALUES(?, ?, ?, ?, ?, ?)`,
-      [c.id, c.name, c.kind || null, stringifyJson(c.models || []), c.createdAt || new Date().toISOString(), c.updatedAt || new Date().toISOString()]
+      `INSERT OR REPLACE INTO combos(id, name, kind, models, caps, createdAt, updatedAt) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+      [c.id, c.name, c.kind || null, stringifyJson(c.models || []), stringifyJson(c.caps || {}), c.createdAt || new Date().toISOString(), c.updatedAt || new Date().toISOString()]
     );
   }, (c) => ({ id: c.id ?? null, name: c.name ?? null }));
 

--- a/src/lib/db/repos/aliasRepo.js
+++ b/src/lib/db/repos/aliasRepo.js
@@ -39,7 +39,16 @@ export async function addCustomModel({ providerAlias, id, type = "llm", name, ca
     const row = db.get(`SELECT value FROM kv WHERE scope = 'customModels' AND key = ?`, [k]);
     if (row) {
       const prev = parseJson(row.value) || {};
-      const next = { ...prev, ...(name ? { name } : {}), ...(caps ? { caps } : {}) };
+      const next = { ...prev, ...(name ? { name } : {}) };
+      if (caps) {
+        const mergedCaps = { ...(prev.caps || {}) };
+        for (const [key, value] of Object.entries(caps)) {
+          if (value === null) delete mergedCaps[key];
+          else mergedCaps[key] = value;
+        }
+        if (Object.keys(mergedCaps).length) next.caps = mergedCaps;
+        else delete next.caps;
+      }
       db.run(`UPDATE kv SET value = ? WHERE scope = 'customModels' AND key = ?`, [stringifyJson(next), k]);
       return;
     }

--- a/src/lib/db/repos/combosRepo.js
+++ b/src/lib/db/repos/combosRepo.js
@@ -9,6 +9,7 @@ function rowToCombo(row) {
     name: row.name,
     kind: row.kind,
     models: parseJson(row.models, []),
+    caps: parseJson(row.caps, {}),
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -40,12 +41,13 @@ export async function createCombo(data) {
     name: data.name,
     kind: data.kind || null,
     models: data.models || [],
+    caps: data.caps || {},
     createdAt: now,
     updatedAt: now,
   };
   db.run(
-    `INSERT INTO combos(id, name, kind, models, createdAt, updatedAt) VALUES(?, ?, ?, ?, ?, ?)`,
-    [combo.id, combo.name, combo.kind, stringifyJson(combo.models), combo.createdAt, combo.updatedAt]
+    `INSERT INTO combos(id, name, kind, models, caps, createdAt, updatedAt) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+    [combo.id, combo.name, combo.kind, stringifyJson(combo.models), stringifyJson(combo.caps), combo.createdAt, combo.updatedAt]
   );
   return combo;
 }
@@ -57,9 +59,10 @@ export async function updateCombo(id, data) {
     const row = db.get(`SELECT * FROM combos WHERE id = ?`, [id]);
     if (!row) return;
     const merged = { ...rowToCombo(row), ...data, updatedAt: new Date().toISOString() };
+    merged.caps ||= {};
     db.run(
-      `UPDATE combos SET name = ?, kind = ?, models = ?, updatedAt = ? WHERE id = ?`,
-      [merged.name, merged.kind, stringifyJson(merged.models || []), merged.updatedAt, id]
+      `UPDATE combos SET name = ?, kind = ?, models = ?, caps = ?, updatedAt = ? WHERE id = ?`,
+      [merged.name, merged.kind, stringifyJson(merged.models || []), stringifyJson(merged.caps || {}), merged.updatedAt, id]
     );
     result = merged;
   });

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -3,7 +3,7 @@
 // pre-change safety backup in migrate.js: when the stored version is lower,
 // one lightweight DB backup is taken before applying schema changes. Forgetting
 // to bump only skips that backup — it does NOT break the additive auto-sync.
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 
 export const PRAGMA_SQL = `
 PRAGMA journal_mode = WAL;
@@ -92,6 +92,7 @@ export const TABLES = {
       name: "TEXT UNIQUE NOT NULL",
       kind: "TEXT",
       models: "TEXT NOT NULL",
+      caps: "TEXT",
       createdAt: "TEXT NOT NULL",
       updatedAt: "TEXT NOT NULL",
     },

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -100,6 +100,16 @@ export function isCustomEmbeddingProvider(providerId) {
 // All providers (combined)
 export const AI_PROVIDERS = { ...FREE_PROVIDERS, ...FREE_TIER_PROVIDERS, ...OAUTH_PROVIDERS, ...APIKEY_PROVIDERS, ...WEB_COOKIE_PROVIDERS };
 
+const RESERVED_PROVIDER_PREFIXES = new Set(REGISTRY.flatMap((provider) => [
+  provider.id,
+  provider.alias,
+  ...(provider.aliases || []),
+]).filter(Boolean));
+
+export function isReservedProviderPrefix(prefix) {
+  return RESERVED_PROVIDER_PREFIXES.has(prefix);
+}
+
 // Auth methods
 export const AUTH_METHODS = {
   oauth: { id: "oauth" },

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -22,6 +22,7 @@ function buildProviderEntry(r) {
     ...display,
     id: r.id,
     alias: r.uiAlias || r.alias,
+    ...(r.aliases?.length ? { aliases: r.aliases } : {}),
     ...(r.hidden ? { hidden: true } : {}),
     ...mediaFields,
     ...(r.priority !== undefined ? { priority: r.priority } : {}),
@@ -120,7 +121,7 @@ export const AUTH_METHODS = {
 // Helper: Get provider by alias
 export function getProviderByAlias(alias) {
   for (const provider of Object.values(AI_PROVIDERS)) {
-    if (provider.alias === alias || provider.id === alias) {
+    if (provider.alias === alias || provider.id === alias || provider.aliases?.includes(alias)) {
       return provider;
     }
   }

--- a/src/shared/hooks/useModelCaps.js
+++ b/src/shared/hooks/useModelCaps.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { resolveProviderId } from "@/shared/constants/providers";
 
 // Module cache: one /api/models fetch shared by every useModelCaps instance.
 let cache = null; // { byFull, byId } | null
@@ -44,9 +45,12 @@ function resolveCaps(byFull, byId, key) {
   const bare = key.includes("/") ? key.slice(key.indexOf("/") + 1) : key;
   if (byId[bare]) return byId[bare];
   const provider = key.includes("/") ? key.slice(0, key.indexOf("/")) : null;
-  const c = getCapabilitiesForModel(provider, bare);
+  const c = getCapabilitiesForModel(provider ? resolveProviderId(provider) : null, bare);
   return {
     vision: c.vision,
+    pdf: c.pdf,
+    audioInput: c.audioInput,
+    videoInput: c.videoInput,
     search: c.search,
     reasoning: c.reasoning,
     contextWindow: c.contextWindow,

--- a/src/shared/utils/providerCustomModels.js
+++ b/src/shared/utils/providerCustomModels.js
@@ -1,5 +1,14 @@
+import { resolveProviderId } from "@/shared/constants/providers";
+
 function modelType(model) {
   return model?.kind || model?.type || "llm";
+}
+
+export function findProviderModelMetadata(customModels, providerAlias, modelId, type = "llm") {
+  const matchesModel = (model) => model.id === modelId && modelType(model) === type;
+  return customModels.find((model) => matchesModel(model) && model.providerAlias === providerAlias)
+    || customModels.find((model) => matchesModel(model)
+      && resolveProviderId(model.providerAlias) === resolveProviderId(providerAlias));
 }
 
 export function getProviderCustomModelRows({

--- a/src/sse/services/model.js
+++ b/src/sse/services/model.js
@@ -1,20 +1,13 @@
 // Re-export from open-sse with localDb integration
 import { getModelAliases, getComboByName, getProviderNodes } from "@/lib/localDb";
 import { parseModel as parseModelCore, resolveModelAliasFromMap, getModelInfoCore } from "open-sse/services/model.js";
-import REGISTRY from "open-sse/providers/registry/index.js";
+import { isReservedProviderPrefix } from "@/shared/constants/providers";
 
 // Local provider alias overrides (HMR-friendly, applied on top of open-sse map)
 const LOCAL_PROVIDER_ALIASES = {
   xmtp: "xiaomi-tokenplan",
   "xiaomi-tokenplan": "xiaomi-tokenplan",
 };
-
-const RESERVED_PROVIDER_PREFIXES = new Set(Object.keys(LOCAL_PROVIDER_ALIASES));
-for (const entry of REGISTRY) {
-  RESERVED_PROVIDER_PREFIXES.add(entry.id);
-  if (entry.alias) RESERVED_PROVIDER_PREFIXES.add(entry.alias);
-  for (const alias of entry.aliases || []) RESERVED_PROVIDER_PREFIXES.add(alias);
-}
 
 export function parseModel(modelStr) {
   const parsed = parseModelCore(modelStr);
@@ -41,7 +34,7 @@ export async function getModelInfo(modelStr) {
   if (!parsed.isAlias) {
     // Provider-node prefixes are user-defined. They must not override built-in
     // provider ids/aliases such as `cf`, `cloudflare-ai`, `openai`, or `hf`.
-    if (!RESERVED_PROVIDER_PREFIXES.has(parsed.providerAlias)) {
+    if (!isReservedProviderPrefix(parsed.providerAlias)) {
       const openaiNodes = await getProviderNodes({ type: "openai-compatible" });
       const matchedOpenAI = openaiNodes.find((node) => node.prefix === parsed.providerAlias);
       if (matchedOpenAI) {

--- a/tests/unit/capabilities.test.js
+++ b/tests/unit/capabilities.test.js
@@ -62,4 +62,10 @@ describe("getCapabilitiesForModel", () => {
     expect(getCapabilitiesForModel("kiro", "gpt-5.6-luna-agentic")).toMatchObject(kiroGpt56Expected);
     expect(getCapabilitiesForModel("kiro", "gpt-5.6-sol-thinking-agentic")).toMatchObject(kiroGpt56Expected);
   });
+
+  it("uses the documented 1M window for GLM 5.2 and 5.3 without changing older GLM", () => {
+    expect(getCapabilitiesForModel("glm", "glm-5.3").contextWindow).toBe(1000000);
+    expect(getCapabilitiesForModel("glm", "glm-5.2").contextWindow).toBe(1000000);
+    expect(getCapabilitiesForModel("glm", "glm-5.1").contextWindow).toBe(200000);
+  });
 });

--- a/tests/unit/combo-capabilities-api.test.js
+++ b/tests/unit/combo-capabilities-api.test.js
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   getProviderConnections: vi.fn(),
   getComboByName: vi.fn(),
   getCombos: vi.fn(),
+  getModelAliases: vi.fn(),
 }));
 
 vi.mock("@/lib/localDb", () => mocks);
@@ -18,6 +19,7 @@ describe("POST /api/combos capability metadata", () => {
     mocks.getComboByName.mockResolvedValue(null);
     mocks.getCustomModels.mockResolvedValue([]);
     mocks.getProviderConnections.mockResolvedValue([]);
+    mocks.getModelAliases.mockResolvedValue({});
     mocks.createCombo.mockImplementation(async (value) => ({ id: "combo-id", ...value }));
   });
 

--- a/tests/unit/combo-capabilities-api.test.js
+++ b/tests/unit/combo-capabilities-api.test.js
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createCombo: vi.fn(),
+  getCustomModels: vi.fn(),
+  getProviderConnections: vi.fn(),
+  getComboByName: vi.fn(),
+  getCombos: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => mocks);
+
+const { POST } = await import("../../src/app/api/combos/route.js");
+
+describe("POST /api/combos capability metadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getComboByName.mockResolvedValue(null);
+    mocks.getCustomModels.mockResolvedValue([]);
+    mocks.getProviderConnections.mockResolvedValue([]);
+    mocks.createCombo.mockImplementation(async (value) => ({ id: "combo-id", ...value }));
+  });
+
+  it("persists configured context and input capabilities", async () => {
+    const caps = {
+      contextWindow: 128000,
+      vision: true,
+      pdf: false,
+      audioInput: false,
+      videoInput: false,
+    };
+    const response = await POST(new Request("https://router.test/api/combos", {
+      method: "POST",
+      body: JSON.stringify({ name: "mixed", models: ["codex/gpt-5.6-sol"], caps }),
+    }));
+
+    expect(response.status).toBe(201);
+    expect(mocks.createCombo).toHaveBeenCalledWith({
+      name: "mixed",
+      models: ["codex/gpt-5.6-sol"],
+      kind: null,
+      caps,
+    });
+  });
+
+  it("rejects invalid capability metadata", async () => {
+    const response = await POST(new Request("https://router.test/api/combos", {
+      method: "POST",
+      body: JSON.stringify({ name: "bad", models: ["p/model"], caps: { contextWindow: 0, vision: "yes" } }),
+    }));
+
+    expect(response.status).toBe(400);
+    expect(mocks.createCombo).not.toHaveBeenCalled();
+  });
+
+  it("rejects metadata unsupported by every fallback", async () => {
+    const response = await POST(new Request("https://router.test/api/combos", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "unsafe",
+        models: ["codex/gpt-5.6-sol", "openai/gpt-5-codex"],
+        caps: { contextWindow: 128000, vision: true },
+      }),
+    }));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Vision is not supported by every fallback model" });
+    expect(mocks.createCombo).not.toHaveBeenCalled();
+  });
+
+  it("uses custom-model capability overrides for safety validation", async () => {
+    mocks.getCustomModels.mockResolvedValue([{
+      providerAlias: "openai-compatible-chat-1",
+      id: "multimodal-probe",
+      caps: { contextWindow: 500000, vision: true },
+    }]);
+    mocks.getProviderConnections.mockResolvedValue([{
+      provider: "openai-compatible-chat-1",
+      providerSpecificData: { prefix: "private" },
+    }]);
+    const caps = { contextWindow: 300000, vision: true };
+    const response = await POST(new Request("https://router.test/api/combos", {
+      method: "POST",
+      body: JSON.stringify({ name: "custom", models: ["private/multimodal-probe"], caps }),
+    }));
+
+    expect(response.status).toBe(201);
+    expect(mocks.createCombo).toHaveBeenCalledWith(expect.objectContaining({ caps }));
+  });
+
+  it.each([null, false, 0, "", { model: "cx/gpt-5.6-sol" }])(
+    "rejects malformed fallback model lists: %j",
+    async (models) => {
+      const response = await POST(new Request("https://router.test/api/combos", {
+        method: "POST",
+        body: JSON.stringify({ name: "bad-models", models }),
+      }));
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: "Models must be an array of non-empty strings" });
+      expect(mocks.createCombo).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/tests/unit/combo-capabilities-models.test.js
+++ b/tests/unit/combo-capabilities-models.test.js
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getProviderConnections: vi.fn(),
+  getCombos: vi.fn(),
+  getCustomModels: vi.fn(),
+  getModelAliases: vi.fn(),
+  getDisabledModels: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: mocks.getProviderConnections,
+  getCombos: mocks.getCombos,
+  getCustomModels: mocks.getCustomModels,
+  getModelAliases: mocks.getModelAliases,
+}));
+vi.mock("@/lib/disabledModelsDb", () => ({ getDisabledModels: mocks.getDisabledModels }));
+
+const { buildModelsList } = await import("../../src/app/api/v1/models/route.js");
+
+describe("combo model metadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getProviderConnections.mockResolvedValue([]);
+    mocks.getCustomModels.mockResolvedValue([]);
+    mocks.getModelAliases.mockResolvedValue({});
+    mocks.getDisabledModels.mockResolvedValue({});
+  });
+
+  it("advertises configured context and input capabilities", async () => {
+    const caps = {
+      contextWindow: 128000,
+      vision: true,
+      pdf: true,
+      audioInput: false,
+      videoInput: false,
+    };
+    mocks.getCombos.mockResolvedValue([{ name: "mixed", kind: null, models: ["p/model"], caps }]);
+
+    const model = (await buildModelsList(["llm"])).find((entry) => entry.id === "mixed");
+
+    expect(model).toMatchObject({
+      owned_by: "combo",
+      context_length: 128000,
+      capabilities: caps,
+    });
+  });
+
+  it("keeps legacy combos backward compatible", async () => {
+    mocks.getCombos.mockResolvedValue([{ name: "legacy", kind: null, models: ["p/model"] }]);
+
+    const model = (await buildModelsList(["llm"])).find((entry) => entry.id === "legacy");
+
+    expect(model).toEqual({ id: "legacy", object: "model", owned_by: "combo" });
+  });
+});

--- a/tests/unit/combo-capabilities-models.test.js
+++ b/tests/unit/combo-capabilities-models.test.js
@@ -35,7 +35,7 @@ describe("combo model metadata", () => {
       audioInput: false,
       videoInput: false,
     };
-    mocks.getCombos.mockResolvedValue([{ name: "mixed", kind: null, models: ["p/model"], caps }]);
+    mocks.getCombos.mockResolvedValue([{ name: "mixed", kind: null, models: ["glm/glm-5.3-flash"], caps }]);
 
     const model = (await buildModelsList(["llm"])).find((entry) => entry.id === "mixed");
 
@@ -44,6 +44,27 @@ describe("combo model metadata", () => {
       context_length: 128000,
       capabilities: caps,
     });
+  });
+
+  it("clamps advertised metadata when a model override lowers the safe limit", async () => {
+    mocks.getCustomModels.mockResolvedValue([{
+      providerAlias: "cx",
+      id: "gpt-5.6-sol",
+      type: "llm",
+      caps: { contextWindow: 123456, vision: false },
+    }]);
+    mocks.getCombos.mockResolvedValue([{
+      name: "lowered",
+      kind: null,
+      models: ["codex/gpt-5.6-sol"],
+      caps: { contextWindow: 200000, vision: true },
+    }]);
+
+    const model = (await buildModelsList(["llm"])).find((entry) => entry.id === "lowered");
+
+    expect(model.context_length).toBe(123456);
+    expect(model.capabilities.contextWindow).toBe(123456);
+    expect(model.capabilities.vision).toBe(false);
   });
 
   it("keeps legacy combos backward compatible", async () => {

--- a/tests/unit/combo-caps-overrides.test.js
+++ b/tests/unit/combo-caps-overrides.test.js
@@ -27,6 +27,17 @@ describe("combo custom-model context overrides", () => {
     expect(getCaps("acme/model-a").contextWindow).toBe(654321);
   });
 
+  it("normalizes registry secondary aliases like the request router", () => {
+    const getCaps = createComboCapsResolver([{
+      providerAlias: "kimi",
+      id: "kimi-k2.5",
+      type: "llm",
+      caps: { contextWindow: 131072 },
+    }]);
+
+    expect(getCaps("kmc/kimi-k2.5").contextWindow).toBe(131072);
+  });
+
   it("ignores media metadata with the same provider and model ID", () => {
     const base = createComboCapsResolver([])("cx/gpt-5.6-sol");
     const withImageMetadata = createComboCapsResolver([{

--- a/tests/unit/combo-caps-overrides.test.js
+++ b/tests/unit/combo-caps-overrides.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { createComboCapsResolver } from "../../src/lib/comboCaps.js";
+
+describe("combo custom-model context overrides", () => {
+  it("applies an alias-stored override when the model uses the provider ID", () => {
+    const getCaps = createComboCapsResolver([{
+      providerAlias: "cx",
+      id: "gpt-5.6-sol",
+      type: "llm",
+      caps: { contextWindow: 123456 },
+    }]);
+
+    expect(getCaps("codex/gpt-5.6-sol").contextWindow).toBe(123456);
+  });
+
+  it("uses overrides stored under a compatible-provider prefix", () => {
+    const getCaps = createComboCapsResolver([{
+      providerAlias: "acme",
+      id: "model-a",
+      type: "llm",
+      caps: { contextWindow: 654321 },
+    }], [{
+      provider: "openai-compatible",
+      providerSpecificData: { prefix: "acme" },
+    }]);
+
+    expect(getCaps("acme/model-a").contextWindow).toBe(654321);
+  });
+
+  it("ignores media metadata with the same provider and model ID", () => {
+    const base = createComboCapsResolver([])("cx/gpt-5.6-sol");
+    const withImageMetadata = createComboCapsResolver([{
+      providerAlias: "cx",
+      id: "gpt-5.6-sol",
+      type: "image",
+      caps: { contextWindow: 1 },
+    }])("cx/gpt-5.6-sol");
+
+    expect(withImageMetadata).toEqual(base);
+  });
+});

--- a/tests/unit/combo-caps-overrides.test.js
+++ b/tests/unit/combo-caps-overrides.test.js
@@ -27,6 +27,16 @@ describe("combo custom-model context overrides", () => {
     expect(getCaps("acme/model-a").contextWindow).toBe(654321);
   });
 
+  it("resolves bare user model aliases before computing caps", () => {
+    const getCaps = createComboCapsResolver(
+      [{ providerAlias: "glm", id: "glm-5.3-flash", type: "llm", caps: { contextWindow: 111111 } }],
+      [],
+      { "my-probe-alias": "glm/glm-5.3-flash" },
+    );
+
+    expect(getCaps("my-probe-alias").contextWindow).toBe(111111);
+  });
+
   it("normalizes registry secondary aliases like the request router", () => {
     const getCaps = createComboCapsResolver([{
       providerAlias: "kimi",

--- a/tests/unit/combo-caps-reserved-prefix.test.js
+++ b/tests/unit/combo-caps-reserved-prefix.test.js
@@ -1,0 +1,21 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ getCapabilitiesForModel: vi.fn(() => ({ contextWindow: 200000 })) }));
+vi.mock("open-sse/providers/capabilities.js", () => mocks);
+
+const { createComboCapsResolver } = await import("../../src/lib/comboCaps.js");
+
+describe("combo compatible-provider prefixes", () => {
+  beforeEach(() => mocks.getCapabilitiesForModel.mockClear());
+
+  it("does not let a custom connection shadow a built-in provider alias", () => {
+    const getCaps = createComboCapsResolver([], [{
+      provider: "openai-compatible",
+      providerSpecificData: { prefix: "cx" },
+    }]);
+
+    getCaps("cx/model-a");
+
+    expect(mocks.getCapabilitiesForModel).toHaveBeenCalledWith("codex", "model-a");
+  });
+});

--- a/tests/unit/custom-model-context-api.test.js
+++ b/tests/unit/custom-model-context-api.test.js
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const addCustomModel = vi.hoisted(() => vi.fn(async () => true));
+
+vi.mock("@/models", () => ({
+  getCustomModels: vi.fn(async () => []),
+  addCustomModel,
+  deleteCustomModel: vi.fn(),
+}));
+
+const { POST } = await import("../../src/app/api/models/custom/route.js");
+
+function request(contextWindow) {
+  return new Request("http://localhost/api/models/custom", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ providerAlias: "glm", id: "glm-5.3", caps: { contextWindow } }),
+  });
+}
+
+describe("POST /api/models/custom context override", () => {
+  beforeEach(() => addCustomModel.mockClear());
+
+  it("persists a positive integer context window and accepts null to clear it", async () => {
+    expect((await POST(request(262144))).status).toBe(200);
+    expect(addCustomModel).toHaveBeenLastCalledWith(expect.objectContaining({ caps: { contextWindow: 262144 } }));
+
+    expect((await POST(request(null))).status).toBe(200);
+    expect(addCustomModel).toHaveBeenLastCalledWith(expect.objectContaining({ caps: { contextWindow: null } }));
+  });
+
+  it.each([0, -1, 1.5, "262144"])("rejects invalid context window %j", async (value) => {
+    expect((await POST(request(value))).status).toBe(400);
+  });
+});

--- a/tests/unit/db-sqlite-vs-lowdb.test.js
+++ b/tests/unit/db-sqlite-vs-lowdb.test.js
@@ -141,14 +141,21 @@ describe("DB SQLite layer — public API parity", () => {
   });
 
   it("combos: CRUD", async () => {
-    const c = await sqliteDb.createCombo({ name: "combo1", models: ["m1", "m2"], kind: "fallback" });
+    const caps = { contextWindow: 128000, vision: true, pdf: false, audioInput: false, videoInput: false };
+    const c = await sqliteDb.createCombo({ name: "combo1", models: ["m1", "m2"], kind: "fallback", caps });
     expect(c.id).toBeDefined();
     expect(c.models).toEqual(["m1", "m2"]);
+    expect(c.caps).toEqual(caps);
     const byName = await sqliteDb.getComboByName("combo1");
     expect(byName.id).toBe(c.id);
-    await sqliteDb.updateCombo(c.id, { models: ["m3"] });
+    expect(byName.caps).toEqual(caps);
+    await sqliteDb.updateCombo(c.id, { models: ["m3"], caps: { ...caps, contextWindow: 200000 } });
     const updated = await sqliteDb.getComboById(c.id);
     expect(updated.models).toEqual(["m3"]);
+    expect(updated.caps.contextWindow).toBe(200000);
+    const cleared = await sqliteDb.updateCombo(c.id, { caps: null });
+    expect(cleared.caps).toEqual({});
+    expect((await sqliteDb.getComboById(c.id)).caps).toEqual({});
     expect(await sqliteDb.deleteCombo(c.id)).toBe(true);
   });
 

--- a/tests/unit/db-sqlite-vs-lowdb.test.js
+++ b/tests/unit/db-sqlite-vs-lowdb.test.js
@@ -181,6 +181,15 @@ describe("DB SQLite layer — public API parity", () => {
     expect(after.find((m) => m.id === "m1")).toBeUndefined();
   });
 
+  it("customModels: merges and clears one capability override without losing siblings", async () => {
+    await sqliteDb.addCustomModel({ providerAlias: "p1", id: "m2", caps: { vision: true } });
+    await sqliteDb.addCustomModel({ providerAlias: "p1", id: "m2", caps: { contextWindow: 262144 } });
+    expect((await sqliteDb.getCustomModels()).find((m) => m.id === "m2").caps).toEqual({ vision: true, contextWindow: 262144 });
+
+    await sqliteDb.addCustomModel({ providerAlias: "p1", id: "m2", caps: { contextWindow: null } });
+    expect((await sqliteDb.getCustomModels()).find((m) => m.id === "m2").caps).toEqual({ vision: true });
+  });
+
   it("mitmAlias: get/set per tool", async () => {
     await sqliteDb.setMitmAliasAll("cursor", { "gpt-5": "claude-3" });
     const a = await sqliteDb.getMitmAlias("cursor");

--- a/tests/unit/models-input-capabilities.test.js
+++ b/tests/unit/models-input-capabilities.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getCustomModels: vi.fn(async () => []),
+  getProviderConnections: vi.fn(async () => []),
+}));
+
+vi.mock("@/models", () => ({
+  getModelAliases: vi.fn(async () => ({})),
+  getCustomModels: mocks.getCustomModels,
+  setModelAlias: vi.fn(),
+}));
+vi.mock("@/lib/disabledModelsDb", () => ({ getDisabledModels: vi.fn(async () => ({})) }));
+vi.mock("@/lib/localDb", () => ({ getProviderConnections: mocks.getProviderConnections }));
+vi.mock("@/shared/constants/config", () => ({
+  AI_MODELS: [
+    { provider: "gemini", model: "gemini-2.5-pro", name: "Gemini" },
+    { provider: "cx", model: "gpt-5.6-sol", name: "Codex" },
+  ],
+}));
+
+const { GET } = await import("../../src/app/api/models/route.js");
+
+describe("GET /api/models input capabilities", () => {
+  it("exposes every input capability used by combo safety checks", async () => {
+    const response = await GET();
+    const [{ caps }] = (await response.json()).models;
+
+    expect(caps).toMatchObject({
+      vision: true,
+      pdf: false,
+      audioInput: true,
+      videoInput: true,
+      contextWindow: 1048576,
+    });
+  });
+
+  it("exposes the configured prefix for compatible-provider custom models", async () => {
+    mocks.getCustomModels.mockResolvedValueOnce([{
+      providerAlias: "openai-compatible-chat-1",
+      id: "multimodal-probe",
+      caps: { vision: true },
+    }]);
+    mocks.getProviderConnections.mockResolvedValueOnce([{
+      provider: "openai-compatible-chat-1",
+      providerSpecificData: { prefix: "private" },
+    }]);
+
+    const response = await GET();
+    const custom = (await response.json()).models.find((model) => model.model === "multimodal-probe");
+    expect(custom.routedModel).toBe("private/multimodal-probe");
+  });
+
+  it("resolves provider aliases before computing model limits", async () => {
+    const response = await GET();
+    const codex = (await response.json()).models.find((model) => model.fullModel === "cx/gpt-5.6-sol");
+    expect(codex.caps.contextWindow).toBe(372000);
+  });
+});

--- a/tests/unit/models-input-capabilities.test.js
+++ b/tests/unit/models-input-capabilities.test.js
@@ -56,4 +56,30 @@ describe("GET /api/models input capabilities", () => {
     const codex = (await response.json()).models.find((model) => model.fullModel === "cx/gpt-5.6-sol");
     expect(codex.caps.contextWindow).toBe(372000);
   });
+
+  it("applies a stored context override to a built-in provider model", async () => {
+    mocks.getCustomModels.mockResolvedValueOnce([{
+      providerAlias: "gemini",
+      id: "gemini-2.5-pro",
+      type: "llm",
+      caps: { contextWindow: 262144 },
+    }]);
+
+    const response = await GET();
+    const model = (await response.json()).models.find((entry) => entry.fullModel === "gemini/gemini-2.5-pro");
+    expect(model.caps.contextWindow).toBe(262144);
+  });
+
+  it("does not apply non-LLM metadata to a provider model with the same ID", async () => {
+    mocks.getCustomModels.mockResolvedValueOnce([{
+      providerAlias: "gemini",
+      id: "gemini-2.5-pro",
+      type: "image",
+      caps: { contextWindow: 1 },
+    }]);
+
+    const response = await GET();
+    const model = (await response.json()).models.find((entry) => entry.fullModel === "gemini/gemini-2.5-pro");
+    expect(model.caps.contextWindow).toBe(1048576);
+  });
 });

--- a/tests/unit/models-input-capabilities.test.js
+++ b/tests/unit/models-input-capabilities.test.js
@@ -70,6 +70,19 @@ describe("GET /api/models input capabilities", () => {
     expect(model.caps.contextWindow).toBe(262144);
   });
 
+  it("applies a canonical-ID override to an alias-routed provider model", async () => {
+    mocks.getCustomModels.mockResolvedValueOnce([{
+      providerAlias: "codex",
+      id: "gpt-5.6-sol",
+      type: "llm",
+      caps: { contextWindow: 131072 },
+    }]);
+
+    const response = await GET();
+    const model = (await response.json()).models.find((entry) => entry.fullModel === "cx/gpt-5.6-sol");
+    expect(model.caps.contextWindow).toBe(131072);
+  });
+
   it("does not apply non-LLM metadata to a provider model with the same ID", async () => {
     mocks.getCustomModels.mockResolvedValueOnce([{
       providerAlias: "gemini",

--- a/tests/unit/provider-custom-models.test.js
+++ b/tests/unit/provider-custom-models.test.js
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { getProviderCustomModelRows } from "@/shared/utils/providerCustomModels.js";
+import { findProviderModelMetadata, getProviderCustomModelRows } from "@/shared/utils/providerCustomModels.js";
 
 describe("provider custom model rows", () => {
+  it("finds canonical-ID metadata from an alias provider page", () => {
+    const metadata = { providerAlias: "codex", id: "gpt-5.6-sol", type: "llm", caps: { contextWindow: 131072 } };
+
+    expect(findProviderModelMetadata([metadata], "cx", "gpt-5.6-sol")).toBe(metadata);
+  });
+
   it("keeps identical model IDs separate per provider", () => {
     const customModels = [
       { providerAlias: "ollama", id: "minimax-m2.5", type: "llm", name: "MiniMax M2.5" },


### PR DESCRIPTION
## Summary

- let Combo models advertise an optional context window and image, PDF, audio, and video input support
- persist the metadata in SQLite/LowDB while keeping existing Combos backward-compatible
- validate create/update payloads against the common denominator of every fallback model, including custom-model overrides and compatible-provider prefixes
- expose the metadata through `/v1/models`
- enlarge the Combo editor, add a safe `Max` context action, and show each fallback model's context window and supported/unsupported capabilities
- show context windows on provider model rows and allow a local per-model override that can be reset to bundled metadata
- update GLM 5.2 and 5.3 to their documented 1M-token context windows

## Safety

A Combo cannot advertise a context limit or input capability that any configured fallback model lacks. The `Max` action selects the smallest context window shared by every fallback. Explicit malformed model lists return `400`; omitting `models` retains the existing empty-list behavior.

The SQLite change is additive (`caps TEXT`), nullable for old rows, and covered by a schema-version backup before synchronization.

## Verification

- `63/63` focused tests pass on the clean upstream branch
- `next build --webpack` passes on the clean upstream branch
- migrated a copy of a six-Combo SQLite database without data loss
- Lightpanda verified the larger modal, visible per-model details, accessible capability states, `Max` selecting the `372,000` shared limit, reorder/edit state integrity, save, and API read-back
- Lightpanda verified provider context display, override persistence, reset to bundled metadata, and Combo `Max` recalculation to an overridden `262,144` limit
- live validation rejects provider-ID references above alias-stored limits and ignores same-ID media metadata
- Combo validation preserves the router's reserved built-in prefix rules, so custom connections cannot shadow providers such as `cx`
- `/v1/models` clamps previously stored Combo metadata if a later model override lowers the safe context or capability set
- provider-ID and alias-backed overrides resolve identically in both model display and the override/reset editor
- bare Combo fallbacks that are user model aliases resolve to their target model for validation and advertisement, matching runtime
- Chromium screenshots were reviewed at desktop and mobile widths; the modal is readable with no horizontal overflow
- isolated candidate routed a real request through a Combo and returned `200`
- deployed the byte-identical candidate artifact locally; live API persistence, `/v1/models`, UI, and routing probes passed and probe records were deleted
- live service completed 90 local health/API/model-list soak requests with zero failures and zero service restarts

## Notes

Capability-aware fallback selection is intentionally out of scope. This uses the conservative common denominator so existing fallback behavior is unchanged.

## Screenshot

![GLM provider context-window override dialog](https://github.com/user-attachments/assets/59dc80af-1097-4286-83ab-33c4449c0f8b)

![Combo configuration with shared context and capabilities](https://github.com/user-attachments/assets/e9696c9a-031e-480d-afd5-27152c60943e)
