### PR TITLE
fix(translator): skip malformed entries in ensureToolCallIds

### DIFF
--- a/open-sse/translator/concerns/toolCall.js
+++ b/open-sse/translator/concerns/toolCall.js
@@ -10,7 +10,10 @@ export function fallbackToolCallId(index) {
 
 // Generate deterministic tool call ID from position + tool name (cache-friendly)
 export function generateToolCallId(msgIndex = 0, tcIndex = 0, toolName = "") {
-  const name = toolName ? `_${toolName.replace(/[^a-zA-Z0-9_-]/g, "")}` : "";
+  const name =
+    typeof toolName === "string" && toolName
+      ? `_${toolName.replace(/[^a-zA-Z0-9_-]/g, "")}`
+      : "";
   return `call_msg${msgIndex}_tc${tcIndex}${name}`;
 }
 
@@ -27,9 +30,11 @@ export function ensureToolCallIds(body) {
 
   for (let i = 0; i < body.messages.length; i++) {
     const msg = body.messages[i];
+    if (msg === null || typeof msg !== "object") continue;
     if (msg.role === "assistant" && msg.tool_calls && Array.isArray(msg.tool_calls)) {
       for (let j = 0; j < msg.tool_calls.length; j++) {
         const tc = msg.tool_calls[j];
+        if (tc === null || typeof tc !== "object") continue;
         // Validate or regenerate ID for Anthropic compatibility
         if (!tc.id || !TOOL_ID_PATTERN.test(tc.id)) {
           const sanitized = sanitizeToolId(tc.id);
@@ -55,6 +60,7 @@ export function ensureToolCallIds(body) {
     if (Array.isArray(msg.content)) {
       for (let k = 0; k < msg.content.length; k++) {
         const block = msg.content[k];
+        if (block === null || typeof block !== "object") continue;
         if (block.type === "tool_use" && block.id && !TOOL_ID_PATTERN.test(block.id)) {
           const sanitized = sanitizeToolId(block.id);
           block.id = sanitized || generateToolCallId(i, k, block.name);

--- a/tests/unit/translator-toolcall-null-guards.test.js
+++ b/tests/unit/translator-toolcall-null-guards.test.js
@@ -1,0 +1,60 @@
+// Guards for malformed entries in ensureToolCallIds (#3764).
+import { describe, it, expect } from "vitest";
+import {
+  ensureToolCallIds,
+  generateToolCallId,
+} from "../../open-sse/translator/concerns/toolCall.js";
+
+describe("ensureToolCallIds — malformed entries", () => {
+  it("skips null messages instead of throwing", () => {
+    const body = { messages: [null, { role: "user", content: "hi" }] };
+    expect(() => ensureToolCallIds(body)).not.toThrow();
+  });
+
+  it("skips null tool_calls entries instead of throwing", () => {
+    const body = {
+      messages: [{ role: "assistant", tool_calls: [null] }],
+    };
+    expect(() => ensureToolCallIds(body)).not.toThrow();
+  });
+
+  it("skips null content blocks instead of throwing", () => {
+    const body = {
+      messages: [{ role: "assistant", content: [null] }],
+    };
+    expect(() => ensureToolCallIds(body)).not.toThrow();
+  });
+
+  it("repairs numeric function names instead of throwing", () => {
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [{ id: "!!!", function: { name: 123 } }],
+        },
+      ],
+    };
+    expect(() => ensureToolCallIds(body)).not.toThrow();
+    expect(body.messages[0].tool_calls[0].id).toMatch(/^call_msg0_tc0/);
+  });
+
+  it("leaves well-formed bodies untouched", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          role: "assistant",
+          tool_calls: [{ id: "call_1", type: "function", function: { name: "get_weather", arguments: "{}" } }],
+        },
+      ],
+    };
+    ensureToolCallIds(body);
+    expect(body.messages[1].tool_calls[0].id).toBe("call_1");
+  });
+});
+
+describe("generateToolCallId — non-string names", () => {
+  it("ignores numeric names instead of throwing", () => {
+    expect(generateToolCallId(0, 0, 123)).toBe("call_msg0_tc0");
+  });
+});


### PR DESCRIPTION
## Summary

Any client POSTing a malformed OpenAI body crashed every translation path with a raw `TypeError`, because `ensureToolCallIds` runs unconditionally on the request body with no null guards: null messages, null `tool_calls` entries, null content blocks, and non-string function names all threw.

## Details

The fix skips non-object entries and only calls string methods on strings, mirroring the null-block guards `formats/claude.js` already has. Well-formed bodies behave exactly as before. Regression tests: 6 passed (5 fail without the fix). Neighbor suites behave as on clean checkout (one pre-existing failure in `translator-helpers-edge`, present without this change too).

Fixes #3764