### PR TITLE
fix(headroom): rewrite dashboard static asset and link paths in proxy response

### DIFF
--- a/src/app/api/headroom/proxy/[...path]/route.js
+++ b/src/app/api/headroom/proxy/[...path]/route.js
@@ -49,11 +49,15 @@ function forwardedHeaders(request, target) {
   return headers;
 }
 
-function rewriteDashboardHtml(html) {
-  return html.replace(
-    /fetch\('(?=\/(?:stats|health|stats-history|transformations\/feed))/g,
-    `fetch('${DASHBOARD_PREFIX}`,
-  );
+export function rewriteDashboardHtml(html) {
+  return html
+    .replace(
+      /fetch\('(?=\/(?:stats|health|stats-history|transformations\/feed))/g,
+      `fetch('${DASHBOARD_PREFIX}`,
+    )
+    .replace(/(?:src|href)=["']\/dashboard\//g, (match) => {
+      return match.replace("/dashboard/", `${DASHBOARD_PREFIX}/dashboard/`);
+    });
 }
 
 async function proxy(request, { params }) {

--- a/tests/unit/headroom-proxy.test.js
+++ b/tests/unit/headroom-proxy.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { rewriteDashboardHtml } from "../../src/app/api/headroom/proxy/[...path]/route.js";
+
+describe("headroom dashboard html rewrite", () => {
+  it("rewrites static asset paths to use the proxy prefix", () => {
+    const input = `
+      <script src="/dashboard/static/tailwind.min.js"></script>
+      <script src="/dashboard/static/htmx.min.js"></script>
+      <script src="/dashboard/static/alpine.min.js" defer></script>
+    `;
+    const output = rewriteDashboardHtml(input);
+
+    expect(output).toContain('src="/api/headroom/proxy/dashboard/static/tailwind.min.js"');
+    expect(output).toContain('src="/api/headroom/proxy/dashboard/static/htmx.min.js"');
+    expect(output).toContain('src="/api/headroom/proxy/dashboard/static/alpine.min.js"');
+  });
+
+  it("rewrites dashboard settings link", () => {
+    const input = '<a href="/dashboard/settings" id="settings-link">Settings</a>';
+    const output = rewriteDashboardHtml(input);
+
+    expect(output).toContain('href="/api/headroom/proxy/dashboard/settings"');
+  });
+
+  it("rewrites api fetch paths to use the proxy prefix", () => {
+    const input = "fetch('/stats?cached=1'); fetch('/health'); fetch('/stats-history'); fetch('/transformations/feed?limit=50');";
+    const output = rewriteDashboardHtml(input);
+
+    expect(output).toContain("fetch('/api/headroom/proxy/stats?cached=1')");
+    expect(output).toContain("fetch('/api/headroom/proxy/health')");
+    expect(output).toContain("fetch('/api/headroom/proxy/stats-history')");
+    expect(output).toContain("fetch('/api/headroom/proxy/transformations/feed?limit=50')");
+  });
+
+  it("leaves external URLs untouched", () => {
+    const input = '<a href="https://headroom-docs.vercel.app/docs">Docs</a>';
+    const output = rewriteDashboardHtml(input);
+
+    expect(output).toBe(input);
+  });
+});


### PR DESCRIPTION
### Problem
When accessing the Headroom dashboard through 9Router's reverse proxy (`/api/headroom/proxy/dashboard`), the dashboard renders unstyled (plain HTML with default browser styling and broken Alpine.js/HTMX scripts).

### Root Cause
Headroom's HTML includes absolute paths for static assets and dashboard links:
```html
<script src="/dashboard/static/tailwind.min.js"></script>
<script src="/dashboard/static/htmx.min.js"></script>
<script src="/dashboard/static/alpine.min.js" defer></script>
<a href="/dashboard/settings" id="settings-link">
```
While `rewriteDashboardHtml()` was rewriting API calls (`fetch('/stats...)`), it did not rewrite `<script src="/dashboard/static/...">` or `<a href="/dashboard/...">`. As a result, the browser attempts to load `/dashboard/static/*` from 9Router's root, receiving 404 responses and failing to load Tailwind CSS and interactive dependencies.

### Solution
- Updated `rewriteDashboardHtml` in `src/app/api/headroom/proxy/[...path]/route.js` to rewrite `src` and `href` attributes pointing to `/dashboard/` so they route via `${DASHBOARD_PREFIX}/dashboard/` (`/api/headroom/proxy/dashboard/...`).
- Exported `rewriteDashboardHtml` and added a unit test in `tests/unit/headroom-proxy.test.js`.
