### PR TITLE
feat(usage): surface Antigravity weekly quotas

### DIFF
--- a/open-sse/providers/registry/antigravity.js
+++ b/open-sse/providers/registry/antigravity.js
@@ -37,6 +37,7 @@ export default {
     },
     usage: {
       quotaApiUrl: `${ANTIGRAVITY_IDE_BASE_URL}/v1internal:fetchAvailableModels`,
+      quotaSummaryApiUrl: `${ANTIGRAVITY_IDE_BASE_URL}/v1internal:retrieveUserQuotaSummary`,
       loadProjectApiUrl: "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist",
       tokenUrl: "https://oauth2.googleapis.com/token",
     },

--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -35,7 +35,7 @@ import {
 const USAGE_HANDLERS = {
   github: (c) => getGitHubUsage(c.accessToken, c.providerSpecificData, c.proxyOptions),
   "gemini-cli": (c) => getGeminiUsage(c.accessToken, c.providerDataWithProjectId, c.proxyOptions),
-  antigravity: (c) => getAntigravityUsage(c.accessToken, c.providerSpecificData, c.proxyOptions),
+  antigravity: (c) => getAntigravityUsage(c.accessToken, c.providerSpecificData, c.proxyOptions, { force: c.force }),
   claude: (c) => getClaudeUsage(c.accessToken, c.proxyOptions, { force: c.force }),
   codex: (c) => getCodexUsage(c.accessToken, c.proxyOptions),
   kiro: (c) => getKiroUsage(c.accessToken, c.providerSpecificData, c.proxyOptions),

--- a/open-sse/services/usage/antigravityWeeklyQuota.js
+++ b/open-sse/services/usage/antigravityWeeklyQuota.js
@@ -6,12 +6,37 @@
  * Best-effort, fail-open, and non-blocking.
  */
 
+import crypto from "crypto";
 import { ANTIGRAVITY_IDE_BASE_URL, ANTIGRAVITY_IDE_USER_AGENT, ANTIGRAVITY_IDE_VERSION } from "../../providers/shared.js";
 import { U, parseResetTime, fetchWithTimeout } from "./shared.js";
 
 const WEEKLY_QUOTA_TTL_MS = 60 * 1000;
 const weeklyQuotaCache = new Map();
 const inflightRequests = new Map();
+
+/**
+ * Generate a collision-resistant, leak-free cache key from projectId and full accessToken hash.
+ *
+ * @param {string} projectId
+ * @param {string} accessToken
+ * @returns {string}
+ */
+export function getWeeklyCacheKey(projectId, accessToken) {
+  const tokenHash = crypto
+    .createHash("sha256")
+    .update(String(accessToken || ""))
+    .digest("hex")
+    .slice(0, 16);
+  return `${projectId}:${tokenHash}`;
+}
+
+/**
+ * Reset in-memory cache (primarily for unit tests).
+ */
+export function _resetWeeklyQuotaCacheForTesting() {
+  weeklyQuotaCache.clear();
+  inflightRequests.clear();
+}
 
 /**
  * Parse raw retrieveUserQuotaSummary response into family-level weekly quotas.
@@ -84,14 +109,18 @@ export function parseAntigravityWeeklyQuotas(summaryData) {
     if (!Number.isFinite(rawFraction)) continue;
 
     const remainingFraction = Math.max(0, Math.min(1, rawFraction));
-    const total = 1000; // Normalized base matching 9Router convention
+    const remainingPercentage = remainingFraction * 100;
+
+    // Normalize to 0..100 percentage scale (used % / total 100) matching 9Router ratioQuota
+    // convention without fabricating an arbitrary request count (such as 1000).
+    const total = 100;
     const remaining = Math.round(total * remainingFraction);
     const used = Math.max(0, total - remaining);
-    const remainingPercentage = remainingFraction * 100;
 
     quotas[familyKey] = {
       used,
       total,
+      remainingFraction,
       resetAt: parseResetTime(weeklyBucket.resetTime),
       remainingPercentage,
       unlimited: false,
@@ -105,7 +134,7 @@ export function parseAntigravityWeeklyQuotas(summaryData) {
 /**
  * Fetch and parse Antigravity weekly quotas from Google Cloud Code API.
  * Fail-open: returns empty object on any failure.
- * Cached process-locally for 60s.
+ * Cached process-locally for 60s, with immediate bypass on force or exhaustion.
  *
  * @param {string} accessToken - OAuth access token
  * @param {string} projectId - Cloud AI Companion project ID
@@ -121,10 +150,13 @@ export async function fetchAndParseAntigravityWeeklyQuotas(
 ) {
   if (!accessToken || !projectId) return {};
 
-  const cacheKey = `${projectId}:${accessToken.slice(0, 16)}`;
+  const isForce = Boolean(options?.force || proxyOptions?.force);
+  const cacheKey = getWeeklyCacheKey(projectId, accessToken);
   const now = Date.now();
 
-  if (!options.force && weeklyQuotaCache.has(cacheKey)) {
+  if (isForce) {
+    weeklyQuotaCache.delete(cacheKey);
+  } else if (weeklyQuotaCache.has(cacheKey)) {
     const cached = weeklyQuotaCache.get(cacheKey);
     if (cached && cached.expiresAt > now) {
       return cached.quotas;
@@ -165,10 +197,19 @@ export async function fetchAndParseAntigravityWeeklyQuotas(
       const data = await response.json();
       const quotas = parseAntigravityWeeklyQuotas(data);
 
-      weeklyQuotaCache.set(cacheKey, {
-        quotas,
-        expiresAt: Date.now() + WEEKLY_QUOTA_TTL_MS,
-      });
+      // Do not cache exhausted quotas (0% remaining) for 60s to prevent stale green state
+      const isExhausted = Object.values(quotas).some(
+        (q) => typeof q?.remainingPercentage === "number" && q.remainingPercentage <= 0
+      );
+
+      if (!isExhausted && Object.keys(quotas).length > 0) {
+        weeklyQuotaCache.set(cacheKey, {
+          quotas,
+          expiresAt: Date.now() + WEEKLY_QUOTA_TTL_MS,
+        });
+      } else {
+        weeklyQuotaCache.delete(cacheKey);
+      }
 
       // Simple bounded cache cleanup
       if (weeklyQuotaCache.size > 100) {

--- a/open-sse/services/usage/antigravityWeeklyQuota.js
+++ b/open-sse/services/usage/antigravityWeeklyQuota.js
@@ -1,0 +1,192 @@
+/**
+ * Antigravity weekly-quota fetcher + parser
+ *
+ * Enforces family-level weekly quota visibility (Gemini Models, Claude and GPT models)
+ * via Google Cloud Code retrieveUserQuotaSummary RPC.
+ * Best-effort, fail-open, and non-blocking.
+ */
+
+import { ANTIGRAVITY_IDE_BASE_URL, ANTIGRAVITY_IDE_USER_AGENT, ANTIGRAVITY_IDE_VERSION } from "../../providers/shared.js";
+import { U, parseResetTime, fetchWithTimeout } from "./shared.js";
+
+const WEEKLY_QUOTA_TTL_MS = 60 * 1000;
+const weeklyQuotaCache = new Map();
+const inflightRequests = new Map();
+
+/**
+ * Parse raw retrieveUserQuotaSummary response into family-level weekly quotas.
+ * Supports both top-level groups envelope and nested quotaSummary.groups envelope.
+ *
+ * @param {object} summaryData - Raw API response JSON
+ * @returns {Record<string, object>} Quotas map keyed by gemini_weekly / claude_gpt_weekly
+ */
+export function parseAntigravityWeeklyQuotas(summaryData) {
+  if (!summaryData || typeof summaryData !== "object") return {};
+
+  const groups = Array.isArray(summaryData.groups)
+    ? summaryData.groups
+    : Array.isArray(summaryData?.quotaSummary?.groups)
+    ? summaryData.quotaSummary.groups
+    : null;
+
+  if (!groups || groups.length === 0) return {};
+
+  const quotas = {};
+
+  for (const group of groups) {
+    if (!group || typeof group !== "object" || !Array.isArray(group.buckets)) continue;
+
+    const displayName = String(group.displayName || "").trim();
+    let familyKey = null;
+    let familyDisplayName = null;
+
+    if (displayName === "Gemini Models") {
+      familyKey = "gemini_weekly";
+      familyDisplayName = "Gemini Weekly";
+    } else if (displayName === "Claude and GPT models") {
+      familyKey = "claude_gpt_weekly";
+      familyDisplayName = "Claude & GPT Weekly";
+    } else {
+      // Ignore unknown Google family groups safely
+      continue;
+    }
+
+    // Identify weekly bucket:
+    // Priority 1: explicit window === "weekly"
+    // Priority 2 (fallback): conservative /\bweekly\b/i on bucketId or displayName
+    let weeklyBucket = null;
+
+    for (const b of group.buckets) {
+      if (!b || typeof b !== "object") continue;
+      if (b.window === "weekly") {
+        weeklyBucket = b;
+        break;
+      }
+    }
+
+    if (!weeklyBucket) {
+      for (const b of group.buckets) {
+        if (!b || typeof b !== "object") continue;
+        const idMatch = typeof b.bucketId === "string" && /\bweekly\b/i.test(b.bucketId);
+        const nameMatch = typeof b.displayName === "string" && /\bweekly\b/i.test(b.displayName);
+        if (idMatch || nameMatch) {
+          weeklyBucket = b;
+          break;
+        }
+      }
+    }
+
+    if (!weeklyBucket) continue;
+    if (weeklyBucket.disabled === true) continue;
+    if (weeklyBucket.remainingFraction == null) continue;
+
+    const rawFraction = Number(weeklyBucket.remainingFraction);
+    if (!Number.isFinite(rawFraction)) continue;
+
+    const remainingFraction = Math.max(0, Math.min(1, rawFraction));
+    const total = 1000; // Normalized base matching 9Router convention
+    const remaining = Math.round(total * remainingFraction);
+    const used = Math.max(0, total - remaining);
+    const remainingPercentage = remainingFraction * 100;
+
+    quotas[familyKey] = {
+      used,
+      total,
+      resetAt: parseResetTime(weeklyBucket.resetTime),
+      remainingPercentage,
+      unlimited: false,
+      displayName: familyDisplayName,
+    };
+  }
+
+  return quotas;
+}
+
+/**
+ * Fetch and parse Antigravity weekly quotas from Google Cloud Code API.
+ * Fail-open: returns empty object on any failure.
+ * Cached process-locally for 60s.
+ *
+ * @param {string} accessToken - OAuth access token
+ * @param {string} projectId - Cloud AI Companion project ID
+ * @param {object} proxyOptions - Connection proxy options
+ * @param {object} options - Options (e.g. { force: true })
+ * @returns {Promise<Record<string, object>>}
+ */
+export async function fetchAndParseAntigravityWeeklyQuotas(
+  accessToken,
+  projectId,
+  proxyOptions = null,
+  options = {}
+) {
+  if (!accessToken || !projectId) return {};
+
+  const cacheKey = `${projectId}:${accessToken.slice(0, 16)}`;
+  const now = Date.now();
+
+  if (!options.force && weeklyQuotaCache.has(cacheKey)) {
+    const cached = weeklyQuotaCache.get(cacheKey);
+    if (cached && cached.expiresAt > now) {
+      return cached.quotas;
+    }
+  }
+
+  if (inflightRequests.has(cacheKey)) {
+    return await inflightRequests.get(cacheKey);
+  }
+
+  const fetchPromise = (async () => {
+    try {
+      const quotaSummaryUrl =
+        U("antigravity")?.quotaSummaryApiUrl ||
+        `${ANTIGRAVITY_IDE_BASE_URL}/v1internal:retrieveUserQuotaSummary`;
+
+      const response = await fetchWithTimeout(
+        quotaSummaryUrl,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "User-Agent": ANTIGRAVITY_IDE_USER_AGENT,
+            "Content-Type": "application/json",
+            "X-Client-Name": "antigravity",
+            "X-Client-Version": ANTIGRAVITY_IDE_VERSION,
+          },
+          body: JSON.stringify({ project: projectId }),
+        },
+        10000,
+        proxyOptions
+      );
+
+      if (!response || !response.ok) {
+        return {};
+      }
+
+      const data = await response.json();
+      const quotas = parseAntigravityWeeklyQuotas(data);
+
+      weeklyQuotaCache.set(cacheKey, {
+        quotas,
+        expiresAt: Date.now() + WEEKLY_QUOTA_TTL_MS,
+      });
+
+      // Simple bounded cache cleanup
+      if (weeklyQuotaCache.size > 100) {
+        const cur = Date.now();
+        for (const [k, v] of weeklyQuotaCache) {
+          if (v.expiresAt <= cur) weeklyQuotaCache.delete(k);
+        }
+      }
+
+      return quotas;
+    } catch {
+      // Fail-open: network failure, timeout, 5xx, or invalid JSON never throw
+      return {};
+    }
+  })().finally(() => {
+    inflightRequests.delete(cacheKey);
+  });
+
+  inflightRequests.set(cacheKey, fetchPromise);
+  return await fetchPromise;
+}

--- a/open-sse/services/usage/google.js
+++ b/open-sse/services/usage/google.js
@@ -1,3 +1,4 @@
+import { fetchAndParseAntigravityWeeklyQuotas } from "./antigravityWeeklyQuota.js";
 /**
  * Google usage handlers (Gemini CLI + Antigravity)
  */
@@ -122,19 +123,24 @@ export async function getAntigravityUsage(accessToken, providerSpecificData, pro
     const subscriptionInfo = await getAntigravitySubscriptionInfo(accessToken, proxyOptions);
     const projectId = subscriptionInfo?.cloudaicompanionProject || null;
 
-    const response = await fetchWithTimeout(ANTIGRAVITY_CONFIG.quotaApiUrl, {
-      method: "POST",
-      headers: {
-        "Authorization": `Bearer ${accessToken}`,
-        "User-Agent": ANTIGRAVITY_CONFIG.userAgent,
-        "Content-Type": "application/json",
-        "X-Client-Name": "antigravity",
-        "X-Client-Version": ANTIGRAVITY_IDE_VERSION,
-      },
-      body: JSON.stringify({
-        ...(projectId ? { project: projectId } : {})
-      }),
-    }, 10000, proxyOptions);
+    const [response, weeklyQuotas] = await Promise.all([
+      fetchWithTimeout(ANTIGRAVITY_CONFIG.quotaApiUrl, {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${accessToken}`,
+          "User-Agent": ANTIGRAVITY_CONFIG.userAgent,
+          "Content-Type": "application/json",
+          "X-Client-Name": "antigravity",
+          "X-Client-Version": ANTIGRAVITY_IDE_VERSION,
+        },
+        body: JSON.stringify({
+          ...(projectId ? { project: projectId } : {})
+        }),
+      }, 10000, proxyOptions),
+      projectId
+        ? fetchAndParseAntigravityWeeklyQuotas(accessToken, projectId, proxyOptions)
+        : Promise.resolve({}),
+    ]);
 
     if (response.status === 403) {
       return {
@@ -214,7 +220,10 @@ export async function getAntigravityUsage(accessToken, providerSpecificData, pro
 
     return {
       plan: subscriptionInfo?.currentTier?.name || "Unknown",
-      quotas,
+      quotas: {
+        ...quotas,
+        ...weeklyQuotas,
+      },
       subscriptionInfo,
     };
   } catch (error) {

--- a/open-sse/services/usage/google.js
+++ b/open-sse/services/usage/google.js
@@ -123,24 +123,19 @@ export async function getAntigravityUsage(accessToken, providerSpecificData, pro
     const subscriptionInfo = await getAntigravitySubscriptionInfo(accessToken, proxyOptions);
     const projectId = subscriptionInfo?.cloudaicompanionProject || null;
 
-    const [response, weeklyQuotas] = await Promise.all([
-      fetchWithTimeout(ANTIGRAVITY_CONFIG.quotaApiUrl, {
-        method: "POST",
-        headers: {
-          "Authorization": `Bearer ${accessToken}`,
-          "User-Agent": ANTIGRAVITY_CONFIG.userAgent,
-          "Content-Type": "application/json",
-          "X-Client-Name": "antigravity",
-          "X-Client-Version": ANTIGRAVITY_IDE_VERSION,
-        },
-        body: JSON.stringify({
-          ...(projectId ? { project: projectId } : {})
-        }),
-      }, 10000, proxyOptions),
-      projectId
-        ? fetchAndParseAntigravityWeeklyQuotas(accessToken, projectId, proxyOptions)
-        : Promise.resolve({}),
-    ]);
+    const response = await fetchWithTimeout(ANTIGRAVITY_CONFIG.quotaApiUrl, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${accessToken}`,
+        "User-Agent": ANTIGRAVITY_CONFIG.userAgent,
+        "Content-Type": "application/json",
+        "X-Client-Name": "antigravity",
+        "X-Client-Version": ANTIGRAVITY_IDE_VERSION,
+      },
+      body: JSON.stringify({
+        ...(projectId ? { project: projectId } : {})
+      }),
+    }, 10000, proxyOptions);
 
     if (response.status === 403) {
       return {
@@ -160,7 +155,12 @@ export async function getAntigravityUsage(accessToken, providerSpecificData, pro
       throw new Error(`Antigravity API error: ${response.status}`);
     }
 
-    const data = await response.json();
+    const [data, weeklyQuotas] = await Promise.all([
+      response.json(),
+      projectId
+        ? fetchAndParseAntigravityWeeklyQuotas(accessToken, projectId, proxyOptions)
+        : Promise.resolve({}),
+    ]);
     const quotas = {};
 
     // Parse model quotas (inspired by vscode-antigravity-cockpit)

--- a/open-sse/services/usage/google.js
+++ b/open-sse/services/usage/google.js
@@ -117,7 +117,7 @@ async function getGeminiSubscriptionInfo(accessToken, proxyOptions = null) {
 /**
  * Antigravity Usage - Fetch quota from Google Cloud Code API
  */
-export async function getAntigravityUsage(accessToken, providerSpecificData, proxyOptions = null) {
+export async function getAntigravityUsage(accessToken, providerSpecificData, proxyOptions = null, options = {}) {
   try {
     // Fetch subscription info once — reuse for both projectId and plan
     const subscriptionInfo = await getAntigravitySubscriptionInfo(accessToken, proxyOptions);
@@ -158,7 +158,7 @@ export async function getAntigravityUsage(accessToken, providerSpecificData, pro
     const [data, weeklyQuotas] = await Promise.all([
       response.json(),
       projectId
-        ? fetchAndParseAntigravityWeeklyQuotas(accessToken, projectId, proxyOptions)
+        ? fetchAndParseAntigravityWeeklyQuotas(accessToken, projectId, proxyOptions, { force: options?.force === true || proxyOptions?.force === true })
         : Promise.resolve({}),
     ]);
     const quotas = {};

--- a/tests/unit/antigravity-usage-headers.test.js
+++ b/tests/unit/antigravity-usage-headers.test.js
@@ -21,7 +21,7 @@ describe("Antigravity usage headers", () => {
 
     await getAntigravityUsage("access-token", {});
 
-    expect(proxyAwareFetch).toHaveBeenCalledTimes(2);
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(3);
     for (const [, options] of proxyAwareFetch.mock.calls) {
       expect(options.headers["User-Agent"]).toBe("antigravity/ide/2.11.0 darwin/arm64");
       expect(options.headers).not.toHaveProperty("x-request-source");

--- a/tests/unit/antigravity-usage-weekly-integration.test.js
+++ b/tests/unit/antigravity-usage-weekly-integration.test.js
@@ -1,0 +1,262 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { proxyAwareFetch } = vi.hoisted(() => ({
+  proxyAwareFetch: vi.fn(),
+}));
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch,
+}));
+
+describe("Antigravity Usage: Weekly Quota Integration & Fail-Open", () => {
+  beforeEach(() => {
+    proxyAwareFetch.mockReset();
+  });
+
+  it("merges existing per-model quotas with weekly family quotas when summary RPC succeeds", async () => {
+    const { getAntigravityUsage } = await import("../../open-sse/services/usage/google.js");
+
+    proxyAwareFetch.mockImplementation(async (url) => {
+      if (url.includes(":loadCodeAssist")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            cloudaicompanionProject: "test-project-123",
+            currentTier: { name: "Pro" },
+          }),
+        };
+      }
+      if (url.includes(":fetchAvailableModels")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            models: {
+              "gemini-3.8-flash-high": {
+                displayName: "Gemini 3.8 Flash (High)",
+                quotaInfo: { remainingFraction: 0.85, resetTime: "2026-09-04T00:00:00Z" },
+              },
+              "claude-opus-4-6-thinking": {
+                displayName: "Claude Opus 4.6 (Thinking)",
+                quotaInfo: { remainingFraction: 0.5, resetTime: "2026-09-04T00:00:00Z" },
+              },
+            },
+          }),
+        };
+      }
+      if (url.includes(":retrieveUserQuotaSummary")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            groups: [
+              {
+                displayName: "Gemini Models",
+                buckets: [
+                  {
+                    bucketId: "gemini-weekly",
+                    displayName: "Weekly Limit Remaining",
+                    window: "weekly",
+                    remainingFraction: 0.98583066,
+                    resetTime: "2026-09-10T15:50:40Z",
+                  },
+                ],
+              },
+              {
+                displayName: "Claude and GPT models",
+                buckets: [
+                  {
+                    bucketId: "3p-weekly",
+                    displayName: "Weekly Limit Remaining",
+                    window: "weekly",
+                    remainingFraction: 0,
+                    resetTime: "2026-09-06T17:02:34Z",
+                  },
+                ],
+              },
+            ],
+          }),
+        };
+      }
+      return { ok: false, status: 404 };
+    });
+
+    const usage = await getAntigravityUsage("test-access-token", {});
+
+    expect(usage.plan).toBe("Pro");
+
+    // Existing per-model quotas are preserved
+    expect(usage.quotas["gemini-3.8-flash-high"]).toMatchObject({
+      used: 150,
+      total: 1000,
+      remainingPercentage: 85,
+      displayName: "Gemini 3.8 Flash (High)",
+    });
+    expect(usage.quotas["claude-opus-4-6-thinking"]).toMatchObject({
+      used: 500,
+      total: 1000,
+      remainingPercentage: 50,
+      displayName: "Claude Opus 4.6 (Thinking)",
+    });
+
+    // Weekly quotas are merged
+    expect(usage.quotas["gemini_weekly"]).toMatchObject({
+      used: 14,
+      total: 1000,
+      displayName: "Gemini Weekly",
+      unlimited: false,
+    });
+    expect(usage.quotas["gemini_weekly"].remainingPercentage).toBeCloseTo(98.583066, 4);
+
+    expect(usage.quotas["claude_gpt_weekly"]).toMatchObject({
+      used: 1000,
+      total: 1000,
+      remainingPercentage: 0,
+      displayName: "Claude & GPT Weekly",
+      unlimited: false,
+    });
+  });
+
+  it("fails open when retrieveUserQuotaSummary returns 404", async () => {
+    const { getAntigravityUsage } = await import("../../open-sse/services/usage/google.js");
+
+    proxyAwareFetch.mockImplementation(async (url) => {
+      if (url.includes(":loadCodeAssist")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            cloudaicompanionProject: "test-project-404",
+            currentTier: { name: "Pro" },
+          }),
+        };
+      }
+      if (url.includes(":fetchAvailableModels")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            models: {
+              "gemini-3.8-flash-high": {
+                displayName: "Gemini 3.8 Flash (High)",
+                quotaInfo: { remainingFraction: 0.85, resetTime: "2026-09-04T00:00:00Z" },
+              },
+            },
+          }),
+        };
+      }
+      if (url.includes(":retrieveUserQuotaSummary")) {
+        return {
+          ok: false,
+          status: 404,
+          text: async () => "Not Found",
+        };
+      }
+      return { ok: false, status: 500 };
+    });
+
+    const usage = await getAntigravityUsage("test-access-token-404", {});
+
+    // Existing model quota preserved
+    expect(usage.quotas["gemini-3.8-flash-high"]).toMatchObject({
+      used: 150,
+      total: 1000,
+      remainingPercentage: 85,
+    });
+
+    // Weekly quotas absent, no crash
+    expect(usage.quotas).not.toHaveProperty("gemini_weekly");
+    expect(usage.quotas).not.toHaveProperty("claude_gpt_weekly");
+  });
+
+  it("fails open when retrieveUserQuotaSummary returns 429", async () => {
+    const { getAntigravityUsage } = await import("../../open-sse/services/usage/google.js");
+
+    proxyAwareFetch.mockImplementation(async (url) => {
+      if (url.includes(":loadCodeAssist")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            cloudaicompanionProject: "test-project-429",
+            currentTier: { name: "Pro" },
+          }),
+        };
+      }
+      if (url.includes(":fetchAvailableModels")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            models: {
+              "gemini-3.8-flash-high": {
+                displayName: "Gemini 3.8 Flash (High)",
+                quotaInfo: { remainingFraction: 0.85, resetTime: "2026-09-04T00:00:00Z" },
+              },
+            },
+          }),
+        };
+      }
+      if (url.includes(":retrieveUserQuotaSummary")) {
+        return {
+          ok: false,
+          status: 429,
+          text: async () => "Too Many Requests",
+        };
+      }
+      return { ok: false, status: 500 };
+    });
+
+    const usage = await getAntigravityUsage("test-access-token-429", {});
+
+    expect(usage.quotas["gemini-3.8-flash-high"]).toMatchObject({
+      used: 150,
+      total: 1000,
+      remainingPercentage: 85,
+    });
+    expect(usage.quotas).not.toHaveProperty("gemini_weekly");
+    expect(usage.quotas).not.toHaveProperty("claude_gpt_weekly");
+  });
+
+  it("fails open when retrieveUserQuotaSummary throws network exception", async () => {
+    const { getAntigravityUsage } = await import("../../open-sse/services/usage/google.js");
+
+    proxyAwareFetch.mockImplementation(async (url) => {
+      if (url.includes(":loadCodeAssist")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            cloudaicompanionProject: "test-project-net-err",
+            currentTier: { name: "Pro" },
+          }),
+        };
+      }
+      if (url.includes(":fetchAvailableModels")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            models: {
+              "gemini-3.8-flash-high": {
+                displayName: "Gemini 3.8 Flash (High)",
+                quotaInfo: { remainingFraction: 0.85, resetTime: "2026-09-04T00:00:00Z" },
+              },
+            },
+          }),
+        };
+      }
+      if (url.includes(":retrieveUserQuotaSummary")) {
+        throw new Error("DNS resolution failed");
+      }
+      return { ok: false, status: 500 };
+    });
+
+    const usage = await getAntigravityUsage("test-access-token-net-err", {});
+
+    expect(usage.quotas["gemini-3.8-flash-high"]).toBeDefined();
+    expect(usage.quotas).not.toHaveProperty("gemini_weekly");
+    expect(usage.quotas).not.toHaveProperty("claude_gpt_weekly");
+  });
+});

--- a/tests/unit/antigravity-usage-weekly-integration.test.js
+++ b/tests/unit/antigravity-usage-weekly-integration.test.js
@@ -118,6 +118,218 @@ describe("Antigravity Usage: Weekly Quota Integration & Fail-Open", () => {
     });
   });
 
+  it("starts consuming fetchAvailableModels body before waiting for weekly quota", async () => {
+    const { getAntigravityUsage } = await import("../../open-sse/services/usage/google.js");
+
+    let mainBodyConsumptionStarted = false;
+    let weeklyResolvedBeforeMainBodyStarted = false;
+
+    proxyAwareFetch.mockImplementation(async (url) => {
+      if (url.includes(":loadCodeAssist")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ cloudaicompanionProject: "test-proj-order" }),
+        };
+      }
+      if (url.includes(":fetchAvailableModels")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => {
+            mainBodyConsumptionStarted = true;
+            return {
+              models: {
+                "gemini-3.8-flash-high": {
+                  displayName: "Gemini 3.8 Flash (High)",
+                  quotaInfo: { remainingFraction: 0.9, resetTime: "2026-09-04T00:00:00Z" },
+                },
+              },
+            };
+          },
+        };
+      }
+      if (url.includes(":retrieveUserQuotaSummary")) {
+        // Controlled delay simulating network latency
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        if (!mainBodyConsumptionStarted) {
+          weeklyResolvedBeforeMainBodyStarted = true;
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            groups: [
+              {
+                displayName: "Gemini Models",
+                buckets: [
+                  {
+                    bucketId: "gemini-weekly",
+                    displayName: "Weekly Limit Remaining",
+                    window: "weekly",
+                    remainingFraction: 0.95,
+                    resetTime: "2026-09-10T15:50:40Z",
+                  },
+                ],
+              },
+            ],
+          }),
+        };
+      }
+      return { ok: false, status: 404 };
+    });
+
+    const usage = await getAntigravityUsage("test-token-order", {});
+
+    expect(mainBodyConsumptionStarted).toBe(true);
+    expect(weeklyResolvedBeforeMainBodyStarted).toBe(false);
+    expect(usage.quotas["gemini-3.8-flash-high"]).toBeDefined();
+    expect(usage.quotas["gemini_weekly"]).toBeDefined();
+  });
+
+  it("prevents stream truncation on large model responses caused by deferred consumption", async () => {
+    const { getAntigravityUsage } = await import("../../open-sse/services/usage/google.js");
+
+    let weeklyFinished = false;
+
+    proxyAwareFetch.mockImplementation(async (url) => {
+      if (url.includes(":loadCodeAssist")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ cloudaicompanionProject: "test-proj-truncation" }),
+        };
+      }
+      if (url.includes(":fetchAvailableModels")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => {
+            if (weeklyFinished) {
+              throw new SyntaxError("Unexpected token 'v', \"very code \"... is not valid JSON");
+            }
+            return {
+              models: {
+                "gemini-3.8-flash-high": {
+                  displayName: "Gemini 3.8 Flash (High)",
+                  quotaInfo: { remainingFraction: 0.85, resetTime: "2026-09-04T00:00:00Z" },
+                },
+              },
+            };
+          },
+        };
+      }
+      if (url.includes(":retrieveUserQuotaSummary")) {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        weeklyFinished = true;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            groups: [
+              {
+                displayName: "Gemini Models",
+                buckets: [
+                  {
+                    bucketId: "gemini-weekly",
+                    displayName: "Weekly Limit Remaining",
+                    window: "weekly",
+                    remainingFraction: 0.98,
+                    resetTime: "2026-09-10T15:50:40Z",
+                  },
+                ],
+              },
+            ],
+          }),
+        };
+      }
+      return { ok: false, status: 404 };
+    });
+
+    const usage = await getAntigravityUsage("test-token-truncation", {});
+
+    expect(usage.message).toBeUndefined();
+    expect(usage.quotas["gemini-3.8-flash-high"]).toBeDefined();
+    expect(usage.quotas["gemini_weekly"]).toBeDefined();
+  });
+
+  it("successfully handles multiple concurrent Antigravity accounts without errors or state cross-talk", async () => {
+    const { getAntigravityUsage } = await import("../../open-sse/services/usage/google.js");
+
+    const accountCount = 8;
+    const accounts = Array.from({ length: accountCount }, (_, i) => ({
+      token: `token-acc-${i + 1}`,
+      project: `project-acc-${i + 1}`,
+      modelFraction: 0.5 + (i * 0.05),
+      weeklyFraction: 0.8 + (i * 0.02),
+    }));
+
+    proxyAwareFetch.mockImplementation(async (url, options) => {
+      const authHeader = options?.headers?.Authorization || "";
+      const token = authHeader.replace("Bearer ", "");
+      const acc = accounts.find((a) => a.token === token) || accounts[0];
+
+      if (url.includes(":loadCodeAssist")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ cloudaicompanionProject: acc.project }),
+        };
+      }
+      if (url.includes(":fetchAvailableModels")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            models: {
+              "gemini-3.8-flash-high": {
+                displayName: "Gemini 3.8 Flash (High)",
+                quotaInfo: { remainingFraction: acc.modelFraction, resetTime: "2026-09-04T00:00:00Z" },
+              },
+            },
+          }),
+        };
+      }
+      if (url.includes(":retrieveUserQuotaSummary")) {
+        await new Promise((resolve) => setTimeout(resolve, 10 + Math.random() * 20));
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            groups: [
+              {
+                displayName: "Gemini Models",
+                buckets: [
+                  {
+                    bucketId: "gemini-weekly",
+                    displayName: "Weekly Limit Remaining",
+                    window: "weekly",
+                    remainingFraction: acc.weeklyFraction,
+                    resetTime: "2026-09-10T15:50:40Z",
+                  },
+                ],
+              },
+            ],
+          }),
+        };
+      }
+      return { ok: false, status: 404 };
+    });
+
+    const results = await Promise.all(
+      accounts.map((acc) => getAntigravityUsage(acc.token, {}))
+    );
+
+    expect(results).toHaveLength(accountCount);
+    results.forEach((res, i) => {
+      expect(res.message).toBeUndefined();
+      expect(res.quotas["gemini-3.8-flash-high"]).toBeDefined();
+      expect(res.quotas["gemini_weekly"]).toBeDefined();
+      const expectedModelRemaining = Math.round(1000 * accounts[i].modelFraction);
+      expect(res.quotas["gemini-3.8-flash-high"].used).toBe(1000 - expectedModelRemaining);
+    });
+  });
+
   it("fails open when retrieveUserQuotaSummary returns 404", async () => {
     const { getAntigravityUsage } = await import("../../open-sse/services/usage/google.js");
 
@@ -158,14 +370,11 @@ describe("Antigravity Usage: Weekly Quota Integration & Fail-Open", () => {
 
     const usage = await getAntigravityUsage("test-access-token-404", {});
 
-    // Existing model quota preserved
     expect(usage.quotas["gemini-3.8-flash-high"]).toMatchObject({
       used: 150,
       total: 1000,
       remainingPercentage: 85,
     });
-
-    // Weekly quotas absent, no crash
     expect(usage.quotas).not.toHaveProperty("gemini_weekly");
     expect(usage.quotas).not.toHaveProperty("claude_gpt_weekly");
   });
@@ -209,6 +418,106 @@ describe("Antigravity Usage: Weekly Quota Integration & Fail-Open", () => {
     });
 
     const usage = await getAntigravityUsage("test-access-token-429", {});
+
+    expect(usage.quotas["gemini-3.8-flash-high"]).toMatchObject({
+      used: 150,
+      total: 1000,
+      remainingPercentage: 85,
+    });
+    expect(usage.quotas).not.toHaveProperty("gemini_weekly");
+    expect(usage.quotas).not.toHaveProperty("claude_gpt_weekly");
+  });
+
+  it("fails open when retrieveUserQuotaSummary returns 500", async () => {
+    const { getAntigravityUsage } = await import("../../open-sse/services/usage/google.js");
+
+    proxyAwareFetch.mockImplementation(async (url) => {
+      if (url.includes(":loadCodeAssist")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            cloudaicompanionProject: "test-project-500",
+            currentTier: { name: "Pro" },
+          }),
+        };
+      }
+      if (url.includes(":fetchAvailableModels")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            models: {
+              "gemini-3.8-flash-high": {
+                displayName: "Gemini 3.8 Flash (High)",
+                quotaInfo: { remainingFraction: 0.85, resetTime: "2026-09-04T00:00:00Z" },
+              },
+            },
+          }),
+        };
+      }
+      if (url.includes(":retrieveUserQuotaSummary")) {
+        return {
+          ok: false,
+          status: 500,
+          text: async () => "Internal Server Error",
+        };
+      }
+      return { ok: false, status: 500 };
+    });
+
+    const usage = await getAntigravityUsage("test-access-token-500", {});
+
+    expect(usage.quotas["gemini-3.8-flash-high"]).toMatchObject({
+      used: 150,
+      total: 1000,
+      remainingPercentage: 85,
+    });
+    expect(usage.quotas).not.toHaveProperty("gemini_weekly");
+    expect(usage.quotas).not.toHaveProperty("claude_gpt_weekly");
+  });
+
+  it("fails open when retrieveUserQuotaSummary returns malformed JSON", async () => {
+    const { getAntigravityUsage } = await import("../../open-sse/services/usage/google.js");
+
+    proxyAwareFetch.mockImplementation(async (url) => {
+      if (url.includes(":loadCodeAssist")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            cloudaicompanionProject: "test-project-bad-json",
+            currentTier: { name: "Pro" },
+          }),
+        };
+      }
+      if (url.includes(":fetchAvailableModels")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            models: {
+              "gemini-3.8-flash-high": {
+                displayName: "Gemini 3.8 Flash (High)",
+                quotaInfo: { remainingFraction: 0.85, resetTime: "2026-09-04T00:00:00Z" },
+              },
+            },
+          }),
+        };
+      }
+      if (url.includes(":retrieveUserQuotaSummary")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => {
+            throw new SyntaxError("Unexpected token in JSON at position 0");
+          },
+        };
+      }
+      return { ok: false, status: 500 };
+    });
+
+    const usage = await getAntigravityUsage("test-access-token-bad-json", {});
 
     expect(usage.quotas["gemini-3.8-flash-high"]).toMatchObject({
       used: 150,

--- a/tests/unit/antigravity-usage-weekly-integration.test.js
+++ b/tests/unit/antigravity-usage-weekly-integration.test.js
@@ -102,16 +102,16 @@ describe("Antigravity Usage: Weekly Quota Integration & Fail-Open", () => {
 
     // Weekly quotas are merged
     expect(usage.quotas["gemini_weekly"]).toMatchObject({
-      used: 14,
-      total: 1000,
+      used: 1,
+      total: 100,
       displayName: "Gemini Weekly",
       unlimited: false,
     });
     expect(usage.quotas["gemini_weekly"].remainingPercentage).toBeCloseTo(98.583066, 4);
 
     expect(usage.quotas["claude_gpt_weekly"]).toMatchObject({
-      used: 1000,
-      total: 1000,
+      used: 100,
+      total: 100,
       remainingPercentage: 0,
       displayName: "Claude & GPT Weekly",
       unlimited: false,

--- a/tests/unit/antigravity-usage-weekly-integration.test.js
+++ b/tests/unit/antigravity-usage-weekly-integration.test.js
@@ -291,7 +291,9 @@ describe("Antigravity Usage: Weekly Quota Integration & Fail-Open", () => {
         };
       }
       if (url.includes(":retrieveUserQuotaSummary")) {
-        await new Promise((resolve) => setTimeout(resolve, 10 + Math.random() * 20));
+        const accIndex = accounts.findIndex((a) => a.token === token);
+        const delay = 10 + (accIndex >= 0 ? accIndex * 2 : 0);
+        await new Promise((resolve) => setTimeout(resolve, delay));
         return {
           ok: true,
           status: 200,

--- a/tests/unit/antigravity-weekly-quota.test.js
+++ b/tests/unit/antigravity-weekly-quota.test.js
@@ -1,0 +1,490 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { parseResetTime } from "../../open-sse/services/usage/shared.js";
+
+const { proxyAwareFetch } = vi.hoisted(() => ({
+  proxyAwareFetch: vi.fn(),
+}));
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch,
+}));
+
+describe("Antigravity Weekly Quota Parser & Fetcher", () => {
+  beforeEach(() => {
+    proxyAwareFetch.mockReset();
+  });
+
+  describe("Parser: parseAntigravityWeeklyQuotas", () => {
+    it("TEST A — parses real top-level groups envelope with Gemini and Claude/GPT weekly buckets", async () => {
+      const { parseAntigravityWeeklyQuotas } = await import(
+        "../../open-sse/services/usage/antigravityWeeklyQuota.js"
+      );
+
+      const realFixture = {
+        description: "Sanitized quota summary",
+        groups: [
+          {
+            displayName: "Gemini Models",
+            description: "Models within this group: Gemini Flash, Gemini Pro",
+            buckets: [
+              {
+                bucketId: "gemini-weekly",
+                displayName: "Weekly Limit Remaining",
+                window: "weekly",
+                remainingFraction: 0.98583066,
+                resetTime: "2026-09-10T15:50:40Z",
+                disabled: false,
+              },
+              {
+                bucketId: "gemini-5h",
+                displayName: "Five Hour Limit Remaining",
+                window: "5h",
+                remainingFraction: 0.9149841,
+                resetTime: "2026-09-03T21:10:50Z",
+                disabled: false,
+              },
+            ],
+          },
+          {
+            displayName: "Claude and GPT models",
+            description: "Models within this group: Claude Opus, Claude Sonnet, GPT-OSS",
+            buckets: [
+              {
+                bucketId: "3p-weekly",
+                displayName: "Weekly Limit Remaining",
+                window: "weekly",
+                remainingFraction: 0,
+                resetTime: "2026-09-06T17:02:34Z",
+                disabled: false,
+              },
+              {
+                bucketId: "3p-5h",
+                displayName: "Five Hour Limit Remaining",
+                window: "5h",
+                remainingFraction: 1,
+                disabled: true,
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = parseAntigravityWeeklyQuotas(realFixture);
+
+      // Must produce gemini_weekly and claude_gpt_weekly
+      expect(result).toHaveProperty("gemini_weekly");
+      expect(result).toHaveProperty("claude_gpt_weekly");
+
+      // Must NOT produce 5h buckets as new quota keys
+      expect(result).not.toHaveProperty("gemini-5h");
+      expect(result).not.toHaveProperty("3p-5h");
+      expect(result).not.toHaveProperty("gemini_5h");
+      expect(result).not.toHaveProperty("claude_gpt_5h");
+
+      // Gemini Weekly checks
+      expect(result.gemini_weekly).toMatchObject({
+        displayName: "Gemini Weekly",
+        total: 1000,
+        used: 14,
+        unlimited: false,
+      });
+      expect(result.gemini_weekly.remainingPercentage).toBeCloseTo(98.583066, 4);
+      expect(result.gemini_weekly.resetAt).toBe(parseResetTime("2026-09-10T15:50:40Z"));
+
+      // Claude & GPT Weekly checks
+      expect(result.claude_gpt_weekly).toMatchObject({
+        displayName: "Claude & GPT Weekly",
+        total: 1000,
+        used: 1000,
+        remainingPercentage: 0,
+        unlimited: false,
+      });
+      expect(result.claude_gpt_weekly.resetAt).toBe(parseResetTime("2026-09-06T17:02:34Z"));
+    });
+
+    it("TEST B — explicit window discriminator wins even with unusual bucketId/displayName", async () => {
+      const { parseAntigravityWeeklyQuotas } = await import(
+        "../../open-sse/services/usage/antigravityWeeklyQuota.js"
+      );
+
+      const fixture = {
+        groups: [
+          {
+            displayName: "Gemini Models",
+            buckets: [
+              {
+                bucketId: "bucket-tier-alpha",
+                displayName: "Quota Pool Primary",
+                window: "weekly",
+                remainingFraction: 0.75,
+                resetTime: "2026-09-10T00:00:00Z",
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = parseAntigravityWeeklyQuotas(fixture);
+      expect(result).toHaveProperty("gemini_weekly");
+      expect(result.gemini_weekly.displayName).toBe("Gemini Weekly");
+      expect(result.gemini_weekly.remainingPercentage).toBe(75);
+      expect(result.gemini_weekly.used).toBe(250);
+      expect(result.gemini_weekly.total).toBe(1000);
+    });
+
+    it("TEST C — compatibility fallback when window field is absent", async () => {
+      const { parseAntigravityWeeklyQuotas } = await import(
+        "../../open-sse/services/usage/antigravityWeeklyQuota.js"
+      );
+
+      const fixtureWithoutWindow = {
+        groups: [
+          {
+            displayName: "Gemini Models",
+            buckets: [
+              {
+                bucketId: "gemini-weekly-bucket",
+                displayName: "Remaining allowance",
+                remainingFraction: 0.5,
+                resetTime: "2026-09-10T00:00:00Z",
+              },
+              {
+                bucketId: "gemini-session-bucket",
+                displayName: "Session allowance",
+                remainingFraction: 0.9,
+                resetTime: "2026-09-03T20:00:00Z",
+              },
+            ],
+          },
+          {
+            displayName: "Claude and GPT models",
+            buckets: [
+              {
+                bucketId: "pool-3p",
+                displayName: "Weekly Allocation",
+                remainingFraction: 0.4,
+                resetTime: "2026-09-10T00:00:00Z",
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = parseAntigravityWeeklyQuotas(fixtureWithoutWindow);
+      expect(result).toHaveProperty("gemini_weekly");
+      expect(result.gemini_weekly.remainingPercentage).toBe(50);
+      expect(result.gemini_weekly.used).toBe(500);
+      expect(result).toHaveProperty("claude_gpt_weekly");
+      expect(result.claude_gpt_weekly.remainingPercentage).toBe(40);
+      expect(result.claude_gpt_weekly.used).toBe(600);
+    });
+
+    it("TEST D — parses alternate envelope { quotaSummary: { groups: [...] } }", async () => {
+      const { parseAntigravityWeeklyQuotas } = await import(
+        "../../open-sse/services/usage/antigravityWeeklyQuota.js"
+      );
+
+      const alternateEnvelope = {
+        quotaSummary: {
+          groups: [
+            {
+              displayName: "Gemini Models",
+              buckets: [
+                {
+                  window: "weekly",
+                  remainingFraction: 0.8,
+                  resetTime: "2026-09-10T00:00:00Z",
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const result = parseAntigravityWeeklyQuotas(alternateEnvelope);
+      expect(result).toHaveProperty("gemini_weekly");
+      expect(result.gemini_weekly.remainingPercentage).toBe(80);
+    });
+
+    it("TEST E — handles missing third-party group gracefully", async () => {
+      const { parseAntigravityWeeklyQuotas } = await import(
+        "../../open-sse/services/usage/antigravityWeeklyQuota.js"
+      );
+
+      const onlyGemini = {
+        groups: [
+          {
+            displayName: "Gemini Models",
+            buckets: [
+              {
+                window: "weekly",
+                remainingFraction: 0.6,
+                resetTime: "2026-09-10T00:00:00Z",
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = parseAntigravityWeeklyQuotas(onlyGemini);
+      expect(result).toHaveProperty("gemini_weekly");
+      expect(result).not.toHaveProperty("claude_gpt_weekly");
+    });
+
+    it("TEST F — handles missing Gemini group gracefully", async () => {
+      const { parseAntigravityWeeklyQuotas } = await import(
+        "../../open-sse/services/usage/antigravityWeeklyQuota.js"
+      );
+
+      const onlyClaude = {
+        groups: [
+          {
+            displayName: "Claude and GPT models",
+            buckets: [
+              {
+                window: "weekly",
+                remainingFraction: 0.2,
+                resetTime: "2026-09-10T00:00:00Z",
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = parseAntigravityWeeklyQuotas(onlyClaude);
+      expect(result).toHaveProperty("claude_gpt_weekly");
+      expect(result).not.toHaveProperty("gemini_weekly");
+    });
+
+    it("TEST G — skips disabled weekly bucket but preserves weekly when sibling 5h is disabled", async () => {
+      const { parseAntigravityWeeklyQuotas } = await import(
+        "../../open-sse/services/usage/antigravityWeeklyQuota.js"
+      );
+
+      // Case 1: weekly bucket itself is disabled
+      const weeklyDisabled = {
+        groups: [
+          {
+            displayName: "Gemini Models",
+            buckets: [
+              {
+                window: "weekly",
+                remainingFraction: 0.5,
+                disabled: true,
+                resetTime: "2026-09-10T00:00:00Z",
+              },
+            ],
+          },
+        ],
+      };
+      expect(parseAntigravityWeeklyQuotas(weeklyDisabled)).toEqual({});
+
+      // Case 2: 5h sibling is disabled, weekly is NOT disabled (real live scenario)
+      const siblingDisabled = {
+        groups: [
+          {
+            displayName: "Claude and GPT models",
+            buckets: [
+              {
+                window: "weekly",
+                remainingFraction: 0,
+                disabled: false,
+                resetTime: "2026-09-06T17:02:34Z",
+              },
+              {
+                window: "5h",
+                remainingFraction: 1,
+                disabled: true,
+                resetTime: "2026-09-03T21:30:12Z",
+              },
+            ],
+          },
+        ],
+      };
+      const res = parseAntigravityWeeklyQuotas(siblingDisabled);
+      expect(res).toHaveProperty("claude_gpt_weekly");
+      expect(res.claude_gpt_weekly.used).toBe(1000);
+      expect(res.claude_gpt_weekly.remainingPercentage).toBe(0);
+    });
+
+    it("TEST H — handles malformed or unexpected input safely without throwing", async () => {
+      const { parseAntigravityWeeklyQuotas } = await import(
+        "../../open-sse/services/usage/antigravityWeeklyQuota.js"
+      );
+
+      expect(parseAntigravityWeeklyQuotas(null)).toEqual({});
+      expect(parseAntigravityWeeklyQuotas(undefined)).toEqual({});
+      expect(parseAntigravityWeeklyQuotas({})).toEqual({});
+      expect(parseAntigravityWeeklyQuotas("string")).toEqual({});
+      expect(parseAntigravityWeeklyQuotas({ groups: null })).toEqual({});
+      expect(parseAntigravityWeeklyQuotas({ groups: [] })).toEqual({});
+      expect(parseAntigravityWeeklyQuotas({ groups: [{}] })).toEqual({});
+      expect(
+        parseAntigravityWeeklyQuotas({
+          groups: [
+            {
+              displayName: "Unknown Family Group",
+              buckets: [{ window: "weekly", remainingFraction: 0.5 }],
+            },
+          ],
+        })
+      ).toEqual({});
+      expect(
+        parseAntigravityWeeklyQuotas({
+          groups: [
+            {
+              displayName: "Gemini Models",
+              buckets: [{ window: "weekly" }], // missing remainingFraction
+            },
+          ],
+        })
+      ).toEqual({});
+    });
+
+    it("TEST I — safely clamps fraction boundaries into 0..1", async () => {
+      const { parseAntigravityWeeklyQuotas } = await import(
+        "../../open-sse/services/usage/antigravityWeeklyQuota.js"
+      );
+
+      const fixture = {
+        groups: [
+          {
+            displayName: "Gemini Models",
+            buckets: [
+              {
+                window: "weekly",
+                remainingFraction: 1.5, // > 1
+                resetTime: "2026-09-10T00:00:00Z",
+              },
+            ],
+          },
+          {
+            displayName: "Claude and GPT models",
+            buckets: [
+              {
+                window: "weekly",
+                remainingFraction: -0.2, // < 0
+                resetTime: "2026-09-10T00:00:00Z",
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = parseAntigravityWeeklyQuotas(fixture);
+      expect(result.gemini_weekly.remainingPercentage).toBe(100);
+      expect(result.gemini_weekly.used).toBe(0);
+      expect(result.gemini_weekly.total).toBe(1000);
+
+      expect(result.claude_gpt_weekly.remainingPercentage).toBe(0);
+      expect(result.claude_gpt_weekly.used).toBe(1000);
+      expect(result.claude_gpt_weekly.total).toBe(1000);
+    });
+
+    it("TEST J — uses parseResetTime semantics for reset timestamps", async () => {
+      const { parseAntigravityWeeklyQuotas } = await import(
+        "../../open-sse/services/usage/antigravityWeeklyQuota.js"
+      );
+
+      const timestamp = "2026-09-10T15:50:40Z";
+      const fixture = {
+        groups: [
+          {
+            displayName: "Gemini Models",
+            buckets: [
+              {
+                window: "weekly",
+                remainingFraction: 0.5,
+                resetTime: timestamp,
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = parseAntigravityWeeklyQuotas(fixture);
+      expect(result.gemini_weekly.resetAt).toBe(parseResetTime(timestamp));
+    });
+  });
+
+  describe("Fetcher: fetchAndParseAntigravityWeeklyQuotas", () => {
+    it("TEST K1 — missing inputs return {} immediately", async () => {
+      const { fetchAndParseAntigravityWeeklyQuotas } = await import(
+        "../../open-sse/services/usage/antigravityWeeklyQuota.js"
+      );
+
+      expect(await fetchAndParseAntigravityWeeklyQuotas(null, "p1")).toEqual({});
+      expect(await fetchAndParseAntigravityWeeklyQuotas("tok", null)).toEqual({});
+      expect(await fetchAndParseAntigravityWeeklyQuotas("", "")).toEqual({});
+      expect(proxyAwareFetch).not.toHaveBeenCalled();
+    });
+
+    it("TEST K2 — upstream 404/429/500 fails open and returns {}", async () => {
+      const { fetchAndParseAntigravityWeeklyQuotas } = await import(
+        "../../open-sse/services/usage/antigravityWeeklyQuota.js"
+      );
+
+      proxyAwareFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      });
+
+      const res404 = await fetchAndParseAntigravityWeeklyQuotas("tok-404", "proj-404", null, { force: true });
+      expect(res404).toEqual({});
+
+      proxyAwareFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+      });
+
+      const res429 = await fetchAndParseAntigravityWeeklyQuotas("tok-429", "proj-429", null, { force: true });
+      expect(res429).toEqual({});
+    });
+
+    it("TEST K3 — network exception / timeout fails open and returns {}", async () => {
+      const { fetchAndParseAntigravityWeeklyQuotas } = await import(
+        "../../open-sse/services/usage/antigravityWeeklyQuota.js"
+      );
+
+      proxyAwareFetch.mockRejectedValueOnce(new Error("ETIMEDOUT"));
+
+      const res = await fetchAndParseAntigravityWeeklyQuotas("tok-err", "proj-err", null, { force: true });
+      expect(res).toEqual({});
+    });
+
+    it("TEST K4 — successful RPC response parses and caches correctly", async () => {
+      const { fetchAndParseAntigravityWeeklyQuotas } = await import(
+        "../../open-sse/services/usage/antigravityWeeklyQuota.js"
+      );
+
+      proxyAwareFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          groups: [
+            {
+              displayName: "Gemini Models",
+              buckets: [
+                {
+                  window: "weekly",
+                  remainingFraction: 0.95,
+                  resetTime: "2026-09-10T12:00:00Z",
+                },
+              ],
+            },
+          ],
+        }),
+      });
+
+      const res = await fetchAndParseAntigravityWeeklyQuotas("tok-cache-test", "proj-cache-test");
+      expect(res).toHaveProperty("gemini_weekly");
+      expect(res.gemini_weekly.remainingPercentage).toBe(95);
+      expect(proxyAwareFetch).toHaveBeenCalledTimes(1);
+
+      // Second call should return from cache without additional network request
+      const cachedRes = await fetchAndParseAntigravityWeeklyQuotas("tok-cache-test", "proj-cache-test");
+      expect(cachedRes).toHaveProperty("gemini_weekly");
+      expect(proxyAwareFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/unit/antigravity-weekly-quota.test.js
+++ b/tests/unit/antigravity-weekly-quota.test.js
@@ -84,8 +84,8 @@ describe("Antigravity Weekly Quota Parser & Fetcher", () => {
       // Gemini Weekly checks
       expect(result.gemini_weekly).toMatchObject({
         displayName: "Gemini Weekly",
-        total: 1000,
-        used: 14,
+        total: 100,
+        used: 1,
         unlimited: false,
       });
       expect(result.gemini_weekly.remainingPercentage).toBeCloseTo(98.583066, 4);
@@ -94,8 +94,8 @@ describe("Antigravity Weekly Quota Parser & Fetcher", () => {
       // Claude & GPT Weekly checks
       expect(result.claude_gpt_weekly).toMatchObject({
         displayName: "Claude & GPT Weekly",
-        total: 1000,
-        used: 1000,
+        total: 100,
+        used: 100,
         remainingPercentage: 0,
         unlimited: false,
       });
@@ -128,8 +128,8 @@ describe("Antigravity Weekly Quota Parser & Fetcher", () => {
       expect(result).toHaveProperty("gemini_weekly");
       expect(result.gemini_weekly.displayName).toBe("Gemini Weekly");
       expect(result.gemini_weekly.remainingPercentage).toBe(75);
-      expect(result.gemini_weekly.used).toBe(250);
-      expect(result.gemini_weekly.total).toBe(1000);
+      expect(result.gemini_weekly.used).toBe(25);
+      expect(result.gemini_weekly.total).toBe(100);
     });
 
     it("TEST C — compatibility fallback when window field is absent", async () => {
@@ -173,10 +173,10 @@ describe("Antigravity Weekly Quota Parser & Fetcher", () => {
       const result = parseAntigravityWeeklyQuotas(fixtureWithoutWindow);
       expect(result).toHaveProperty("gemini_weekly");
       expect(result.gemini_weekly.remainingPercentage).toBe(50);
-      expect(result.gemini_weekly.used).toBe(500);
+      expect(result.gemini_weekly.used).toBe(50);
       expect(result).toHaveProperty("claude_gpt_weekly");
       expect(result.claude_gpt_weekly.remainingPercentage).toBe(40);
-      expect(result.claude_gpt_weekly.used).toBe(600);
+      expect(result.claude_gpt_weekly.used).toBe(60);
     });
 
     it("TEST D — parses alternate envelope { quotaSummary: { groups: [...] } }", async () => {
@@ -303,7 +303,7 @@ describe("Antigravity Weekly Quota Parser & Fetcher", () => {
       };
       const res = parseAntigravityWeeklyQuotas(siblingDisabled);
       expect(res).toHaveProperty("claude_gpt_weekly");
-      expect(res.claude_gpt_weekly.used).toBe(1000);
+      expect(res.claude_gpt_weekly.used).toBe(100);
       expect(res.claude_gpt_weekly.remainingPercentage).toBe(0);
     });
 
@@ -374,11 +374,11 @@ describe("Antigravity Weekly Quota Parser & Fetcher", () => {
       const result = parseAntigravityWeeklyQuotas(fixture);
       expect(result.gemini_weekly.remainingPercentage).toBe(100);
       expect(result.gemini_weekly.used).toBe(0);
-      expect(result.gemini_weekly.total).toBe(1000);
+      expect(result.gemini_weekly.total).toBe(100);
 
       expect(result.claude_gpt_weekly.remainingPercentage).toBe(0);
-      expect(result.claude_gpt_weekly.used).toBe(1000);
-      expect(result.claude_gpt_weekly.total).toBe(1000);
+      expect(result.claude_gpt_weekly.used).toBe(100);
+      expect(result.claude_gpt_weekly.total).toBe(100);
     });
 
     it("TEST J — uses parseResetTime semantics for reset timestamps", async () => {
@@ -485,6 +485,95 @@ describe("Antigravity Weekly Quota Parser & Fetcher", () => {
       const cachedRes = await fetchAndParseAntigravityWeeklyQuotas("tok-cache-test", "proj-cache-test");
       expect(cachedRes).toHaveProperty("gemini_weekly");
       expect(proxyAwareFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("TEST K5 — cache key uses sha256 hash of token without raw token leakage or prefix collision", async () => {
+      const { getWeeklyCacheKey } = await import(
+        "../../open-sse/services/usage/antigravityWeeklyQuota.js"
+      );
+
+      const tokenA = "dummy-token-sameprefix-AAAAA";
+      const tokenB = "dummy-token-sameprefix-BBBBB";
+
+      const keyA = getWeeklyCacheKey("proj-1", tokenA);
+      const keyB = getWeeklyCacheKey("proj-1", tokenB);
+
+      expect(keyA).not.toBe(keyB);
+      expect(keyA.startsWith("proj-1:")).toBe(true);
+      expect(keyA).not.toContain("ya29.");
+      expect(keyA).not.toContain("sameprefix");
+    });
+
+    it("TEST K6 — options.force bypasses cached quotas and performs live fetch", async () => {
+      const { fetchAndParseAntigravityWeeklyQuotas, _resetWeeklyQuotaCacheForTesting } = await import(
+        "../../open-sse/services/usage/antigravityWeeklyQuota.js"
+      );
+      _resetWeeklyQuotaCacheForTesting();
+
+      proxyAwareFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          groups: [
+            {
+              displayName: "Gemini Models",
+              buckets: [
+                {
+                  window: "weekly",
+                  remainingFraction: 0.90,
+                  resetTime: "2026-09-10T12:00:00Z",
+                },
+              ],
+            },
+          ],
+        }),
+      });
+
+      // 1. Initial call populates cache
+      const res1 = await fetchAndParseAntigravityWeeklyQuotas("tok-force", "proj-force");
+      expect(res1.gemini_weekly.remainingPercentage).toBe(90);
+      expect(proxyAwareFetch).toHaveBeenCalledTimes(1);
+
+      // 2. Call with force: true bypasses cache
+      const res2 = await fetchAndParseAntigravityWeeklyQuotas("tok-force", "proj-force", null, { force: true });
+      expect(res2.gemini_weekly.remainingPercentage).toBe(90);
+      expect(proxyAwareFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("TEST K7 — exhausted weekly quotas (0% remaining) are evicted and not cached", async () => {
+      const { fetchAndParseAntigravityWeeklyQuotas, _resetWeeklyQuotaCacheForTesting } = await import(
+        "../../open-sse/services/usage/antigravityWeeklyQuota.js"
+      );
+      _resetWeeklyQuotaCacheForTesting();
+
+      proxyAwareFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          groups: [
+            {
+              displayName: "Gemini Models",
+              buckets: [
+                {
+                  window: "weekly",
+                  remainingFraction: 0,
+                  resetTime: "2026-09-10T12:00:00Z",
+                },
+              ],
+            },
+          ],
+        }),
+      });
+
+      // 1. Call with exhausted quota
+      const res1 = await fetchAndParseAntigravityWeeklyQuotas("tok-zero", "proj-zero");
+      expect(res1.gemini_weekly.remainingPercentage).toBe(0);
+      expect(proxyAwareFetch).toHaveBeenCalledTimes(1);
+
+      // 2. Subsequent call must NOT be served from a stale 60s cache
+      const res2 = await fetchAndParseAntigravityWeeklyQuotas("tok-zero", "proj-zero");
+      expect(res2.gemini_weekly.remainingPercentage).toBe(0);
+      expect(proxyAwareFetch).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds family-level Antigravity weekly quota visibility alongside the existing
per-model quota data.

Google exposes these limits through a separate Cloud Code RPC:

```text
v1internal:retrieveUserQuotaSummary
```

The response includes weekly buckets for:

* `Gemini Models`
* `Claude and GPT models`

9Router exposes them as:

* `gemini_weekly` → `Gemini Weekly`
* `claude_gpt_weekly` → `Claude & GPT Weekly`

The existing Provider Limits UI already renders quota entries generically, so
no frontend-specific change is required.

## Motivation

The existing Antigravity usage path reads per-model quota information from
`fetchAvailableModels`, which reflects the shorter quota window.

An account can therefore appear available in the existing quota view while its
family-level weekly pool is exhausted.

Displaying the weekly pools separately makes both limits visible without
changing routing or credential selection.

## Implementation

This PR:

1. Adds `quotaSummaryApiUrl` to the Antigravity usage transport config.

2. Adds a small weekly quota helper that requests:

```text
v1internal:retrieveUserQuotaSummary
```

3. Supports both:

```js
{ groups: [...] }
```

and the defensive alternate shape:

```js
{ quotaSummary: { groups: [...] } }
```

4. Uses:

```text
window: "weekly"
```

as the primary weekly bucket discriminator, with a conservative
`weekly` identifier fallback.

5. Maps:

```text
Gemini Models
-> gemini_weekly
-> Gemini Weekly

Claude and GPT models
-> claude_gpt_weekly
-> Claude & GPT Weekly
```

6. Merges these entries into the existing Antigravity `quotas` object.

## Response consumption ordering

`fetchAvailableModels` can return a relatively large response.

The main response body is therefore consumed immediately after its HTTP status
is checked, while the weekly summary request runs concurrently:

```js
const [data, weeklyQuotas] = await Promise.all([
  response.json(),
  fetchWeeklyQuotas(),
]);
```

This avoids delaying consumption of the existing quota response while waiting
for the additional network request.

Regression coverage includes concurrent multi-account usage refreshes.

## Failure behavior

The weekly quota request is best-effort and fail-open.

Failures such as:

* network errors
* 404 / 429 / 5xx
* malformed JSON
* unexpected response shapes

produce no weekly rows while preserving the existing per-model quota result.

No routing behavior changes.

## Caching

Weekly results use a small process-local cache to avoid repeatedly requesting
the quota summary during dashboard refreshes.

There is no database persistence or migration.

## Tests

Coverage includes:

* weekly group parsing
* explicit `window: "weekly"` detection
* compatibility fallback detection
* alternate response envelope
* missing quota families
* disabled weekly buckets
* malformed input
* remaining-fraction bounds
* reset-time parsing
* cache behavior
* HTTP/network fail-open behavior
* malformed JSON fail-open behavior
* main-response consumption ordering
* delayed response-consumption regression
* concurrent multi-account Antigravity usage

Relevant existing Antigravity and Gemini usage regressions also pass.

## Validation

Validated through the normal 9Router usage path with multiple real Antigravity
OAuth connections.

Both sequential and concurrent account refreshes completed successfully while:

* existing per-model quota rows remained intact
* both weekly family rows were returned
* no duplicate 5-hour family-summary rows appeared
* Antigravity Gemini inference remained unaffected

No account identifiers, credentials, or private infrastructure information are
included here.

## Scope

This PR intentionally does not:

* change credential selection
* change account fallback
* use weekly quota for routing decisions
* change Antigravity circuit-breaker behavior
* modify `/v1/models`
* modify Model Catalog Sync
* add a database migration
* add frontend-specific code
* modify the shared network transport

It only extends the existing Antigravity usage data with weekly quota
visibility.

## Prior art

The separate weekly quota RPC and family-level quota concept have also been
observed in OmniRoute:

* diegosouzapw/OmniRoute#4017
* diegosouzapw/OmniRoute#6818

This implementation is adapted to 9Router's existing usage transport,
proxy-aware request path, quota data shape, caching, and fail-open behavior.
