### PR TITLE
fix(errors): stop reporting an unconfigured provider as a missing model

### DIFF
--- a/open-sse/utils/error.js
+++ b/open-sse/utils/error.js
@@ -6,7 +6,7 @@ import { ERROR_TYPES, DEFAULT_ERROR_MESSAGES } from "../config/errorConfig.js";
  * @param {string} message - Error message
  * @returns {object} Error response object
  */
-export function buildErrorBody(statusCode, message) {
+export function buildErrorBody(statusCode, message, overrides = null) {
   const errorInfo = ERROR_TYPES[statusCode] || 
     (statusCode >= 500 
       ? { type: "server_error", code: "internal_server_error" }
@@ -15,8 +15,12 @@ export function buildErrorBody(statusCode, message) {
   return {
     error: {
       message: message || DEFAULT_ERROR_MESSAGES[statusCode] || "An error occurred",
-      type: errorInfo.type,
-      code: errorInfo.code
+      // ERROR_TYPES maps one code to a whole status, which is right for most of
+      // them but not for 404: it hardcodes "model_not_found", so every 404 claims
+      // the model is unknown even when the real cause is something else. Callers
+      // that know better pass the accurate pair.
+      type: overrides?.type || errorInfo.type,
+      code: overrides?.code || errorInfo.code
     }
   };
 }
@@ -27,8 +31,8 @@ export function buildErrorBody(statusCode, message) {
  * @param {string} message - Error message
  * @returns {Response} HTTP Response object
  */
-export function errorResponse(statusCode, message) {
-  return new Response(JSON.stringify(buildErrorBody(statusCode, message)), {
+export function errorResponse(statusCode, message, overrides = null) {
+  return new Response(JSON.stringify(buildErrorBody(statusCode, message, overrides)), {
     status: statusCode,
     headers: {
       "Content-Type": "application/json",

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -123,6 +123,25 @@ export function resolveProviderId(aliasOrId) {
   return provider?.id || aliasOrId;
 }
 
+/**
+ * Is this something the router could route to at all, as opposed to a name it has
+ * never heard of?
+ *
+ * Two things count. The registry, resolved through aliases so "cmc" is as valid as
+ * "commandcode". And the user-defined compatible nodes, whose ids carry a prefix
+ * and are deliberately absent from the registry — they reach account selection by
+ * exactly the same path, so a registry-only check would report a user's own node
+ * as an unknown provider the moment its connection went inactive.
+ *
+ * Says nothing about whether an account is connected. That is a separate question
+ * with a separate answer for the caller.
+ */
+export function isRoutableProvider(aliasOrId) {
+  if (!aliasOrId) return false;
+  if (getProviderByAlias(aliasOrId)) return true;
+  return isOpenAICompatibleProvider(aliasOrId) || isAnthropicCompatibleProvider(aliasOrId);
+}
+
 // Helper: Get alias from provider ID
 export function getProviderAlias(providerId) {
   const provider = AI_PROVIDERS[providerId];

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -9,6 +9,7 @@ import {
 } from "../services/auth.js";
 import { handleAntigravityQuotaError, clearAntigravityStrikes } from "../services/antigravityQuota.js";
 import { getSettings } from "@/lib/localDb";
+import { isRoutableProvider } from "@/shared/constants/providers.js";
 import { getModelInfo, getComboModels } from "../services/model.js";
 import { handleChatCore } from "open-sse/handlers/chatCore.js";
 import { DEFAULT_HEADROOM_URL } from "@/lib/headroom/detect";
@@ -242,8 +243,28 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
         return unavailableResponse(status, `[${provider}/${model}] ${errorMsg}`, credentials.retryAfter, credentials.retryAfterHuman);
       }
       if (excludeConnectionIds.size === 0) {
-        log.warn("AUTH", `No active credentials for provider: ${provider}`);
-        return errorResponse(HTTP_STATUS.NOT_FOUND, `No active credentials for provider: ${provider}`);
+        // 404 is right either way here, because /v1/models filters on isActive too,
+        // so the model genuinely is not in the catalogue. What differs is WHY, and
+        // the 404 code table hardcodes "model_not_found" for both cases.
+        if (isRoutableProvider(provider)) {
+          // We serve this provider; the operator just has no account linked.
+          // Saying "model not found" sends clients hunting for a bad model name
+          // when the fix is a dashboard action only the operator can take.
+          log.warn("AUTH", `No active credentials for provider: ${provider}`);
+          return errorResponse(
+            HTTP_STATUS.NOT_FOUND,
+            `No active credentials for provider: ${provider}. Connect an account for this provider in the dashboard.`,
+            { code: "provider_not_configured" },
+          );
+        }
+        // Not a provider we serve at all, so telling the operator to go connect an
+        // account for it is a dead end. Here "model not found" is the truth, and
+        // naming the unrecognised half is what makes it actionable.
+        log.warn("AUTH", `Unknown provider: ${provider}`);
+        return errorResponse(
+          HTTP_STATUS.NOT_FOUND,
+          `Unknown provider "${provider}" in model "${provider}/${model}". See /v1/models for what this router serves.`,
+        );
       }
       log.warn("CHAT", "No more accounts available", { provider });
       return errorResponse(lastStatus || HTTP_STATUS.SERVICE_UNAVAILABLE, lastError || "All accounts unavailable");

--- a/tests/unit/provider-error-codes.test.js
+++ b/tests/unit/provider-error-codes.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { buildErrorBody } from "open-sse/utils/error.js";
+import { isRoutableProvider } from "@/shared/constants/providers.js";
+
+/**
+ * ERROR_TYPES maps one code per status, and for 404 that code is
+ * "model_not_found". That is right when the model really is unknown, and wrong
+ * for the other 404 the chat handler emits: "no account connected for this
+ * provider". A client reading model_not_found there looks for a bad model name,
+ * when the fix is a dashboard action only the operator can take.
+ */
+describe("404 error codes", () => {
+  it("still says model_not_found by default, so existing callers are unchanged", () => {
+    expect(buildErrorBody(404, "x").error).toMatchObject({
+      type: "invalid_request_error",
+      code: "model_not_found",
+    });
+  });
+
+  it("lets a caller that knows better name the real cause", () => {
+    expect(buildErrorBody(404, "x", { code: "provider_not_configured" }).error).toMatchObject({
+      type: "invalid_request_error",
+      code: "provider_not_configured",
+    });
+  });
+
+  it.each([
+    [400, "bad_request"],
+    [401, "invalid_api_key"],
+    [429, "rate_limit_exceeded"],
+    [503, "service_unavailable"],
+  ])("leaves %i alone", (status, code) => {
+    expect(buildErrorBody(status, "x").error.code).toBe(code);
+  });
+
+  it("keeps the table's type when only the code is overridden", () => {
+    expect(buildErrorBody(404, "x", { code: "provider_not_configured" }).error.type)
+      .toBe("invalid_request_error");
+  });
+
+  it("keeps the table's code when only the type is overridden", () => {
+    expect(buildErrorBody(404, "x", { type: "server_error" }).error.code).toBe("model_not_found");
+  });
+});
+
+/**
+ * "No account connected" and "no such provider" reach the same line in
+ * chat.js but have different fixes, so they need different answers. Telling
+ * someone with a typo to go connect an account for a provider that does not
+ * exist is a dead end.
+ */
+describe("isRoutableProvider", () => {
+  it.each([
+    ["a registry id", "codex"],
+    ["another registry id", "claude"],
+    ["an alias", "cc"],
+    ["a hyphenated id", "gemini-cli"],
+  ])("accepts %s", (_label, name) => {
+    expect(isRoutableProvider(name)).toBe(true);
+  });
+
+  // These carry a prefix and are deliberately absent from the registry, yet they
+  // reach account selection by the identical path. A registry-only check would
+  // call a user's own node an unknown provider the moment it went inactive.
+  it.each([
+    ["an openai-compatible node", "openai-compatible-mybox"],
+    ["an anthropic-compatible node", "anthropic-compatible-mybox"],
+  ])("accepts %s", (_label, name) => {
+    expect(isRoutableProvider(name)).toBe(true);
+  });
+
+  it.each([
+    ["a typo", "nosuchprovider"],
+    ["empty", ""],
+    ["null", null],
+    ["undefined", undefined],
+  ])("rejects %s", (_label, name) => {
+    expect(isRoutableProvider(name)).toBe(false);
+  });
+
+  it("is not fooled by a bare prefix-like name that is not a node", () => {
+    expect(isRoutableProvider("openai-compatible")).toBe(false);
+  });
+});


### PR DESCRIPTION
Asking for a provider with no connected account returns a 404 whose code says the model does not exist:

```
404  {"message":"No active credentials for provider: codex",
      "type":"invalid_request_error","code":"model_not_found"}
```

`ERROR_TYPES` maps one code per status and hardcodes `model_not_found` for 404, so a configuration state is reported as an unknown model. A client cannot act on that — it reads "this model does not exist" and may drop the model for good, when the real fix is for the operator to link an account. Clients that classify on the code cannot tell the two cases apart at all.

**404 itself is correct and stays.** `/v1/models` filters on `isActive` too, so a provider with nothing connected genuinely is not in the catalogue. Only the code and the message change, and they now split by cause:

| request | code | message |
|---|---|---|
| `codex/…` with no account linked | `provider_not_configured` | tells the operator to connect an account |
| `nosuchprovider/…` | `model_not_found` | names the unrecognised half, points at `/v1/models` |
| unknown model on a **connected** provider | `model_not_found` | unchanged |

### How

- `buildErrorBody`/`errorResponse` take an optional `{type, code}` override that defaults to the existing table, so **every other caller is byte-identical**.
- New `isRoutableProvider()` decides which branch applies. It resolves aliases, so `cc` counts as `claude`, and it also accepts the `openai-`/`anthropic-compatible` prefixes.

That last part is load-bearing rather than defensive: user-defined compatible nodes are absent from the registry by design, yet they reach account selection by the identical path. A registry-only check would call a users own node an unknown provider the moment its connection went inactive. It reuses the existing `isOpenAICompatibleProvider`/`isAnthropicCompatibleProvider` helpers.

### Verification

Ran the router and requested each shape, rather than reasoning about it:

- unconfigured provider → `provider_not_configured`
- unknown provider name → `model_not_found` naming the provider
- inactive `openai-compatible-…` node → `provider_not_configured`, not the typo message
- genuinely unknown model on a connected provider → `model_not_found`, untouched (including the provider that reports it as a 401 with a `ModelError` body)

19 new tests in `tests/unit/provider-error-codes.test.js`. `verify-providers.mjs` byte-for-byte equal. The suite is not green on a clean checkout, so I compared against a stashed clean tree in the same checkout: **237 failures before and after**, with only the 19 new tests added to the pass count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnrdG9vY3xmA5PBB8gPPtM