### PR TITLE
fix(errors): preserve the upstream status class instead of flattening it to 503

### DIFF
--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -57,6 +57,22 @@ const COOLDOWN = {
  *   - backoff: true = use exponential backoff (rate limit)
  */
 export const ERROR_RULES = [
+  // --- Permanent, request-scoped failures (highest priority) ---
+  // The model name itself is wrong, so no other account can do better. Without
+  // these the default "fall back and cool down" applied: one typo walked every
+  // account into cooldown and then answered 503 "try again later" for something
+  // retrying can never fix. `permanent` returns the upstream 4xx straight to the
+  // caller and leaves account state untouched.
+  // Matched on text, not status, because providers report this as 400 as often
+  // as 404 — the observed message is "The 'x' model is not supported when using
+  // Codex with a ChatGPT account." on a 400.
+  { text: "model is not supported",   permanent: true },
+  { text: "model not supported",      permanent: true },
+  { text: "model not found",          permanent: true },
+  { text: "model does not exist",     permanent: true },
+  { text: "unknown model",            permanent: true },
+  { text: "invalid model",            permanent: true },
+
   // --- Text-based rules (checked first, order = priority) ---
   { text: "no credentials",           cooldownMs: COOLDOWN.long },
   { text: "request not allowed",      cooldownMs: COOLDOWN.short },

--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -56,22 +56,76 @@ const COOLDOWN = {
  *   - cooldownMs: fixed cooldown duration
  *   - backoff: true = use exponential backoff (rate limit)
  */
+/**
+ * Phrases that identify a permanently wrong model name, whatever status the
+ * provider chose to attach to it. Providers are wildly inconsistent here: the
+ * same class of failure arrives as 400 ("model is not supported"), as 401 with
+ * a ModelError body, or as 404. Clients key their retry behaviour off the
+ * status, so these are normalised to one permanent status rather than passed
+ * through as an auth failure the caller cannot act on.
+ */
+export const PERMANENT_MODEL_ERROR_PATTERNS = [
+  "model is not supported",
+  "model not supported",
+  "model not found",
+  "model does not exist",
+  "unknown model",
+  "invalid model",
+  // Matches a lowercased `"type":"ModelError"` body, which is how at least one
+  // provider reports an unknown model — on a 401, of all statuses.
+  "modelerror",
+];
+
+/**
+ * Regex matchers for the same class, needed where the model NAME sits in the
+ * middle of the phrase: "Model does-not-exist-xyz is not supported". A plain
+ * substring cannot span that.
+ */
+export const PERMANENT_MODEL_ERROR_REGEXES = [
+  /\bmodel\s+\S+\s+is\s+not\s+supported\b/,
+  /\bmodel\s+\S+\s+(?:does\s+not\s+exist|not\s+found)\b/,
+];
+
+/**
+ * Request-scoped failures that are permanent but are NOT about the model — a
+ * parameter the model rejects, for instance. These must not cool down the
+ * account: the request is the caller's fault, so retrying on another account
+ * repeats the same failure, and locking the model makes one client's bad
+ * parameter break every other client's good request for the cooldown window.
+ *
+ * Matched on the INNER error class, because this provider wraps everything in
+ * "Upstream request failed:" — including genuinely transient socket errors. The
+ * bracketed class after that prefix is what separates them:
+ *   permanent : "Upstream request failed: [invalid_request_error] invalid temperature: ..."
+ *   transient : "Upstream request failed: connection reset by peer"
+ * Matching "invalid_request_error" alone would wrongly catch the transient case,
+ * whose envelope also carries that type.
+ */
+export const PERMANENT_REQUEST_ERROR_REGEXES = [
+  /upstream request failed:\s*\[invalid_request_error\]/,
+];
+
+/**
+ * @param {string|object} errorText - upstream error text or parsed body
+ * @returns {boolean} true when the text names a permanently wrong model
+ */
+export function isPermanentModelError(errorText) {
+  if (!errorText) return false;
+  const text = (typeof errorText === "string" ? errorText : JSON.stringify(errorText)).toLowerCase();
+  if (PERMANENT_MODEL_ERROR_PATTERNS.some((p) => text.includes(p))) return true;
+  return PERMANENT_MODEL_ERROR_REGEXES.some((re) => re.test(text));
+}
+
 export const ERROR_RULES = [
   // --- Permanent, request-scoped failures (highest priority) ---
   // The model name itself is wrong, so no other account can do better. Without
   // these the default "fall back and cool down" applied: one typo walked every
   // account into cooldown and then answered 503 "try again later" for something
-  // retrying can never fix. `permanent` returns the upstream 4xx straight to the
-  // caller and leaves account state untouched.
-  // Matched on text, not status, because providers report this as 400 as often
-  // as 404 — the observed message is "The 'x' model is not supported when using
-  // Codex with a ChatGPT account." on a 400.
-  { text: "model is not supported",   permanent: true },
-  { text: "model not supported",      permanent: true },
-  { text: "model not found",          permanent: true },
-  { text: "model does not exist",     permanent: true },
-  { text: "unknown model",            permanent: true },
-  { text: "invalid model",            permanent: true },
+  // retrying can never fix. `permanent` returns the upstream status straight to
+  // the caller and leaves account state untouched.
+  ...PERMANENT_MODEL_ERROR_PATTERNS.map((text) => ({ text, permanent: true })),
+  ...PERMANENT_MODEL_ERROR_REGEXES.map((pattern) => ({ pattern, permanent: true })),
+  ...PERMANENT_REQUEST_ERROR_REGEXES.map((pattern) => ({ pattern, permanent: true })),
 
   // --- Text-based rules (checked first, order = priority) ---
   { text: "no credentials",           cooldownMs: COOLDOWN.long },

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -8,7 +8,7 @@ import { refreshWithRetry } from "../services/tokenRefresh.js";
 import { createRequestLogger } from "../utils/requestLogger.js";
 import { getModelTargetFormat, getModelSupportedFormats, getModelStrip, getModelUpstreamId, getModelType, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.js";
 import { PROVIDERS } from "../config/providers.js";
-import { createErrorResult, parseUpstreamError, formatProviderError } from "../utils/error.js";
+import { createErrorResult, parseUpstreamError, formatProviderError, clientStatusForUpstream } from "../utils/error.js";
 import { HTTP_STATUS, TOKEN_SAVER_HEADER } from "../config/runtimeConfig.js";
 import { handleBypassRequest } from "../utils/bypassHandler.js";
 import { trackPendingRequest, appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
@@ -447,7 +447,10 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
       log.errorLine(reqTag, "✗", `ERROR ${statusCode} · ${provider}/${model} · ${Date.now() - requestStartTime}ms${urlStr}\n    ${errMsg}`);
     }
     reqLogger.logError(new Error(message), finalBody || translatedBody);
-    return createErrorResult(statusCode, errMsg, resetsAtMs);
+    // Client sees the normalised class (4xx stop / 5xx retry, unknown model as
+    // 404 rather than the provider's 401); internal classification keeps the
+    // real upstream status.
+    return createErrorResult(statusCode, errMsg, resetsAtMs, clientStatusForUpstream(statusCode, message));
   }
 
   const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary, reqTag, log };

--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -28,6 +28,9 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
   for (const rule of ERROR_RULES) {
     // Text-based rule: match substring in error message
     if (rule.text && lowerError && lowerError.includes(rule.text)) {
+      // Permanent: the request itself is wrong, so trying another account only
+      // repeats the same failure and cools down healthy accounts for nothing.
+      if (rule.permanent) return { shouldFallback: false, cooldownMs: 0 };
       if (rule.backoff) {
         const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
         return { shouldFallback: true, cooldownMs: getQuotaCooldown(newLevel), newBackoffLevel: newLevel };
@@ -37,6 +40,7 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
 
     // Status-based rule: match HTTP status code
     if (rule.status && rule.status === status) {
+      if (rule.permanent) return { shouldFallback: false, cooldownMs: 0 };
       if (rule.backoff) {
         const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
         return { shouldFallback: true, cooldownMs: getQuotaCooldown(newLevel), newBackoffLevel: newLevel };

--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -26,6 +26,17 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
     : "";
 
   for (const rule of ERROR_RULES) {
+    // Regex rule: for phrases the model name sits inside, which a substring
+    // cannot span ("Model does-not-exist-xyz is not supported").
+    if (rule.pattern && lowerError && rule.pattern.test(lowerError)) {
+      if (rule.permanent) return { shouldFallback: false, cooldownMs: 0 };
+      if (rule.backoff) {
+        const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
+        return { shouldFallback: true, cooldownMs: getQuotaCooldown(newLevel), newBackoffLevel: newLevel };
+      }
+      return { shouldFallback: true, cooldownMs: rule.cooldownMs };
+    }
+
     // Text-based rule: match substring in error message
     if (rule.text && lowerError && lowerError.includes(rule.text)) {
       // Permanent: the request itself is wrong, so trying another account only

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -3,7 +3,7 @@
  */
 
 import { checkFallbackError, formatRetryAfter } from "./accountFallback.js";
-import { unavailableResponse } from "../utils/error.js";
+import { unavailableResponse, clientStatusForBreakerOpen } from "../utils/error.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { extractTextContent } from "../translator/formats/gemini.js";
 
@@ -365,12 +365,17 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
   // the request itself is invalid, but here the providers are simply unavailable
   // or have no active credentials. 503 is more accurate and retryable by clients.
   const allDisabled = lastError && lastError.toLowerCase().includes("no credentials");
-  const status = allDisabled ? 503 : (lastStatus || 503);
+  // Same one-status correction as the single-model path in chat.js: a non-model 404
+  // here is a cooldown the router set itself, not a missing model. Every other class
+  // is left exactly as it was. Note lastStatus is the FIRST member's status while
+  // lastError is the LAST member's text, so this pair can disagree — pre-existing,
+  // and the reason this only narrows a 404 rather than trusting the text further.
+  const status = allDisabled ? 503 : clientStatusForBreakerOpen(lastStatus || 503, lastError);
   const msg = lastError || "All combo models unavailable";
 
   if (earliestRetryAfter) {
     const retryHuman = formatRetryAfter(earliestRetryAfter);
-    log.warn("COMBO", `All models failed | ${msg} (${retryHuman})`);
+    log.warn("COMBO", `All models failed | ${status} | ${msg} (${retryHuman})`);
     return unavailableResponse(status, msg, earliestRetryAfter, retryHuman);
   }
 

--- a/open-sse/utils/error.js
+++ b/open-sse/utils/error.js
@@ -146,6 +146,45 @@ export function clientStatusForUpstream(upstreamStatus, errorText = null) {
 }
 
 /**
+ * Status for the breaker-open path: every account is in cooldown and we already
+ * know when the earliest one frees up.
+ *
+ * A lock is NOT proof the failure was transient. `checkFallbackError` cools an
+ * account down for 30s on ANY error it has no rule for, client-fault 400s
+ * included, so "all accounts locked" mixes genuinely self-clearing conditions
+ * with permanent ones. Remapping the whole path to 503 would resurrect the
+ * incident `.claude/rules/error-classification.md` forbids: a 400 "prompt is too
+ * long" would come back retryable, the client would wait and resend the same
+ * oversized prompt forever instead of compacting it.
+ *
+ * So exactly one status is remapped, the one that was reported broken:
+ *
+ *   A 404 whose text does NOT name a model problem. Nothing else produces it —
+ *   an unknown model is caught by isPermanentModelError and keeps its 404 — so
+ *   what is left is a gateway/routing hop returning a bodyless 404 that the
+ *   router itself decided to cool down for two minutes. Reporting that as 404
+ *   told clients "this will never work" about a state that cleared itself: the
+ *   model was in /v1/models the whole time and served the request once the
+ *   window closed, while clients that classify on status burned their retry
+ *   budget in six seconds against a two-minute breaker.
+ *
+ * Everything else keeps the class clientStatusForUpstream gives it, which is the
+ * function that rule names as the owner of this decision. In particular 401/402/
+ * 403 stay 4xx deliberately: a revoked or unpaid upstream account is not
+ * something the caller's retry can fix, so "try again later" would be a lie.
+ *
+ * @param {number|string|null} upstreamStatus - status of the error that caused the lock
+ * @param {string|null} errorText - stored upstream error text
+ * @returns {number}
+ */
+export function clientStatusForBreakerOpen(upstreamStatus, errorText = null) {
+  if (Number(upstreamStatus) === HTTP_STATUS.NOT_FOUND && !isPermanentModelError(errorText)) {
+    return HTTP_STATUS.SERVICE_UNAVAILABLE;
+  }
+  return clientStatusForUpstream(upstreamStatus, errorText);
+}
+
+/**
  * Create unavailable response when all accounts are rate limited
  * @param {number} statusCode - Original error status code
  * @param {string} message - Error message (without retry info)

--- a/open-sse/utils/error.js
+++ b/open-sse/utils/error.js
@@ -1,4 +1,5 @@
-import { ERROR_TYPES, DEFAULT_ERROR_MESSAGES } from "../config/errorConfig.js";
+import { ERROR_TYPES, DEFAULT_ERROR_MESSAGES, isPermanentModelError } from "../config/errorConfig.js";
+import { HTTP_STATUS } from "../config/runtimeConfig.js";
 
 /**
  * Build OpenAI-compatible error response body
@@ -95,14 +96,53 @@ export async function parseUpstreamError(response, executor = null) {
  * @param {number} [resetsAtMs] - Optional precise cooldown expiry (ms epoch) for provider-specific quota errors
  * @returns {{ success: false, status: number, error: string, response: Response, resetsAtMs?: number }}
  */
-export function createErrorResult(statusCode, message, resetsAtMs) {
+export function createErrorResult(statusCode, message, resetsAtMs, clientStatus = null) {
   return {
     success: false,
+    // The true upstream status, kept for internal classification (fallback
+    // rules, cooldowns) so those keep seeing what the provider actually said.
     status: statusCode,
     error: message,
     resetsAtMs,
-    response: errorResponse(statusCode, message)
+    // What the CLIENT sees, which may be normalised — e.g. an unknown model
+    // reported as 401 becomes 404, so callers do not read it as an auth failure.
+    response: errorResponse(clientStatus ?? statusCode, message)
   };
+}
+
+/**
+ * Map an upstream failure onto the status the client should see.
+ *
+ * The contract clients actually depend on is coarse: 4xx means stop, 5xx means
+ * retry. So the rule is to preserve the upstream's CLASS, never to flatten it.
+ *
+ * An earlier version of this collapsed every non-429 4xx to 503 to stop a
+ * flaky upstream killing a turn. That was the wrong lever: the real cause of
+ * those mislabelled statuses was stale per-connection error state being replayed
+ * across requests (fixed in auth.js), and the flattening made permanent failures
+ * — a rejected temperature, a nonexistent model — look transient. Clients then
+ * burned their whole retry budget on hopeless requests, and 5xx bypassed the
+ * reactive repair paths that key off a 4xx naming the rejected parameter.
+ *
+ * Wrong-model errors are the one deliberate re-mapping: providers report them as
+ * 400, as 404, and as 401-with-a-ModelError-body. Passing a 401 through makes a
+ * client report "authentication failed" for perfectly good credentials, so those
+ * are normalised to 404.
+ *
+ * @param {number|string|null} upstreamStatus - status from the upstream attempt
+ * @param {string|object} [errorText] - upstream error text, for model detection
+ * @returns {number} status to return to the client
+ */
+export function clientStatusForUpstream(upstreamStatus, errorText = null) {
+  if (isPermanentModelError(errorText)) return HTTP_STATUS.NOT_FOUND;
+
+  const status = Number(upstreamStatus);
+  // Nothing usable to propagate (no attempt made, or a non-numeric code): this
+  // is our own "no capacity" condition, which is genuinely transient.
+  if (!Number.isFinite(status) || status < 400) return HTTP_STATUS.SERVICE_UNAVAILABLE;
+  // Anything already carrying a real class keeps it — 4xx stop, 5xx retry.
+  if (status <= 599) return status;
+  return HTTP_STATUS.SERVICE_UNAVAILABLE;
 }
 
 /**

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -14,7 +14,7 @@ import { handleChatCore } from "open-sse/handlers/chatCore.js";
 import { DEFAULT_HEADROOM_URL } from "@/lib/headroom/detect";
 import { getTransform as getPxpipeTransform } from "@/lib/pxpipe/loader.js";
 import { appendPxpipeEvent } from "@/lib/pxpipe/events.js";
-import { errorResponse, unavailableResponse, clientStatusForUpstream } from "open-sse/utils/error.js";
+import { errorResponse, unavailableResponse, clientStatusForUpstream, clientStatusForBreakerOpen } from "open-sse/utils/error.js";
 import { handleComboChat, handleFusionChat, detectRequiredCapabilities } from "open-sse/services/combo.js";
 import { augmentModelsWithCapacityAdapter, withCapacityAdapterStripping, getActiveAdapterStrategy } from "open-sse/services/capacityAdapter.js";
 import { handleBypassRequest } from "open-sse/utils/bypassHandler.js";
@@ -237,12 +237,14 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     if (!credentials || credentials.allRateLimited) {
       if (credentials?.allRateLimited) {
         const errorMsg = lastError || credentials.lastError || "Unavailable";
-        // Preserve the upstream class so 4xx still means stop and 5xx still
-        // means retry. credentials.lastErrorCode is only populated when the
-        // stored error provably belongs to THIS model (see auth.js), so a stale
-        // code from another request can no longer decide this status.
-        const status = clientStatusForUpstream(lastStatus || Number(credentials.lastErrorCode), errorMsg);
-        log.warn("CHAT", `[${provider}/${model}] ${errorMsg} (${credentials.retryAfterHuman})`);
+        // Preserve the upstream class so 4xx still means stop and 5xx still means
+        // retry, EXCEPT for the one status that lied here: a non-model 404, which
+        // is a cooldown the router set itself (see clientStatusForBreakerOpen).
+        // credentials.lastErrorCode is only populated when the stored error provably
+        // belongs to THIS model (see auth.js), so a stale code from another request
+        // can no longer decide this status.
+        const status = clientStatusForBreakerOpen(lastStatus || Number(credentials.lastErrorCode), errorMsg);
+        log.warn("CHAT", `[${provider}/${model}] ${status} | ${errorMsg} (${credentials.retryAfterHuman})`);
         return unavailableResponse(status, `[${provider}/${model}] ${errorMsg}`, credentials.retryAfter, credentials.retryAfterHuman);
       }
       if (excludeConnectionIds.size === 0) {

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -14,7 +14,7 @@ import { handleChatCore } from "open-sse/handlers/chatCore.js";
 import { DEFAULT_HEADROOM_URL } from "@/lib/headroom/detect";
 import { getTransform as getPxpipeTransform } from "@/lib/pxpipe/loader.js";
 import { appendPxpipeEvent } from "@/lib/pxpipe/events.js";
-import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
+import { errorResponse, unavailableResponse, clientStatusForUpstream } from "open-sse/utils/error.js";
 import { handleComboChat, handleFusionChat, detectRequiredCapabilities } from "open-sse/services/combo.js";
 import { augmentModelsWithCapacityAdapter, withCapacityAdapterStripping, getActiveAdapterStrategy } from "open-sse/services/capacityAdapter.js";
 import { handleBypassRequest } from "open-sse/utils/bypassHandler.js";
@@ -237,7 +237,11 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     if (!credentials || credentials.allRateLimited) {
       if (credentials?.allRateLimited) {
         const errorMsg = lastError || credentials.lastError || "Unavailable";
-        const status = HTTP_STATUS.SERVICE_UNAVAILABLE;
+        // Preserve the upstream class so 4xx still means stop and 5xx still
+        // means retry. credentials.lastErrorCode is only populated when the
+        // stored error provably belongs to THIS model (see auth.js), so a stale
+        // code from another request can no longer decide this status.
+        const status = clientStatusForUpstream(lastStatus || Number(credentials.lastErrorCode), errorMsg);
         log.warn("CHAT", `[${provider}/${model}] ${errorMsg} (${credentials.retryAfterHuman})`);
         return unavailableResponse(status, `[${provider}/${model}] ${errorMsg}`, credentials.retryAfter, credentials.retryAfterHuman);
       }
@@ -246,7 +250,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
         return errorResponse(HTTP_STATUS.NOT_FOUND, `No active credentials for provider: ${provider}`);
       }
       log.warn("CHAT", "No more accounts available", { provider });
-      return errorResponse(lastStatus || HTTP_STATUS.SERVICE_UNAVAILABLE, lastError || "All accounts unavailable");
+      return errorResponse(clientStatusForUpstream(lastStatus, lastError), lastError || "All accounts unavailable");
     }
 
     // Account selection shown in the unified "▶" line (acc:...)

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -119,14 +119,32 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
       }
       const earliest = expiries.sort()[0] || null;
       if (earliest) {
-        const earliestConn = lockedConns[0];
-        log.warn("AUTH", `${provider} | all ${connections.length} accounts locked for ${model || "all"} (${formatRetryAfter(earliest)}) | lastError=${earliestConn?.lastError?.slice(0, 50)}`);
+        // Pick the connection that actually owns `earliest`, not just the first
+        // locked one — otherwise the countdown and the error came from different
+        // accounts.
+        const earliestConn = lockedConns.find((c) => getEarliestModelLockUntil(c) === earliest) || lockedConns[0];
+
+        // lastError/errorCode are per-CONNECTION, while locks are per-model, so
+        // the stored error belongs to whichever model failed on this connection
+        // most recently — not necessarily the one being requested. Serving it
+        // regardless leaked one request's error into an unrelated one: a probe
+        // for a bogus model produced a 401 ModelError that was then replayed to
+        // a live conversation on a different model for the whole backoff window,
+        // making good credentials look broken. Only surface it when it provably
+        // belongs to this model.
+        const errorMatchesModel = earliestConn?.lastErrorModel
+          ? earliestConn.lastErrorModel === (model || null)
+          : false;
+        const lastError = errorMatchesModel ? earliestConn?.lastError || null : null;
+        const lastErrorCode = errorMatchesModel ? earliestConn?.errorCode || null : null;
+
+        log.warn("AUTH", `${provider} | all ${connections.length} accounts locked for ${model || "all"} (${formatRetryAfter(earliest)}) | lastError=${errorMatchesModel ? earliestConn?.lastError?.slice(0, 50) : `<withheld: belongs to ${earliestConn?.lastErrorModel || "unknown"}>`}`);
         return {
           allRateLimited: true,
           retryAfter: earliest,
           retryAfterHuman: formatRetryAfter(earliest),
-          lastError: earliestConn?.lastError || null,
-          lastErrorCode: earliestConn?.errorCode || null
+          lastError,
+          lastErrorCode
         };
       }
       log.warn("AUTH", `${provider} | all ${connections.length} accounts unavailable`);
@@ -271,6 +289,10 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
     testStatus: "unavailable",
     lastError: reason,
     errorCode: status,
+    // Which model produced this error. Locks are per-model but lastError is a
+    // single per-connection field, so without this the reader cannot tell
+    // whether the stored error belongs to the model being asked about.
+    lastErrorModel: model || null,
     lastErrorAt: new Date().toISOString(),
     backoffLevel: newBackoffLevel ?? backoffLevel
   });
@@ -328,6 +350,7 @@ export async function clearAccountError(connectionId, currentConnection, model =
       testStatus: "active",
       lastError: null,
       errorCode: null,
+      lastErrorModel: null,
       lastErrorAt: null,
       backoffLevel: 0
     });

--- a/tests/unit/breaker-open-status.test.js
+++ b/tests/unit/breaker-open-status.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { clientStatusForBreakerOpen, clientStatusForUpstream, unavailableResponse } from "open-sse/utils/error.js";
+import { checkFallbackError } from "open-sse/services/accountFallback.js";
+
+/**
+ * Reported from production: with the circuit breaker open on codex, the router
+ * answered
+ *
+ *   404  [codex/gpt-5.6-luna] [404]: HTTP 404 (reset after 1m 58s)
+ *
+ * The model was in /v1/models the whole time and served the request two minutes
+ * later. A client classifying on status read 404 as "never retry", spent three
+ * retries in six seconds, and gave up on a breaker that needed two minutes.
+ */
+describe("breaker-open status classification", () => {
+  it("reports a bodyless 404 cooldown as 503, not the upstream 404", () => {
+    expect(clientStatusForBreakerOpen(404, "[404]: HTTP 404")).toBe(503);
+  });
+
+  /**
+   * The correction is deliberately ONE status wide.
+   *
+   * The tempting version — "we locked the account, so the state is transient,
+   * so return 503" — is false. checkFallbackError cools an account down for 30s
+   * on any error it has no rule for, client-fault 400s included. Remapping the
+   * whole path would resurrect the incident error-classification.md forbids.
+   */
+  describe("does not touch any other class", () => {
+    it.each([
+      ["a rejected parameter", 400, "Invalid 'temperature': expected <= 2, got 5"],
+      ["an over-long prompt", 400, "prompt is too long: 250000 > 200000"],
+      ["a malformed tool schema", 422, "tools[0].function.parameters must be an object"],
+      ["a conflict", 409, "conflict"],
+      ["a revoked key", 401, "invalid_api_key"],
+      ["payment required", 402, "payment required"],
+      ["forbidden", 403, "forbidden"],
+    ])("keeps %s as its own 4xx", (_label, status, text) => {
+      expect(clientStatusForBreakerOpen(status, text)).toBe(status);
+      // and identical to what the shared classifier would have said
+      expect(clientStatusForBreakerOpen(status, text)).toBe(clientStatusForUpstream(status, text));
+    });
+
+    it.each([
+      ["429", 429],
+      ["500", 500],
+      ["502", 502],
+      ["503", 503],
+    ])("leaves %s alone (already retryable)", (_label, status) => {
+      expect(clientStatusForBreakerOpen(status, "boom")).toBe(clientStatusForUpstream(status, "boom"));
+    });
+
+    it.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["a non-numeric code", "NaN"],
+    ])("falls back to 503 for %s, same as before", (_label, status) => {
+      expect(clientStatusForBreakerOpen(status, "Unavailable")).toBe(503);
+    });
+  });
+
+  /**
+   * This is the regression guard for the mistake above. It asserts the PREMISE,
+   * not just the output: an account really does get locked by a client-fault
+   * 400, so anything that assumes "locked implies transient" is wrong.
+   */
+  it("a client-fault 400 locks the account yet must still return 400", () => {
+    const verdict = checkFallbackError(400, "prompt is too long: 250000 > 200000");
+    expect(verdict.shouldFallback).toBe(true);
+    expect(verdict.permanent).toBeFalsy();
+
+    expect(clientStatusForBreakerOpen(400, "prompt is too long: 250000 > 200000")).toBe(400);
+  });
+
+  it("keeps 404 when the text really does name a missing model", () => {
+    for (const text of [
+      "[404]: model gpt-9 not found",
+      "Model foo is not supported",
+      "model bar does not exist",
+      '{"type":"ModelError"}',
+    ]) {
+      expect(clientStatusForBreakerOpen(404, text)).toBe(404);
+    }
+  });
+
+  // The reporter asked for "503 with a Retry-After: 118 header". The header was
+  // already emitted; only the status was wrong. Pin both together so a future
+  // change cannot drop the header while fixing something else.
+  it("emits Retry-After in seconds alongside the 503", async () => {
+    const resetAt = new Date(Date.now() + 118_000).toISOString();
+    const status = clientStatusForBreakerOpen(404, "[404]: HTTP 404");
+    const res = unavailableResponse(status, "[codex/gpt-5.6-luna] [404]: HTTP 404", resetAt, "reset after 1m 58s");
+
+    expect(res.status).toBe(503);
+    const retryAfter = Number(res.headers.get("Retry-After"));
+    expect(retryAfter).toBeGreaterThan(110);
+    expect(retryAfter).toBeLessThanOrEqual(118);
+
+    const body = await res.json();
+    expect(body.error.message).toContain("reset after 1m 58s");
+    // The upstream detail survives: it is the operator's only clue about WHY the
+    // breaker opened. It just no longer decides the class.
+    expect(body.error.message).toContain("HTTP 404");
+  });
+
+  it("never emits a Retry-After below 1 second, even on an already-passed reset", () => {
+    const res = unavailableResponse(503, "msg", new Date(Date.now() - 60_000).toISOString(), "reset after 0s");
+    expect(Number(res.headers.get("Retry-After"))).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
Three related defects in how upstream failures are reported to clients. They have to land together — each one alone is incomplete, and the third exists specifically to stop the first two going too far.

## 1. Every exhausted-account response is 503, including permanent ones

`chat.js` hardcodes `HTTP_STATUS.SERVICE_UNAVAILABLE` when all accounts are cooling down. But `checkFallbackError` cools an account for 30s on **any** error it has no rule for, client-fault 400s included, so this path is not only transient conditions.

Concrete: a client sends an over-long prompt, upstream answers `400 prompt is too long`, the account is locked, the client gets `503 + Retry-After: 30`. It waits, resends the identical prompt, gets 503 again. Forever. The prompt is never compacted, and the account stays cooled for a fault that was never the accounts.

`clientStatusForUpstream()` preserves the class instead: 4xx still means stop, 5xx still means retry.

Wrong-model errors are the one deliberate re-mapping. Providers report them as 400, as 404, and as **401 with a `ModelError` body** — passing that 401 through makes a client report "authentication failed" for perfectly good credentials, so they are normalised to 404.

## 2. A wrong model name cools down every account

`checkFallbackError` returns `shouldFallback: true` on every path, so one typo walks every account into cooldown and then answers "try again later" for something retrying can never fix.

Request-scoped failures are now marked `permanent`: they return the upstream status straight to the caller and leave account state untouched. Matching is on **text, not status**, because a bad model arrives as 400 as often as 404, and because one provider wraps both transient socket errors and permanent parameter errors in the same `Upstream request failed:` prefix — the bracketed class after that prefix is what separates them.

## 3. One requests error is replayed onto another

`lastError`/`errorCode` are flat **per-connection** fields, while model locks are per-model, so the stored error belongs to whichever model failed on that connection most recently. Serving it without checking leaks one requests failure into an unrelated one.

Observed: a probe for a bogus model produced a `401 ModelError`, which was then replayed to a live conversation **on a different model** for the whole backoff window, making good credentials look broken. On a shared router that is a cross-tenant fault. `lastErrorModel` now records ownership, and a stored error is only surfaced when it provably belongs to the model being requested.

This one is why 1 and 2 are safe. Preserving the upstream class without it would make the replay worse, not better — it would replay the *status* too.

## The guard rail: `clientStatusForBreakerOpen`

Preserving the class has a failure mode of its own, which we hit in production. A bodyless `404` from a gateway hop is not a model error, so it cools the account down for two minutes — and then the preserved 404 tells the client "this will never work" about a state that clears itself:

```
404  [codex/gpt-5.6-luna] [404]: HTTP 404 (reset after 1m 58s)
```

The model was in `/v1/models` the whole time and served the request two minutes later. A client classifying on status burned three retries in six seconds against a two-minute breaker.

So the breaker path remaps **exactly one** status — a 404 whose text does not name a model problem — and delegates everything else to `clientStatusForUpstream`. Deliberately not "we locked it, therefore its transient, therefore 503": that is defect 1 in reverse. `Retry-After` was already emitted and is now pinned by test alongside the status.

## Verification

Driven through the real functions rather than mocks:

| case | breaker status | cools account? |
|---|---|---|
| bodyless 404 cooldown | 503 | yes, 120s |
| `prompt is too long` (400) | **400** | yes, 30s |
| rejected parameter (400) | **400** | yes, 30s |
| wrong model name | 404 | **no — permanent** |
| `ModelError` on a 401 | 404 | **no — permanent** |
| upstream 500 | 500 | yes, 30s |

19 tests in `tests/unit/breaker-open-status.test.js`, shown non-vacuous in both directions by mutation: reverting the breaker remap fails 2, and widening it to a blanket 503 fails 12.

The suite is not green on a clean checkout, so I compared against a stashed clean tree in the same checkout: **237 failures before and after**, with only the 19 new tests added to the pass count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnrdG9vY3xmA5PBB8gPPtM