### PR TITLE
fix(proxy-pools): strip client-IP headers in relay forwarders

### DIFF
--- a/src/app/api/proxy-pools/[id]/test/route.js
+++ b/src/app/api/proxy-pools/[id]/test/route.js
@@ -33,6 +33,35 @@ async function testVercelRelay(relayUrl, timeoutMs = 10000) {
   }
 }
 
+// Anonymity probe: a relay must not forward client-IP headers. Sends a canary
+// X-Forwarded-For through the relay to httpbin's header echo; if the canary
+// comes back, the relay leaks the origin IP and per-IP upstream rate limits
+// (e.g. OpenCode free-tier 429) survive relaying. Old Cloudflare/Deno relay
+// code forwards it; Vercel's edge strips it at the platform layer.
+async function testRelayIpLeak(relayUrl, timeoutMs = 10000) {
+  const canary = `9router-canary-${Date.now().toString(36)}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await undiciFetch(relayUrl, {
+      method: "GET",
+      headers: {
+        "x-relay-target": "https://httpbin.org",
+        "x-relay-path": "/headers",
+        "x-forwarded-for": canary,
+      },
+      signal: controller.signal,
+    });
+    if (!res.ok) return { checked: false, leaked: null };
+    const text = await res.text();
+    return { checked: true, leaked: text.toLowerCase().includes(canary.toLowerCase()) };
+  } catch {
+    return { checked: false, leaked: null };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // POST /api/proxy-pools/[id]/test - Test proxy pool entry
 export async function POST(request, { params }) {
   try {
@@ -43,9 +72,17 @@ export async function POST(request, { params }) {
       return NextResponse.json({ error: "Proxy pool not found" }, { status: 404 });
     }
 
-    const result = proxyPool.type === "vercel" || proxyPool.type === "cloudflare" || proxyPool.type === "deno"
+    const isRelay = proxyPool.type === "vercel" || proxyPool.type === "cloudflare" || proxyPool.type === "deno";
+    const result = isRelay
       ? await testVercelRelay(proxyPool.proxyUrl)
       : await testProxyUrl({ proxyUrl: proxyPool.proxyUrl });
+    // Anonymity probe is informational only — it never flips liveness, so
+    // relays that still work for non-IP-sensitive providers stay active.
+    let ipLeak = null;
+    if (isRelay && result.ok) {
+      const leak = await testRelayIpLeak(proxyPool.proxyUrl);
+      if (leak.checked) ipLeak = leak.leaked;
+    }
     const now = new Date().toISOString();
 
     await updateProxyPool(id, {
@@ -62,6 +99,10 @@ export async function POST(request, { params }) {
       error: result.error || null,
       elapsedMs: result.elapsedMs || 0,
       testedAt: now,
+      ipLeak,
+      warning: ipLeak === true
+        ? "Relay forwards client-IP headers; per-IP upstream limits (e.g. OpenCode free 429) will persist. Redeploy the relay to pick up the anonymized forwarder."
+        : null,
     });
   } catch (error) {
     console.log("Error testing proxy pool:", error);

--- a/src/app/api/proxy-pools/cloudflare-deploy/route.js
+++ b/src/app/api/proxy-pools/cloudflare-deploy/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createProxyPool } from "@/models";
+import { buildRelaySanitizeSnippet } from "@/lib/network/relayHeaders";
 
 // Relay worker source code deployed to Cloudflare
 const RELAY_WORKER_CODE = `
@@ -7,7 +8,7 @@ export default {
   async fetch(request, env, ctx) {
     const target = request.headers.get("x-relay-target");
     const relayPath = request.headers.get("x-relay-path") || "/";
-    
+
     if (!target) {
       return new Response(JSON.stringify({ error: "Missing x-relay-target header" }), {
         status: 400,
@@ -16,19 +17,17 @@ export default {
     }
 
     const targetUrl = target.replace(/\\/$/, "") + relayPath;
+    const forwardHeaders = new Headers(request.headers);
+${buildRelaySanitizeSnippet()}
+    sanitizeRelayHeaders(forwardHeaders);
     const newRequestInit = {
       method: request.method,
-      headers: new Headers(request.headers),
+      headers: forwardHeaders,
     };
-
     if (request.method !== "GET" && request.method !== "HEAD") {
       newRequestInit.body = request.body;
       newRequestInit.duplex = "half";
     }
-
-    newRequestInit.headers.delete("x-relay-target");
-    newRequestInit.headers.delete("x-relay-path");
-    newRequestInit.headers.delete("host");
 
     try {
       const response = await fetch(targetUrl, newRequestInit);

--- a/src/app/api/proxy-pools/deno-deploy/route.js
+++ b/src/app/api/proxy-pools/deno-deploy/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createProxyPool } from "@/models";
+import { buildRelaySanitizeSnippet } from "@/lib/network/relayHeaders";
 
 const DENO_V2_API = "https://api.deno.com/v2";
 
@@ -16,9 +17,8 @@ const DENO_RELAY_CODE = `Deno.serve(async (request) => {
 
   const targetUrl = target.replace(/\\/$/, "") + relayPath;
   const newHeaders = new Headers(request.headers);
-  newHeaders.delete("x-relay-target");
-  newHeaders.delete("x-relay-path");
-  newHeaders.delete("host");
+${buildRelaySanitizeSnippet()}
+  sanitizeRelayHeaders(newHeaders);
 
   const init = {
     method: request.method,

--- a/src/app/api/proxy-pools/vercel-deploy/route.js
+++ b/src/app/api/proxy-pools/vercel-deploy/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createProxyPool } from "@/models";
+import { buildRelaySanitizeSnippet } from "@/lib/network/relayHeaders";
 
 const VERCEL_API = "https://api.vercel.com";
 
@@ -21,9 +22,8 @@ export default async function handler(req) {
   const targetUrl = target.replace(/\\/$/, "") + relayPath;
 
   const headers = new Headers(req.headers);
-  headers.delete("x-relay-target");
-  headers.delete("x-relay-path");
-  headers.delete("host");
+${buildRelaySanitizeSnippet()}
+  sanitizeRelayHeaders(headers);
 
   const response = await fetch(targetUrl, {
     method: req.method,

--- a/src/lib/network/relayHeaders.js
+++ b/src/lib/network/relayHeaders.js
@@ -1,0 +1,117 @@
+// Relay header sanitization — single source of truth for every relay target
+// (Vercel Edge, Cloudflare Workers, Deno Deploy).
+//
+// Root cause this fixes: the relay must be an anonymous forwarder. It used to
+// copy every inbound header — including the platform edge's `x-forwarded-for`,
+// `cf-connecting-ip`, `x-real-ip`, `cdn-loop`, `x-vercel-*`, … — to the
+// upstream. Upstreams behind Cloudflare (e.g. opencode.ai) can recover the
+// origin IP from `X-Forwarded-For` and keep rate-limiting it, so the relay is
+// defeated and the free tier keeps returning HTTP 429 FreeUsageLimitError.
+// Vercel's edge strips `X-Forwarded-For`/`X-Real-IP` on outbound fetch by
+// default, which is why only Vercel relays bypassed the per-IP limiter.
+// Stripping these headers explicitly in the relay makes every platform behave
+// like Vercel.
+//
+// The same lists feed both sides:
+// - `sanitizeRelayHeaders` runs in this process (tests, contract checks).
+// - `buildRelaySanitizeSnippet()` emits equivalent JS source that is embedded
+//   into the remotely-deployed relay code (which cannot import this module).
+
+// Exact header names to drop (lowercased).
+export const RELAY_STRIP_EXACT = [
+  // Relay control headers (never forward upstream).
+  "x-relay-target",
+  "x-relay-path",
+  "host",
+  // Client-IP revealing headers — forwarding these defeats IP rotation.
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-forwarded-proto",
+  "x-forwarded-port",
+  "x-forwarded-server",
+  "forwarded",
+  "via",
+  "x-real-ip",
+  "real-ip",
+  "true-client-ip",
+  "x-client-ip",
+  "x-cluster-client-ip",
+  "fastly-client-ip",
+  "cf-connecting-ip",
+  "cf-ipcountry",
+  "cf-ray",
+  "cf-visitor",
+  "cf-warp-tag",
+  "cf-request-id",
+  "cdn-loop",
+  // Hop-by-hop headers (RFC 2616 §13.5.1) — must not be forwarded by proxies.
+  "connection",
+  "keep-alive",
+  "transfer-encoding",
+  "te",
+  "trailer",
+  "upgrade",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "expect",
+];
+
+// Prefixes (lowercased) for platform/proxy header families.
+export const RELAY_STRIP_PREFIXES = [
+  "cf-",
+  "x-vercel-",
+  "x-deno-",
+  "x-forwarded-",
+  "x-amz-cf-",
+  "x-amzn-",
+  "fastly-",
+  "akamai-",
+  "cloudfront-",
+];
+
+export function shouldStripRelayHeader(name) {
+  const lower = String(name || "").toLowerCase();
+  if (!lower) return false;
+  if (RELAY_STRIP_EXACT.includes(lower)) return true;
+  return RELAY_STRIP_PREFIXES.some((prefix) => lower.startsWith(prefix));
+}
+
+// Mutate `headers` in place (accepts a `Headers` instance or a plain object)
+// and return it. Preserves everything else: authorization, content-type,
+// user-agent, x-opencode-*, accept, …
+export function sanitizeRelayHeaders(headers) {
+  if (!headers) return headers;
+  if (typeof headers.delete === "function" && typeof headers.forEach === "function") {
+    const names = [];
+    headers.forEach((_value, name) => names.push(name));
+    for (const name of names) {
+      if (shouldStripRelayHeader(name)) headers.delete(name);
+    }
+    return headers;
+  }
+  for (const name of Object.keys(headers)) {
+    if (shouldStripRelayHeader(name)) delete headers[name];
+  }
+  return headers;
+}
+
+// JS source embedded into the remotely-deployed relay functions. Kept
+// forEach-based (no iterator spread) for max runtime compat.
+export function buildRelaySanitizeSnippet() {
+  return [
+    `const RELAY_STRIP_EXACT = new Set(${JSON.stringify(RELAY_STRIP_EXACT)});`,
+    `const RELAY_STRIP_PREFIXES = ${JSON.stringify(RELAY_STRIP_PREFIXES)};`,
+    "function sanitizeRelayHeaders(headers) {",
+    "  const names = [];",
+    "  headers.forEach(function (_v, name) { names.push(name); });",
+    "  for (const name of names) {",
+    "    const lower = name.toLowerCase();",
+    "    if (RELAY_STRIP_EXACT.has(lower)) { headers.delete(name); continue; }",
+    "    for (const prefix of RELAY_STRIP_PREFIXES) {",
+    "      if (lower.indexOf(prefix) === 0) { headers.delete(name); break; }",
+    "    }",
+    "  }",
+    "}",
+  ].join("\n");
+}

--- a/tests/unit/relay-header-sanitize.test.js
+++ b/tests/unit/relay-header-sanitize.test.js
@@ -1,0 +1,131 @@
+// Relay anonymity contract: every relay target (Vercel / Cloudflare / Deno)
+// must strip client-IP and proxy-identifying headers before forwarding.
+// Otherwise per-IP upstream limits (OpenCode free-tier HTTP 429
+// FreeUsageLimitError) survive relaying — only Vercel worked, because its
+// edge strips X-Forwarded-For on outbound fetch at the platform layer.
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import vm from "node:vm";
+import {
+  RELAY_STRIP_EXACT,
+  RELAY_STRIP_PREFIXES,
+  sanitizeRelayHeaders,
+  buildRelaySanitizeSnippet,
+} from "../../src/lib/network/relayHeaders.js";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const readSource = (rel) => readFileSync(path.join(repoRoot, rel), "utf8");
+
+describe("relay header strip lists", () => {
+  it("covers the client-IP headers that defeat IP rotation", () => {
+    for (const name of [
+      "x-relay-target",
+      "x-relay-path",
+      "host",
+      "x-forwarded-for",
+      "forwarded",
+      "via",
+      "x-real-ip",
+      "true-client-ip",
+      "cdn-loop",
+      "cf-connecting-ip",
+      "cf-ray",
+      "connection",
+      "transfer-encoding",
+    ]) {
+      expect(RELAY_STRIP_EXACT, name).toContain(name);
+    }
+  });
+
+  it("covers platform header families by prefix", () => {
+    for (const prefix of ["cf-", "x-vercel-", "x-deno-", "x-forwarded-"]) {
+      expect(RELAY_STRIP_PREFIXES, prefix).toContain(prefix);
+    }
+  });
+});
+
+describe("sanitizeRelayHeaders", () => {
+  it("strips leak/hop-by-hop headers but preserves upstream request headers", () => {
+    const headers = {
+      "user-agent": "opencode",
+      Authorization: "Bearer public",
+      "Content-Type": "application/json",
+      "x-opencode-session": "ses_abc",
+      "x-opencode-request": "msg_abc",
+      "x-opencode-client": "desktop",
+      Accept: "text/event-stream",
+      "x-forwarded-for": "203.0.113.7",
+      "X-Real-IP": "203.0.113.7",
+      "cf-connecting-ip": "203.0.113.7",
+      "cdn-loop": "cloudflare",
+      "x-vercel-id": "iad1::abc",
+      "x-deno-region": "us-east",
+      connection: "keep-alive",
+      host: "relay.example.com",
+      "x-relay-target": "https://opencode.ai",
+      "x-relay-path": "/zen/v1/responses",
+    };
+    sanitizeRelayHeaders(headers);
+    expect(headers).toMatchObject({
+      "user-agent": "opencode",
+      Authorization: "Bearer public",
+      "Content-Type": "application/json",
+      "x-opencode-session": "ses_abc",
+      "x-opencode-request": "msg_abc",
+      "x-opencode-client": "desktop",
+      Accept: "text/event-stream",
+    });
+    for (const name of Object.keys(headers)) {
+      expect(name.toLowerCase().startsWith("x-forwarded-")).toBe(false);
+      expect(name.toLowerCase().startsWith("cf-")).toBe(false);
+      expect(name.toLowerCase().startsWith("x-vercel-")).toBe(false);
+    }
+    expect("x-forwarded-for" in headers).toBe(false);
+    expect("host" in headers).toBe(false);
+    expect("x-relay-target" in headers).toBe(false);
+  });
+});
+
+describe("deployed relay templates", () => {
+  const routes = [
+    "src/app/api/proxy-pools/vercel-deploy/route.js",
+    "src/app/api/proxy-pools/cloudflare-deploy/route.js",
+    "src/app/api/proxy-pools/deno-deploy/route.js",
+  ];
+
+  it("all three embed the shared sanitize snippet", () => {
+    for (const rel of routes) {
+      const source = readSource(rel);
+      expect(source, `${rel} imports snippet`).toContain("buildRelaySanitizeSnippet");
+      expect(source, `${rel} calls sanitize`).toContain("sanitizeRelayHeaders(");
+    }
+    const cf = readSource(routes[1]);
+    expect(cf).toContain("sanitizeRelayHeaders(forwardHeaders)");
+    const deno = readSource(routes[2]);
+    expect(deno).toContain("sanitizeRelayHeaders(newHeaders)");
+    const vercel = readSource(routes[0]);
+    expect(vercel).toContain("sanitizeRelayHeaders(headers)");
+  });
+
+  it("snippet is syntactically valid and strips like the module", () => {
+    const snippet = buildRelaySanitizeSnippet();
+    const sandbox = vm.runInNewContext(
+      `${snippet}; const __h = new Headers({
+        "user-agent": "opencode",
+        "x-opencode-session": "ses_abc",
+        "x-forwarded-for": "203.0.113.7",
+        "cf-connecting-ip": "203.0.113.7",
+        "x-vercel-id": "iad1::abc",
+        "host": "relay.example.com",
+        "x-relay-target": "https://opencode.ai"
+      }); sanitizeRelayHeaders(__h); __h;`,
+      { Headers }
+    );
+    const out = Object.fromEntries(sandbox.entries());
+    expect(out).toMatchObject({ "user-agent": "opencode", "x-opencode-session": "ses_abc" });
+    expect("x-forwarded-for" in out).toBe(false);
+    expect("host" in out).toBe(false);
+  });
+});


### PR DESCRIPTION
## Root cause

OpenCode free-tier 429 (`FreeUsageLimitError`) is a per-IP limiter. All three relay templates forwarded every inbound header upstream, including the platform edge's `x-forwarded-for` / `cf-connecting-ip` carrying the origin IP. opencode.ai (Cloudflare-fronted) recovers the origin IP from `X-Forwarded-For`, so Deno/Cloudflare relays leaked the real IP and the limit survived relaying. Only Vercel relays worked because Vercel's edge strips `X-Forwarded-For`/`X-Real-IP` on outbound fetch at the platform layer.

## Changes

- **`src/lib/network/relayHeaders.js` (new)** — single source of truth: exact + prefix strip lists, `sanitizeRelayHeaders()`, and `buildRelaySanitizeSnippet()` emitting equivalent JS for the remotely-deployed runtimes.
- **Vercel / Cloudflare / Deno deploy routes** — relay templates embed and call the snippet; POST body + `duplex: half` streaming preserved; `authorization`, `user-agent`, `x-opencode-*` untouched.
- **`proxy-pools/[id]/test`** — informational XFF-canary anonymity probe (`ipLeak` + redeploy `warning`); never flips liveness.
- **`tests/unit/relay-header-sanitize.test.js`** — 5 tests covering lists, local sanitize, template embedding, and snippet validity.

## Verification

- New test 5/5 pass; `node --check` parses all route files and all three interpolated relay payloads; old-vs-new demo proves leak then anonymity with opencode headers intact.
- eslint clean on touched files; `base-executor-retry` + `mimo-free` 35/35 pass (`executor-const-guard` antigravity-429 failure is pre-existing on clean tree).
- Code review verdict: correct (0.9), no blocking issues.

## Note

Already-deployed Deno/Cloudflare relays still run the old forwarder and must be **redeployed**; the pool test route now flags them with `ipLeak: true`.