### PR TITLE
fix(kiro): route requests through current runtime surfaces and fix 400 REQUEST_BODY_INVALID

### DIFF
--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -259,6 +259,19 @@ export class KiroExecutor extends BaseExecutor {
       }
     }
 
+    // CLIRO parity for the Amazon surfaces: the Kiro runtime accepts the
+    // SSO bearer header + agent-mode marker. Without these the deprecated
+    // path gateway answers REQUEST_BODY_INVALID for modern payloads.
+    if (credentials?.accessToken) {
+      headers["x-amz-sso-bearer"] = credentials.accessToken;
+    }
+    headers["x-amzn-kiro-agent-mode"] = "spec";
+    headers["x-amzn-codewhisperer-machine-id"] = "kiro-desktop";
+    const profileArn = credentials?.providerSpecificData?.profileArn;
+    if (profileArn) {
+      headers["x-amzn-codewhisperer-profile-arn"] = profileArn;
+    }
+
     return headers;
   }
 
@@ -285,9 +298,13 @@ export class KiroExecutor extends BaseExecutor {
     // 403 "bearer token invalid", so they must hit the CodeWhisperer
     // *.amazonaws.com surface, and in the region the token was minted in
     // (the baseUrls are hardcoded us-east-1).
-    const isCodeWhispererSurface =
-      authMethod === "api_key" || authMethod === "external_idp" || authMethod === "idc";
-    if (!isCodeWhispererSurface) return baseUrls;
+    // Kiro deprecated the legacy path-style GenerateAssistantResponse on
+    // runtime.*.kiro.dev (IDE 1.0.228+ moved to POST / + x-amz-target). The
+    // path gateway now answers valid modern payloads with 400
+    // REQUEST_BODY_INVALID, and 400 is terminal in BaseExecutor, so kiro.dev
+    // must never be the first surface for any auth method. Amazon surfaces
+    // reject foreign tokens with 401/403, which DO fall through, so trying
+    // q/codewhisperer first is safe for every auth method (CLIRO parity).
 
     const region = (credentials?.providerSpecificData?.region || "us-east-1").trim();
     const regionalize = (u) =>
@@ -310,7 +327,8 @@ export class KiroExecutor extends BaseExecutor {
 
   buildUrl(model, stream, urlIndex = 0, credentials = null) {
     const baseUrls = this.getOrderedBaseUrls(credentials);
-    return baseUrls[urlIndex] || baseUrls[0] || this.config.baseUrl;
+    const url = baseUrls[urlIndex] || baseUrls[0] || this.config.baseUrl;
+    return url;
   }
 
   // Retry only endpoint/auth-surface failures. Payload-invalid HTTP 400 must be

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -316,14 +316,11 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
     conversationState: {
       chatTriggerType: "MANUAL",
       conversationId,
-      agentContinuationId: continuationId,
-      agentTaskType: "vibe",
       currentMessage: {
         userInputMessage,
       },
       history: canonical.history,
     },
-    agentMode: "vibe",
   };
 
   if (profileArn) payload.profileArn = profileArn;

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -397,8 +397,6 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
     conversationState: {
       chatTriggerType: "MANUAL",
       conversationId,
-      agentContinuationId: continuationId,
-      agentTaskType: "vibe",
       currentMessage: {
         userInputMessage: {
           content: replayCurrent.content || "",
@@ -414,7 +412,6 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
       },
       history: canonical.history
     },
-    agentMode: "vibe",
   };
 
   if (profileArn) {

--- a/tests/translator/claude-kiro-direct.test.js
+++ b/tests/translator/claude-kiro-direct.test.js
@@ -26,9 +26,8 @@ describe("Claude → Kiro (direct route)", () => {
 
     expect(first.conversationState.conversationId).toBe("hermes-session-123-claude-replay");
     expect(second.conversationState.conversationId).toBe("hermes-session-123-claude-replay");
-    expect(first.conversationState.agentContinuationId).toBeTruthy();
-    expect(second.conversationState.agentContinuationId).toBe(first.conversationState.agentContinuationId);
-    expect(first.conversationState.agentTaskType).toBe("vibe");
+    expect(first.conversationState).not.toHaveProperty("agentContinuationId");
+    expect(second.conversationState).not.toHaveProperty("agentTaskType");
     expect(second.conversationState.history[0].userInputMessage.content).toBe(
       first.conversationState.currentMessage.userInputMessage.content
     );
@@ -84,7 +83,7 @@ describe("Claude → Kiro (direct route)", () => {
     expect(out.systemPrompt).toContain(
       "<thinking_mode>enabled</thinking_mode>"
     );
-    expect(out.agentMode).toBe("vibe");
+    expect(out).not.toHaveProperty("agentMode");
   });
 
   it("does not send additionalModelRequestFields for Kiro models without effort support", () => {

--- a/tests/unit/kiro-api-key-endpoint-routing.test.js
+++ b/tests/unit/kiro-api-key-endpoint-routing.test.js
@@ -20,26 +20,26 @@ describe("Kiro auth-aware endpoint routing", () => {
     ]);
   });
 
-  it("keeps Builder ID OAuth on the Kiro runtime surface", () => {
+  it("routes Builder ID OAuth through Amazon Q first (runtime path deprecated)", () => {
     expect(executor.getOrderedBaseUrls(credentials("builder-id"))).toEqual([
-      RUNTIME,
-      CODEWHISPERER,
       Q,
+      CODEWHISPERER,
+      RUNTIME,
     ]);
   });
 
-  it("keeps external IdP on CodeWhisperer before Amazon Q", () => {
+  it("routes external IdP through Amazon Q first", () => {
     expect(executor.getOrderedBaseUrls(credentials("external_idp"))).toEqual([
-      CODEWHISPERER,
       Q,
+      CODEWHISPERER,
       RUNTIME,
     ]);
   });
 
-  it("regionalizes AWS endpoints for IDC without changing Kiro runtime", () => {
+  it("regionalizes AWS endpoints for IDC with Q first", () => {
     expect(executor.getOrderedBaseUrls(credentials("idc", "eu-west-1"))).toEqual([
-      "https://codewhisperer.eu-west-1.amazonaws.com/generateAssistantResponse",
       "https://q.eu-west-1.amazonaws.com/generateAssistantResponse",
+      "https://codewhisperer.eu-west-1.amazonaws.com/generateAssistantResponse",
       RUNTIME,
     ]);
   });

--- a/tests/unit/kiro-minimal-wire-payload.test.js
+++ b/tests/unit/kiro-minimal-wire-payload.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { openaiToKiroRequest } from "../../open-sse/translator/request/openai-to-kiro.js";
+import { claudeToKiroRequest } from "../../open-sse/translator/request/claude-to-kiro.js";
+
+for (const [name, translate, body] of [
+  ["OpenAI", openaiToKiroRequest, { messages: [{ role: "user", content: "hello" }] }],
+  ["Claude", claudeToKiroRequest, { messages: [{ role: "user", content: "hello" }] }],
+]) {
+  describe(`${name} Kiro minimal wire payload`, () => {
+    it("omits unsupported agent fields", () => {
+      const payload = translate("kiro/claude-sonnet-4.5", body, true, {});
+      expect(payload).not.toHaveProperty("agentMode");
+      expect(payload.conversationState).not.toHaveProperty("agentContinuationId");
+      expect(payload.conversationState).not.toHaveProperty("agentTaskType");
+      expect(payload.conversationState.chatTriggerType).toBe("MANUAL");
+      expect(payload.conversationState.currentMessage.userInputMessage.origin).toBe("AI_EDITOR");
+    });
+  });
+}

--- a/tests/unit/openai-to-kiro.test.js
+++ b/tests/unit/openai-to-kiro.test.js
@@ -606,7 +606,7 @@ describe("openaiToKiroRequest", () => {
       );
 
       expect(second.conversationState.conversationId).toBe("hermes-session-openai-replay");
-      expect(second.conversationState.agentContinuationId).toBe(first.conversationState.agentContinuationId);
+      expect(second.conversationState).not.toHaveProperty("agentContinuationId");
       expect(second.conversationState.history[0].userInputMessage.content).toBe(
         first.conversationState.currentMessage.userInputMessage.content
       );


### PR DESCRIPTION
Closes #3774

### Problem
Requests to Kiro models (e.g. `kr/claude-sonnet-4.5` / `kiro/claude-sonnet-4.5`) fail with HTTP 400:
```json
{"message": "Improperly formed request.", "reason": "REQUEST_BODY_INVALID"}
```
Target: `https://runtime.us-east-1.kiro.dev/generateAssistantResponse`

### Root Cause
1. **Deprecated Path-Style Runtime Gateway**: Upstream Kiro deprecated direct path requests on `runtime.*.kiro.dev/generateAssistantResponse`, rejecting modern requests with HTTP 400. Kiro IDE and CLIRO route requests through Amazon Q (`q.<region>.amazonaws.com`) and CodeWhisperer (`codewhisperer.<region>.amazonaws.com`).
2. **Missing Runtime Headers**: Upstream expects AWS SSO bearer headers and agent markers:
   - `x-amz-sso-bearer`: access token
   - `x-amzn-kiro-agent-mode`: `spec`
   - `x-amzn-codewhisperer-machine-id`: `kiro-desktop`
   - `x-amzn-codewhisperer-profile-arn`: when profile ARN is present
3. **Obsolete Payload Schema Fields**: Upstream rejects payload objects containing:
   - Top-level `agentMode`
   - `conversationState.agentContinuationId`
   - `conversationState.agentTaskType`

### Changes
- **`open-sse/executors/kiro.js`**:
  - Prioritize fallback endpoints: try Amazon Q (`q.<region>.amazonaws.com`) and CodeWhisperer before falling back to `runtime.kiro.dev`.
  - Add required headers: `x-amz-sso-bearer`, `x-amzn-kiro-agent-mode`, `x-amzn-codewhisperer-machine-id`, and `x-amzn-codewhisperer-profile-arn`.
- **`open-sse/translator/request/claude-to-kiro.js` & `openai-to-kiro.js`**:
  - Remove deprecated `agentMode`, `agentContinuationId`, and `agentTaskType` fields.
- **Unit & Regression Tests**:
  - Add `tests/unit/kiro-minimal-wire-payload.test.js` asserting omitted deprecated fields.
  - Update `tests/unit/kiro-api-key-endpoint-routing.test.js` for prioritized Amazon surfaces.
  - Update `tests/translator/claude-kiro-direct.test.js` and `tests/unit/openai-to-kiro.test.js`.

### Verification
Tested on live Kiro accounts:
1. **Non-Stream**: 200 OK (`PONG`).
2. **SSE Stream**: 200 OK (`Two units combine, result two.`).
3. **Multi-Turn Context**: Verified memory retention across 3 consecutive turns without continuation IDs.
