### PR TITLE
Fix Codex reset-credit errors

### DIFF
--- a/open-sse/services/usage/codex.js
+++ b/open-sse/services/usage/codex.js
@@ -21,6 +21,13 @@ function toIsoDate(value) {
   return Number.isFinite(time) ? date.toISOString() : null;
 }
 
+function errorMessage(value, fallback) {
+  if (!value) return fallback;
+  if (typeof value === "string") return value;
+  if (typeof value.message === "string") return value.message;
+  return JSON.stringify(value);
+}
+
 function getCodexAccountId(providerSpecificData) {
   return providerSpecificData?.workspaceId || providerSpecificData?.accountId || providerSpecificData?.chatgptAccountId || null;
 }
@@ -162,7 +169,7 @@ export async function getCodexRateLimitResetCredits(accessToken, proxyOptions = 
   }
 
   if (!response.ok) {
-    const message = data?.message || data?.error || data?.detail || `Codex reset credits API unavailable (${response.status}).`;
+    const message = errorMessage(data?.message || data?.error || data?.detail, `Codex reset credits API unavailable (${response.status}).`);
     throw new Error(message);
   }
 

--- a/tests/unit/codex-reset-credits.test.js
+++ b/tests/unit/codex-reset-credits.test.js
@@ -91,6 +91,17 @@ describe("Codex reset credits", () => {
     });
   });
 
+  it("surfaces structured upstream errors as readable messages", async () => {
+    mocks.proxyAwareFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: { message: "Reset credits are unavailable for this account" } }),
+    });
+
+    const { getCodexRateLimitResetCredits } = await import("../../open-sse/services/usage/codex.js");
+    await expect(getCodexRateLimitResetCredits("token")).rejects.toThrow("Reset credits are unavailable for this account");
+  });
+
   it("GET refreshes OAuth credentials before returning reset credit details", async () => {
     const connection = {
       id: "conn_1",


### PR DESCRIPTION
## Summary

- preserve readable Codex reset-credit API errors when the upstream `error` field is an object
- prefer the nested error message and JSON-serialize other structured errors instead of displaying `[object Object]`

## Reproduction

The reset-credit endpoint can return a body such as:

```json
{"error":{"message":"Connector rate limit exceeded"}}
```

Passing that object directly to `new Error()` produces `[object Object]`.

## Verification

- added a regression test for structured upstream errors
- observed the test fail with `Received: "[object Object]"` before the fix
- focused Codex reset-credit tests pass after the fix
- live local endpoint now returns `{"error":"Connector rate limit exceeded"}` instead of `{"error":"[object Object]"}`
