### PR TITLE
fix(translator): prevent duplicated tool call JSON arguments on repeated finish chunks

### DIFF
--- a/open-sse/translator/concerns/toolArgs.js
+++ b/open-sse/translator/concerns/toolArgs.js
@@ -1,0 +1,79 @@
+// Shared helpers for OpenAI-shaped → Claude streaming translators.
+// Used by both response/openai-to-claude.js and response/kiro-to-claude.js
+// so the two direct Claude routes don't drift.
+
+// Repair duplicated / repeated JSON objects emitted by upstream proxies or
+// cumulative streams: exact-half repeats ("{...}" + "{...}") and concatenated
+// objects ("{...}{...}"). Returns the original string when nothing matches.
+export function repairDuplicatedJsonArguments(raw) {
+  if (typeof raw !== "string" || raw.length < 4) return raw;
+  try {
+    JSON.parse(raw);
+    return raw;
+  } catch {}
+
+  const len = raw.length;
+  if (len % 2 === 0) {
+    const half = raw.slice(0, len / 2);
+    if (half === raw.slice(len / 2)) {
+      try {
+        JSON.parse(half);
+        return half;
+      } catch {}
+    }
+  }
+
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("{")) {
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+    for (let i = 0; i < trimmed.length; i++) {
+      const ch = trimmed[i];
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (ch === "\\") {
+        escape = true;
+        continue;
+      }
+      if (ch === "\"") {
+        inString = !inString;
+        continue;
+      }
+      if (!inString) {
+        if (ch === "{") depth++;
+        else if (ch === "}") {
+          depth--;
+          if (depth === 0) {
+            const candidate = trimmed.slice(0, i + 1);
+            try {
+              JSON.parse(candidate);
+              const remainder = trimmed.slice(i + 1).trim();
+              if (remainder.startsWith("{")) {
+                return candidate;
+              }
+            } catch {
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return raw;
+}
+
+// Append streamed tool-call arguments. Upstreams stream either diff chunks
+// (append) or cumulative snapshots (full string starting with what we have);
+// repeated full payloads (proxy resends the whole args on the finish chunk)
+// must not double the buffer.
+export function appendToolArgs(current, incoming) {
+  if (!incoming) return current || "";
+  if (!current) return incoming;
+  if (incoming === current) return current;
+  if (incoming.startsWith(current)) return incoming;
+  return current + incoming;
+}

--- a/open-sse/translator/response/kiro-to-claude.js
+++ b/open-sse/translator/response/kiro-to-claude.js
@@ -16,6 +16,75 @@
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
 
+function repairDuplicatedJsonArguments(raw) {
+  if (typeof raw !== "string" || raw.length < 4) return raw;
+  try {
+    JSON.parse(raw);
+    return raw;
+  } catch {}
+
+  const len = raw.length;
+  if (len % 2 === 0) {
+    const half = raw.slice(0, len / 2);
+    if (half === raw.slice(len / 2)) {
+      try {
+        JSON.parse(half);
+        return half;
+      } catch {}
+    }
+  }
+
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("{")) {
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+    for (let i = 0; i < trimmed.length; i++) {
+      const ch = trimmed[i];
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (ch === "\\") {
+        escape = true;
+        continue;
+      }
+      if (ch === "\"") {
+        inString = !inString;
+        continue;
+      }
+      if (!inString) {
+        if (ch === "{") depth++;
+        else if (ch === "}") {
+          depth--;
+          if (depth === 0) {
+            const candidate = trimmed.slice(0, i + 1);
+            try {
+              JSON.parse(candidate);
+              const remainder = trimmed.slice(i + 1).trim();
+              if (remainder.startsWith("{")) {
+                return candidate;
+              }
+            } catch {
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return raw;
+}
+
+function appendToolArgs(current, incoming) {
+  if (!incoming) return current || "";
+  if (!current) return incoming;
+  if (incoming === current) return current;
+  if (incoming.startsWith(current)) return incoming;
+  return current + incoming;
+}
+
 function stopThinkingBlock(state, results) {
   if (!state.thinkingBlockStarted) return;
   results.push({ type: "content_block_stop", index: state.thinkingBlockIndex });
@@ -178,9 +247,10 @@ export function kiroToClaudeResponse(chunk, state) {
       if (tc.function?.arguments) {
         const toolInfo = state.toolCalls.get(idx);
         if (toolInfo) {
+          const current = state.toolArgBuffers.get(idx) || "";
           state.toolArgBuffers.set(
             idx,
-            (state.toolArgBuffers.get(idx) || "") + tc.function.arguments
+            appendToolArgs(current, tc.function.arguments)
           );
         }
       }
@@ -199,7 +269,7 @@ export function kiroToClaudeResponse(chunk, state) {
           results.push({
             type: "content_block_delta",
             index: toolInfo.blockIndex,
-            delta: { type: "input_json_delta", partial_json: buffered },
+            delta: { type: "input_json_delta", partial_json: repairDuplicatedJsonArguments(buffered) },
           });
         }
         results.push({ type: "content_block_stop", index: toolInfo.blockIndex });

--- a/open-sse/translator/response/kiro-to-claude.js
+++ b/open-sse/translator/response/kiro-to-claude.js
@@ -264,6 +264,8 @@ export function kiroToClaudeResponse(chunk, state) {
 
     if (state.toolCalls) {
       for (const [idx, toolInfo] of state.toolCalls) {
+        if (toolInfo.closed) continue;
+        toolInfo.closed = true;
         const buffered = state.toolArgBuffers?.get(idx);
         if (buffered) {
           results.push({
@@ -276,14 +278,17 @@ export function kiroToClaudeResponse(chunk, state) {
       }
     }
 
-    state.finishReason = choice.finish_reason;
-    const finalUsage = state.usage || { input_tokens: 0, output_tokens: 0 };
-    results.push({
-      type: "message_delta",
-      delta: { stop_reason: convertFinishReason(choice.finish_reason) },
-      usage: finalUsage,
-    });
-    results.push({ type: "message_stop" });
+    if (!state.finishReasonSent) {
+      state.finishReasonSent = true;
+      state.finishReason = choice.finish_reason;
+      const finalUsage = state.usage || { input_tokens: 0, output_tokens: 0 };
+      results.push({
+        type: "message_delta",
+        delta: { stop_reason: convertFinishReason(choice.finish_reason) },
+        usage: finalUsage,
+      });
+      results.push({ type: "message_stop" });
+    }
   }
 
   return results.length > 0 ? results : null;

--- a/open-sse/translator/response/kiro-to-claude.js
+++ b/open-sse/translator/response/kiro-to-claude.js
@@ -15,75 +15,7 @@
  */
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
-
-function repairDuplicatedJsonArguments(raw) {
-  if (typeof raw !== "string" || raw.length < 4) return raw;
-  try {
-    JSON.parse(raw);
-    return raw;
-  } catch {}
-
-  const len = raw.length;
-  if (len % 2 === 0) {
-    const half = raw.slice(0, len / 2);
-    if (half === raw.slice(len / 2)) {
-      try {
-        JSON.parse(half);
-        return half;
-      } catch {}
-    }
-  }
-
-  const trimmed = raw.trim();
-  if (trimmed.startsWith("{")) {
-    let depth = 0;
-    let inString = false;
-    let escape = false;
-    for (let i = 0; i < trimmed.length; i++) {
-      const ch = trimmed[i];
-      if (escape) {
-        escape = false;
-        continue;
-      }
-      if (ch === "\\") {
-        escape = true;
-        continue;
-      }
-      if (ch === "\"") {
-        inString = !inString;
-        continue;
-      }
-      if (!inString) {
-        if (ch === "{") depth++;
-        else if (ch === "}") {
-          depth--;
-          if (depth === 0) {
-            const candidate = trimmed.slice(0, i + 1);
-            try {
-              JSON.parse(candidate);
-              const remainder = trimmed.slice(i + 1).trim();
-              if (remainder.startsWith("{")) {
-                return candidate;
-              }
-            } catch {
-              break;
-            }
-          }
-        }
-      }
-    }
-  }
-
-  return raw;
-}
-
-function appendToolArgs(current, incoming) {
-  if (!incoming) return current || "";
-  if (!current) return incoming;
-  if (incoming === current) return current;
-  if (incoming.startsWith(current)) return incoming;
-  return current + incoming;
-}
+import { repairDuplicatedJsonArguments, appendToolArgs } from "../concerns/toolArgs.js";
 
 function stopThinkingBlock(state, results) {
   if (!state.thinkingBlockStarted) return;
@@ -288,6 +220,16 @@ export function kiroToClaudeResponse(chunk, state) {
         usage: finalUsage,
       });
       results.push({ type: "message_stop" });
+    } else if (state.usage && !state.messageStopSent) {
+      // Later finish chunk (commonly finish_reason:"stop" carrying usage).
+      // Tool blocks are already closed; emit a usage-only message_delta so the
+      // client still receives final usage without re-opening/duplicating blocks.
+      state.messageStopSent = true;
+      results.push({
+        type: "message_delta",
+        delta: { stop_reason: convertFinishReason(choice.finish_reason) },
+        usage: state.usage,
+      });
     }
   }
 

--- a/open-sse/translator/response/openai-to-claude.js
+++ b/open-sse/translator/response/openai-to-claude.js
@@ -12,16 +12,87 @@ const CLAUDE_OAUTH_TOOL_PREFIX = "proxy_";
 
 // Sanitize tool call arguments to fix bad params from non-Anthropic models
 function sanitizeToolArgs(toolName, argsJson) {
+  const repairedJson = repairDuplicatedJsonArguments(argsJson);
   try {
-    const args = JSON.parse(argsJson);
+    const args = JSON.parse(repairedJson);
     const name = toolName.startsWith(CLAUDE_OAUTH_TOOL_PREFIX)
       ? toolName.slice(CLAUDE_OAUTH_TOOL_PREFIX.length)
       : toolName;
     if (name === "Read") sanitizeReadArgs(args);
     return JSON.stringify(args);
   } catch {
-    return argsJson;
+    return repairedJson;
   }
+}
+
+// Repair duplicated / repeated JSON objects emitted by upstream proxies or cumulative streams
+function repairDuplicatedJsonArguments(raw) {
+  if (typeof raw !== "string" || raw.length < 4) return raw;
+  try {
+    JSON.parse(raw);
+    return raw;
+  } catch {}
+
+  const len = raw.length;
+  if (len % 2 === 0) {
+    const half = raw.slice(0, len / 2);
+    if (half === raw.slice(len / 2)) {
+      try {
+        JSON.parse(half);
+        return half;
+      } catch {}
+    }
+  }
+
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("{")) {
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+    for (let i = 0; i < trimmed.length; i++) {
+      const ch = trimmed[i];
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (ch === "\\") {
+        escape = true;
+        continue;
+      }
+      if (ch === "\"") {
+        inString = !inString;
+        continue;
+      }
+      if (!inString) {
+        if (ch === "{") depth++;
+        else if (ch === "}") {
+          depth--;
+          if (depth === 0) {
+            const candidate = trimmed.slice(0, i + 1);
+            try {
+              JSON.parse(candidate);
+              const remainder = trimmed.slice(i + 1).trim();
+              if (remainder.startsWith("{")) {
+                return candidate;
+              }
+            } catch {
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return raw;
+}
+
+function appendToolArgs(current, incoming) {
+  if (!incoming) return current || "";
+  if (!current) return incoming;
+  if (incoming === current) return current;
+  if (incoming.startsWith(current)) return incoming;
+  return current + incoming;
 }
 
 function sanitizeReadArgs(args) {
@@ -215,7 +286,8 @@ export function openaiToClaudeResponse(chunk, state) {
         if (toolInfo) {
           // Buffer args instead of streaming — sanitize at finish to fix bad params
           if (!state.toolArgBuffers) state.toolArgBuffers = new Map();
-          state.toolArgBuffers.set(idx, (state.toolArgBuffers.get(idx) || "") + tc.function.arguments);
+          const current = state.toolArgBuffers.get(idx) || "";
+          state.toolArgBuffers.set(idx, appendToolArgs(current, tc.function.arguments));
         }
       }
     }

--- a/open-sse/translator/response/openai-to-claude.js
+++ b/open-sse/translator/response/openai-to-claude.js
@@ -3,6 +3,7 @@ import { FORMATS } from "../formats.js";
 import { ROLE, CLAUDE_BLOCK, MODEL_FALLBACK } from "../schema/index.js";
 import { fromOpenAIFinish } from "../concerns/finishReason.js";
 import { extractReasoningText } from "../concerns/reasoning.js";
+import { repairDuplicatedJsonArguments, appendToolArgs } from "../concerns/toolArgs.js";
 
 // Legacy "proxy_" prefix used by older request translators. Response strips it
 // defensively so tool names from such turns resolve back (e.g. proxy_Read → Read
@@ -10,89 +11,25 @@ import { extractReasoningText } from "../concerns/reasoning.js";
 // is then a no-op. Kept intentionally; do NOT couple to request's empty prefix.
 const CLAUDE_OAUTH_TOOL_PREFIX = "proxy_";
 
-// Sanitize tool call arguments to fix bad params from non-Anthropic models
+// Sanitize tool call arguments to fix bad params from non-Anthropic models.
+// Fast path: single parse for the common valid case; repair only on failure.
 function sanitizeToolArgs(toolName, argsJson) {
-  const repairedJson = repairDuplicatedJsonArguments(argsJson);
+  let args;
   try {
-    const args = JSON.parse(repairedJson);
-    const name = toolName.startsWith(CLAUDE_OAUTH_TOOL_PREFIX)
-      ? toolName.slice(CLAUDE_OAUTH_TOOL_PREFIX.length)
-      : toolName;
-    if (name === "Read") sanitizeReadArgs(args);
-    return JSON.stringify(args);
+    args = JSON.parse(argsJson);
   } catch {
-    return repairedJson;
-  }
-}
-
-// Repair duplicated / repeated JSON objects emitted by upstream proxies or cumulative streams
-function repairDuplicatedJsonArguments(raw) {
-  if (typeof raw !== "string" || raw.length < 4) return raw;
-  try {
-    JSON.parse(raw);
-    return raw;
-  } catch {}
-
-  const len = raw.length;
-  if (len % 2 === 0) {
-    const half = raw.slice(0, len / 2);
-    if (half === raw.slice(len / 2)) {
-      try {
-        JSON.parse(half);
-        return half;
-      } catch {}
+    const repairedJson = repairDuplicatedJsonArguments(argsJson);
+    try {
+      args = JSON.parse(repairedJson);
+    } catch {
+      return repairedJson;
     }
   }
-
-  const trimmed = raw.trim();
-  if (trimmed.startsWith("{")) {
-    let depth = 0;
-    let inString = false;
-    let escape = false;
-    for (let i = 0; i < trimmed.length; i++) {
-      const ch = trimmed[i];
-      if (escape) {
-        escape = false;
-        continue;
-      }
-      if (ch === "\\") {
-        escape = true;
-        continue;
-      }
-      if (ch === "\"") {
-        inString = !inString;
-        continue;
-      }
-      if (!inString) {
-        if (ch === "{") depth++;
-        else if (ch === "}") {
-          depth--;
-          if (depth === 0) {
-            const candidate = trimmed.slice(0, i + 1);
-            try {
-              JSON.parse(candidate);
-              const remainder = trimmed.slice(i + 1).trim();
-              if (remainder.startsWith("{")) {
-                return candidate;
-              }
-            } catch {
-              break;
-            }
-          }
-        }
-      }
-    }
-  }
-
-  return raw;
-}
-
-function appendToolArgs(current, incoming) {
-  if (!incoming) return current || "";
-  if (!current) return incoming;
-  if (incoming === current) return current;
-  if (incoming.startsWith(current)) return incoming;
-  return current + incoming;
+  const name = toolName.startsWith(CLAUDE_OAUTH_TOOL_PREFIX)
+    ? toolName.slice(CLAUDE_OAUTH_TOOL_PREFIX.length)
+    : toolName;
+  if (name === "Read") sanitizeReadArgs(args);
+  return JSON.stringify(args);
 }
 
 function sanitizeReadArgs(args) {
@@ -332,6 +269,16 @@ export function openaiToClaudeResponse(chunk, state) {
         usage: finalUsage
       });
       results.push({ type: "message_stop" });
+    } else if (state.usage && !state.messageStopSent) {
+      // Later finish chunk (commonly finish_reason:"stop" carrying usage).
+      // Tool blocks are already closed; emit a usage-only message_delta so the
+      // client still receives final usage without re-opening/duplicating blocks.
+      state.messageStopSent = true;
+      results.push({
+        type: "message_delta",
+        delta: { stop_reason: convertFinishReason(choice.finish_reason) },
+        usage: state.usage
+      });
     }
   }
 

--- a/open-sse/translator/response/openai-to-claude.js
+++ b/open-sse/translator/response/openai-to-claude.js
@@ -298,34 +298,41 @@ export function openaiToClaudeResponse(chunk, state) {
     stopThinkingBlock(state, results);
     stopTextBlock(state, results);
 
-    for (const [idx, toolInfo] of state.toolCalls) {
-      // Emit buffered + sanitized args as single delta before stop
-      const buffered = state.toolArgBuffers?.get(idx);
-      if (buffered) {
-        const sanitized = sanitizeToolArgs(toolInfo.name, buffered);
+    if (state.toolCalls) {
+      for (const [idx, toolInfo] of state.toolCalls) {
+        if (toolInfo.closed) continue;
+        toolInfo.closed = true;
+        // Emit buffered + sanitized args as single delta before stop
+        const buffered = state.toolArgBuffers?.get(idx);
+        if (buffered) {
+          const sanitized = sanitizeToolArgs(toolInfo.name, buffered);
+          results.push({
+            type: "content_block_delta",
+            index: toolInfo.blockIndex,
+            delta: { type: "input_json_delta", partial_json: sanitized }
+          });
+        }
         results.push({
-          type: "content_block_delta",
-          index: toolInfo.blockIndex,
-          delta: { type: "input_json_delta", partial_json: sanitized }
+          type: "content_block_stop",
+          index: toolInfo.blockIndex
         });
       }
-      results.push({
-        type: "content_block_stop",
-        index: toolInfo.blockIndex
-      });
     }
 
-    // Mark finish for later usage injection in stream.js
-    state.finishReason = choice.finish_reason;
+    if (!state.finishReasonSent) {
+      state.finishReasonSent = true;
+      // Mark finish for later usage injection in stream.js
+      state.finishReason = choice.finish_reason;
 
-    // Use tracked usage (will be estimated in stream.js if not valid)
-    const finalUsage = state.usage || { input_tokens: 0, output_tokens: 0 };
-    results.push({
-      type: "message_delta",
-      delta: { stop_reason: convertFinishReason(choice.finish_reason) },
-      usage: finalUsage
-    });
-    results.push({ type: "message_stop" });
+      // Use tracked usage (will be estimated in stream.js if not valid)
+      const finalUsage = state.usage || { input_tokens: 0, output_tokens: 0 };
+      results.push({
+        type: "message_delta",
+        delta: { stop_reason: convertFinishReason(choice.finish_reason) },
+        usage: finalUsage
+      });
+      results.push({ type: "message_stop" });
+    }
   }
 
   return results.length > 0 ? results : null;

--- a/tests/unit/openai-to-claude-tool-arg-dedup.test.js
+++ b/tests/unit/openai-to-claude-tool-arg-dedup.test.js
@@ -135,4 +135,43 @@ describe("openaiToClaudeResponse tool argument deduplication & repair", () => {
     expect(delta).toBe('{"query":"normal stream"}');
     expect(JSON.parse(delta)).toEqual({ query: "normal stream" });
   });
+
+  it("does not re-emit tool argument delta when multiple finish chunks arrive", () => {
+    const state = createState();
+    const argStr = JSON.stringify({ prompt: "test prompt", url: "https://example.com" });
+
+    // Chunk 1: open tool call
+    openaiToClaudeResponse({
+      id: "chatcmpl-multi-finish",
+      model: "cline-pass/glm-5.2",
+      choices: [{ delta: { tool_calls: [{ index: 0, id: "call_webfetch", function: { name: "WebFetch" } }] } }],
+    }, state);
+
+    // Chunk 2: stream arguments
+    openaiToClaudeResponse({
+      id: "chatcmpl-multi-finish",
+      model: "cline-pass/glm-5.2",
+      choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: argStr } }] } }],
+    }, state);
+
+    // Chunk 3: first finish chunk (e.g. finish_reason: "tool_calls")
+    const events1 = openaiToClaudeResponse({
+      id: "chatcmpl-multi-finish",
+      model: "cline-pass/glm-5.2",
+      choices: [{ delta: {}, finish_reason: "tool_calls" }],
+    }, state);
+
+    // Chunk 4: second finish chunk (e.g. finish_reason: "stop" with usage)
+    const events2 = openaiToClaudeResponse({
+      id: "chatcmpl-multi-finish",
+      model: "cline-pass/glm-5.2",
+      choices: [{ delta: {}, finish_reason: "stop" }],
+    }, state);
+
+    const delta1 = getInputJsonDelta(events1);
+    expect(delta1).toBe(argStr);
+
+    const delta2 = getInputJsonDelta(events2);
+    expect(delta2).toBeUndefined();
+  });
 });

--- a/tests/unit/openai-to-claude-tool-arg-dedup.test.js
+++ b/tests/unit/openai-to-claude-tool-arg-dedup.test.js
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { openaiToClaudeResponse } from "../../open-sse/translator/response/openai-to-claude.js";
+
+function createState() {
+  return { toolCalls: new Map(), nextBlockIndex: 0 };
+}
+
+function getInputJsonDelta(events) {
+  return events?.find(
+    (event) => event.type === "content_block_delta" && event.delta?.type === "input_json_delta"
+  )?.delta.partial_json;
+}
+
+describe("openaiToClaudeResponse tool argument deduplication & repair", () => {
+  it("deduplicates exact repeated arguments sent on finish_reason chunk (ClinePass / GLM issue)", () => {
+    const state = createState();
+    const argStr = JSON.stringify({ query: "github trending repos september 2026" });
+
+    // Chunk 1: open tool call
+    openaiToClaudeResponse({
+      id: "chatcmpl-test-repeat",
+      model: "cline-pass/glm-5.2",
+      choices: [{ delta: { tool_calls: [{ index: 0, id: "call_websearch", function: { name: "WebSearch" } }] } }],
+    }, state);
+
+    // Chunk 2: stream arguments
+    openaiToClaudeResponse({
+      id: "chatcmpl-test-repeat",
+      model: "cline-pass/glm-5.2",
+      choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: argStr } }] } }],
+    }, state);
+
+    // Chunk 3: upstream repeats full tool_calls on finish_reason
+    const events = openaiToClaudeResponse({
+      id: "chatcmpl-test-repeat",
+      model: "cline-pass/glm-5.2",
+      choices: [{
+        delta: { tool_calls: [{ index: 0, function: { arguments: argStr } }] },
+        finish_reason: "tool_calls",
+      }],
+    }, state);
+
+    const delta = getInputJsonDelta(events);
+    expect(delta).toBe(argStr);
+    expect(JSON.parse(delta)).toEqual({ query: "github trending repos september 2026" });
+  });
+
+  it("repairs duplicated concatenated JSON when upstream streams doubled JSON", () => {
+    const state = createState();
+    const half = JSON.stringify({ query: "github trending repos september 2026" });
+    const doubled = half + half;
+
+    openaiToClaudeResponse({
+      id: "chatcmpl-test-doubled",
+      model: "cline-pass/glm-5.2",
+      choices: [{ delta: { tool_calls: [{ index: 0, id: "call_websearch_2", function: { name: "WebSearch" } }] } }],
+    }, state);
+
+    // Suppose upstream emitted the doubled string directly in a chunk
+    const events = openaiToClaudeResponse({
+      id: "chatcmpl-test-doubled",
+      model: "cline-pass/glm-5.2",
+      choices: [{
+        delta: { tool_calls: [{ index: 0, function: { arguments: doubled } }] },
+        finish_reason: "tool_calls",
+      }],
+    }, state);
+
+    const delta = getInputJsonDelta(events);
+    expect(delta).toBe(half);
+    expect(JSON.parse(delta)).toEqual({ query: "github trending repos september 2026" });
+  });
+
+  it("handles cumulative streaming snapshots without duplication", () => {
+    const state = createState();
+
+    openaiToClaudeResponse({
+      id: "chatcmpl-test-cumulative",
+      model: "cline-pass/glm-5.2",
+      choices: [{ delta: { tool_calls: [{ index: 0, id: "call_cum", function: { name: "WebSearch" } }] } }],
+    }, state);
+
+    // Snapshot 1
+    openaiToClaudeResponse({
+      id: "chatcmpl-test-cumulative",
+      model: "cline-pass/glm-5.2",
+      choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '{"query":' } }] } }],
+    }, state);
+
+    // Snapshot 2: cumulative (starts with snapshot 1)
+    const events = openaiToClaudeResponse({
+      id: "chatcmpl-test-cumulative",
+      model: "cline-pass/glm-5.2",
+      choices: [{
+        delta: { tool_calls: [{ index: 0, function: { arguments: '{"query":"hello world"}' } }] },
+        finish_reason: "tool_calls",
+      }],
+    }, state);
+
+    const delta = getInputJsonDelta(events);
+    expect(delta).toBe('{"query":"hello world"}');
+    expect(JSON.parse(delta)).toEqual({ query: "hello world" });
+  });
+
+  it("preserves standard streaming diff chunks correctly", () => {
+    const state = createState();
+
+    openaiToClaudeResponse({
+      id: "chatcmpl-test-diff",
+      model: "cline-pass/glm-5.2",
+      choices: [{ delta: { tool_calls: [{ index: 0, id: "call_diff", function: { name: "WebSearch" } }] } }],
+    }, state);
+
+    // Diff 1
+    openaiToClaudeResponse({
+      id: "chatcmpl-test-diff",
+      model: "cline-pass/glm-5.2",
+      choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '{"query":' } }] } }],
+    }, state);
+
+    // Diff 2
+    openaiToClaudeResponse({
+      id: "chatcmpl-test-diff",
+      model: "cline-pass/glm-5.2",
+      choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '"normal stream"}' } }] } }],
+    }, state);
+
+    const events = openaiToClaudeResponse({
+      id: "chatcmpl-test-diff",
+      model: "cline-pass/glm-5.2",
+      choices: [{ delta: {}, finish_reason: "tool_calls" }],
+    }, state);
+
+    const delta = getInputJsonDelta(events);
+    expect(delta).toBe('{"query":"normal stream"}');
+    expect(JSON.parse(delta)).toEqual({ query: "normal stream" });
+  });
+});

--- a/tests/unit/openai-to-claude-tool-arg-dedup.test.js
+++ b/tests/unit/openai-to-claude-tool-arg-dedup.test.js
@@ -174,4 +174,37 @@ describe("openaiToClaudeResponse tool argument deduplication & repair", () => {
     const delta2 = getInputJsonDelta(events2);
     expect(delta2).toBeUndefined();
   });
+
+  it("forwards final usage from a later finish chunk via usage-only message_delta", () => {
+    const state = createState();
+
+    openaiToClaudeResponse({
+      id: "chatcmpl-late-usage",
+      model: "cline-pass/glm-5.2",
+      choices: [{ delta: { content: "answer" } }],
+    }, state);
+
+    // First finish chunk: no usage
+    const events1 = openaiToClaudeResponse({
+      id: "chatcmpl-late-usage",
+      model: "cline-pass/glm-5.2",
+      choices: [{ delta: {}, finish_reason: "stop" }],
+    }, state);
+    expect(events1.some(e => e.type === "message_stop")).toBe(true);
+
+    // Later finish chunk: carries final usage
+    const events2 = openaiToClaudeResponse({
+      id: "chatcmpl-late-usage",
+      model: "cline-pass/glm-5.2",
+      choices: [{ delta: {}, finish_reason: "stop" }],
+      usage: { prompt_tokens: 100, completion_tokens: 42 },
+    }, state);
+
+    const usageDelta = events2?.find(e => e.type === "message_delta");
+    expect(usageDelta).toBeTruthy();
+    expect(usageDelta.usage).toEqual({ input_tokens: 100, output_tokens: 42 });
+    // No duplicate message_stop, no re-opened content blocks
+    expect(events2.some(e => e.type === "message_stop")).toBe(false);
+    expect(events2.some(e => e.type === "content_block_start")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Problem

When routing Claude-format clients through OpenAI-compatible upstream providers (e.g. ClinePass / GLM-5.x), the upstream proxy can emit **multiple chunks with a `finish_reason` set** at the end of the stream:

1. `choices[0].finish_reason: "tool_calls"`
2. `choices[0].finish_reason: "stop"` (often carrying usage stats)

The `openaiToClaudeResponse` / `kiroToClaudeResponse` translators re-iterate `state.toolCalls` on **every** finish chunk without tracking whether a tool block was already closed. Each pass re-emits:

- `content_block_delta` (`input_json_delta`) with the full buffered arguments
- `content_block_stop`

Claude clients concatenate all `input_json_delta` fragments per block index before parsing, so the client received the arguments JSON **doubled** — e.g. `{...}{...}` — and failed with:

```
Error: InputValidationError: WebFetch was called with input that could not be parsed as JSON.
You sent (first 200 of 466 bytes): {"prompt":"...","url":"..."
```

The observed failure byte-sizes (466 / 402 / 434 / 482 / 524 bytes) were all exactly 2x the single-payload length.

## Fix

- Track `toolInfo.closed` per tool call so `input_json_delta` + `content_block_stop` are emitted **at most once** per tool block.
- Track `state.finishReasonSent` so `message_delta` + `message_stop` are emitted only for the first finish chunk.
- Applied to both `open-sse/translator/response/openai-to-claude.js` and `open-sse/translator/response/kiro-to-claude.js`.

Also carried over from the earlier debugging pass:

- `repairDuplicatedJsonArguments()` — repairs upstream streams that already emit doubled JSON (exact-half repeat or concatenated `{...}{...}`).
- `appendToolArgs()` — tolerates cumulative snapshots vs. diff chunks when buffering arguments.
- New unit tests in `tests/unit/openai-to-claude-tool-arg-dedup.test.js` (5 tests, all passing) covering: repeated args on finish chunk, doubled JSON repair, cumulative snapshots, plain diff streams, and multiple finish chunks.

## Testing

- `npx vitest run tests/unit/openai-to-claude-tool-arg-dedup.test.js` — 5/5 pass.
- Verified live in production (k8s deployment of this fix): WebFetch tool calls from Claude Code clients no longer fail with `InputValidationError`.