### PR TITLE
fix(claude): convert non-streaming responses to Claude message format and add SSE ping heartbeat

### DIFF
--- a/open-sse/handlers/chatCore/claudeResponseConverter.js
+++ b/open-sse/handlers/chatCore/claudeResponseConverter.js
@@ -1,0 +1,75 @@
+import { FORMATS } from "../../translator/formats.js";
+import { fromOpenAIFinish } from "../../translator/concerns/finishReason.js";
+import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../../config/defaultThinkingSignature.js";
+
+function parseToolArguments(value) {
+  if (!value) return {};
+  if (typeof value === "object") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Convert an OpenAI Chat Completions response body into an Anthropic Claude Message response.
+ * @param {object} responseBody - OpenAI Chat Completion object
+ * @returns {object} Claude Message object
+ */
+export function chatCompletionToClaudeMessage(responseBody) {
+  if (!responseBody) return responseBody;
+  if (responseBody.type === "message" && Array.isArray(responseBody.content)) {
+    return responseBody; // Already Claude message
+  }
+  if (!responseBody.choices?.[0]) return responseBody;
+  const choice = responseBody.choices[0];
+  const message = choice.message || {};
+  const content = [];
+
+  const reasoning = message.reasoning_content || message.provider_specific_fields?.reasoning_content || "";
+  if (reasoning) {
+    content.push({
+      type: "thinking",
+      thinking: reasoning,
+      signature: DEFAULT_THINKING_CLAUDE_SIGNATURE
+    });
+  }
+  if (typeof message.content === "string" && message.content.length > 0) {
+    content.push({ type: "text", text: message.content });
+  }
+  for (const toolCall of message.tool_calls || []) {
+    const fn = toolCall.function || {};
+    content.push({
+      type: "tool_use",
+      id: toolCall.id || `toolu_${Date.now()}_${content.length}`,
+      name: fn.name || toolCall.name || "",
+      input: parseToolArguments(fn.arguments || toolCall.arguments),
+    });
+  }
+  if (content.length === 0) content.push({ type: "text", text: "" });
+
+  const usage = responseBody.usage || {};
+  const claudeUsage = {
+    input_tokens: usage.prompt_tokens || usage.input_tokens || 0,
+    output_tokens: usage.completion_tokens || usage.output_tokens || 0,
+  };
+  const cacheRead = usage.cache_read_input_tokens || usage.cached_tokens;
+  if (typeof cacheRead === "number" && cacheRead > 0) {
+    claudeUsage.cache_read_input_tokens = cacheRead;
+  }
+  if (typeof usage.cache_creation_input_tokens === "number" && usage.cache_creation_input_tokens > 0) {
+    claudeUsage.cache_creation_input_tokens = usage.cache_creation_input_tokens;
+  }
+
+  return {
+    id: String(responseBody.id || `msg_${Date.now()}`).replace(/^chatcmpl-/, ""),
+    type: "message",
+    role: "assistant",
+    model: responseBody.model || "unknown",
+    content,
+    stop_reason: fromOpenAIFinish(choice.finish_reason, FORMATS.CLAUDE),
+    stop_sequence: null,
+    usage: claudeUsage,
+  };
+}

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -10,6 +10,7 @@ import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, sav
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
 import { ROLE, RESPONSES_ITEM } from "../../translator/schema/index.js";
+import { chatCompletionToClaudeMessage } from "./claudeResponseConverter.js";
 
 function parseToolArguments(value) {
   if (!value) return {};
@@ -211,6 +212,9 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
         result.usage.completion_tokens_details = { reasoning_tokens: usage.thoughtsTokenCount };
       }
     }
+    if (sourceFormat === FORMATS.CLAUDE) {
+      return chatCompletionToClaudeMessage(result);
+    }
     return result;
   }
 
@@ -272,7 +276,11 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
 
   // Ollama
   if (targetFormat === FORMATS.OLLAMA) {
-    return ollamaBodyToOpenAI(responseBody);
+    const res = ollamaBodyToOpenAI(responseBody);
+    if (sourceFormat === FORMATS.CLAUDE) {
+      return chatCompletionToClaudeMessage(res);
+    }
+    return res;
   }
 
   return responseBody;

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -5,6 +5,7 @@ import { FORMATS } from "../../translator/formats.js";
 import { PROVIDERS } from "../../config/providers.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { ROLE, RESPONSES_ITEM } from "../../translator/schema/index.js";
+import { chatCompletionToClaudeMessage } from "./claudeResponseConverter.js";
 
 // Responses-API providers (e.g. codex) may emit SSE without content-type + use Responses output shape
 const isResponsesProvider = (p) => PROVIDERS[p]?.format === FORMATS.OPENAI_RESPONSES;
@@ -266,6 +267,20 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
             responseId: jsonResponse.id || `resp_${Date.now()}`
           }
         };
+      } else if (sourceFormat === FORMATS.CLAUDE) {
+        const message = { role: "assistant", content: textContent || (hasToolCalls ? null : "") };
+        if (hasToolCalls) message.tool_calls = toolCalls;
+        const responseDone = jsonResponse.status === "completed" || jsonResponse.status === "done";
+        const finishReason = hasToolCalls ? "tool_calls" : (responseDone ? "stop" : (jsonResponse.status || "stop"));
+        const intermediate = {
+          id: jsonResponse.id || `chatcmpl-${Date.now()}`,
+          object: "chat.completion",
+          created: jsonResponse.created_at || Math.floor(Date.now() / 1000),
+          model: jsonResponse.model || model,
+          choices: [{ index: 0, message, finish_reason: finishReason }],
+          usage: { prompt_tokens: inTokens, completion_tokens: outTokens, total_tokens: inTokens + outTokens, ...cacheDetails }
+        };
+        finalResp = chatCompletionToClaudeMessage(intermediate);
       } else {
         const message = { role: "assistant", content: textContent || (hasToolCalls ? null : "") };
         if (hasToolCalls) message.tool_calls = toolCalls;
@@ -347,9 +362,12 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
     // lost on the non-streaming return path. Inlined (not imported from
     // nonStreamingHandler.js) to avoid a circular import: nonStreamingHandler
     // already imports parseSSEToOpenAIResponse from this module.
-    const finalBody = sourceFormat === FORMATS.OPENAI_RESPONSES
-      ? chatCompletionToResponses(parsed, customToolNames)
-      : parsed;
+    let finalBody = parsed;
+    if (sourceFormat === FORMATS.OPENAI_RESPONSES) {
+      finalBody = chatCompletionToResponses(parsed, customToolNames);
+    } else if (sourceFormat === FORMATS.CLAUDE) {
+      finalBody = chatCompletionToClaudeMessage(parsed);
+    }
 
     return { success: true, response: new Response(JSON.stringify(finalBody), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
   } catch (err) {

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -9,6 +9,9 @@ import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLin
 import { saveRequestDetail } from "@/lib/usageDb.js";
 import { SSE_HEADERS_CORS as SSE_HEADERS } from "../../utils/sseConstants.js";
 
+const CLAUDE_PING_BYTES = new TextEncoder().encode("event: ping\ndata: {\"type\": \"ping\"}\n\n");
+const CLAUDE_PING_INTERVAL_MS = 15000;
+
 // Codex returns Responses API SSE → which client format to translate INTO, by request sourceFormat.
 // Gemini-family all map to ANTIGRAVITY decoder; unknown sources fall back to OPENAI.
 const CODEX_SOURCE_TO_TARGET = {
@@ -85,7 +88,8 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
   const isResponsesPassthrough = sourceFormat === FORMATS.OPENAI_RESPONSES && targetFormat === FORMATS.OPENAI_RESPONSES;
   const onAbortTerminal = isResponsesPassthrough ? buildAbortedResponsesTerminalBytes : null;
   const stallTimeoutMs = PROVIDERS[provider]?.stallTimeoutMs || STREAM_STALL_TIMEOUT_MS;
-  const transformedBody = pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal, stallTimeoutMs);
+  const pingBytes = sourceFormat === FORMATS.CLAUDE ? CLAUDE_PING_BYTES : null;
+  const transformedBody = pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal, stallTimeoutMs, pingBytes, CLAUDE_PING_INTERVAL_MS);
 
   saveRequestDetail(buildRequestDetail({
     provider, model, connectionId,

--- a/open-sse/translator/concerns/finishReason.js
+++ b/open-sse/translator/concerns/finishReason.js
@@ -53,8 +53,11 @@ export function fromOpenAIFinish(reason, format) {
     case "claude":
       switch (reason) {
         case OPENAI_FINISH.STOP: return CLAUDE_STOP.END_TURN;
-        case OPENAI_FINISH.LENGTH: return CLAUDE_STOP.MAX_TOKENS;
-        case OPENAI_FINISH.TOOL_CALLS: return CLAUDE_STOP.TOOL_USE;
+        case OPENAI_FINISH.LENGTH:
+        case "max_tokens": return CLAUDE_STOP.MAX_TOKENS;
+        case OPENAI_FINISH.TOOL_CALLS:
+        case "tool_calls":
+        case "tool_use": return CLAUDE_STOP.TOOL_USE;
         default: return CLAUDE_STOP.END_TURN;
       }
     default:

--- a/open-sse/utils/streamHandler.js
+++ b/open-sse/utils/streamHandler.js
@@ -96,10 +96,20 @@ export function createStreamController({ onDisconnect, onError, log, provider, m
  * for long periods while raw bytes still flow (e.g. Kiro EventStream
  * binary frames buffering, Claude reasoning streams).
  */
-export function createDisconnectAwareStream(transformStream, streamController, onAbortTerminal = null) {
+export function createDisconnectAwareStream(transformStream, streamController, onAbortTerminal = null, pingBytes = null, pingIntervalMs = 15000) {
   const reader = transformStream.readable.getReader();
   const writer = transformStream.writable.getWriter();
   let terminalEmitted = false;
+  let pingTimer = null;
+  let lastChunkAt = Date.now();
+  let streamEnded = false;
+
+  const clearPing = () => {
+    if (pingTimer) {
+      clearInterval(pingTimer);
+      pingTimer = null;
+    }
+  };
 
   // Emit a synthesized terminal payload (e.g. Responses response.failed + [DONE]) once
   const emitTerminal = (controller) => {
@@ -107,13 +117,34 @@ export function createDisconnectAwareStream(transformStream, streamController, o
     terminalEmitted = true;
     try {
       const bytes = onAbortTerminal();
-      if (bytes) controller.enqueue(bytes);
+      if (bytes && controller.desiredSize !== null) controller.enqueue(bytes);
     } catch { /* best-effort terminal */ }
   };
 
   return new ReadableStream({
+    start(controller) {
+      if (pingBytes && pingIntervalMs > 0) {
+        pingTimer = setInterval(() => {
+          if (streamEnded || !streamController.isConnected() || controller.desiredSize === null) {
+            clearPing();
+            return;
+          }
+          const idleMs = Date.now() - lastChunkAt;
+          if (idleMs >= pingIntervalMs) {
+            try {
+              controller.enqueue(pingBytes);
+              lastChunkAt = Date.now();
+            } catch {
+              clearPing();
+            }
+          }
+        }, Math.min(pingIntervalMs, 5000));
+      }
+    },
+
     async pull(controller) {
       if (!streamController.isConnected()) {
+        clearPing();
         emitTerminal(controller);
         controller.close();
         return;
@@ -123,12 +154,17 @@ export function createDisconnectAwareStream(transformStream, streamController, o
         const { done, value } = await reader.read();
 
         if (done) {
+          clearPing();
+          streamEnded = true;
           streamController.handleComplete();
           controller.close();
           return;
         }
+        lastChunkAt = Date.now();
         controller.enqueue(value);
       } catch (error) {
+        clearPing();
+        streamEnded = true;
         const wasConnected = streamController.isConnected();
         // Controller already closed = downstream ended; not an upstream error, skip noisy log.
         const msg0 = error?.message || "";
@@ -166,6 +202,8 @@ export function createDisconnectAwareStream(transformStream, streamController, o
     },
 
     cancel(reason) {
+      clearPing();
+      streamEnded = true;
       streamController.handleDisconnect(reason || "cancelled");
       reader.cancel();
       writer.abort();
@@ -189,7 +227,7 @@ export function createDisconnectAwareStream(transformStream, streamController, o
  * @param {TransformStream} transformStream - Transform stream for SSE
  * @param {object} streamController - Stream controller from createStreamController
  */
-export function pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal = null, stallTimeoutMs = STREAM_STALL_TIMEOUT_MS) {
+export function pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal = null, stallTimeoutMs = STREAM_STALL_TIMEOUT_MS, pingBytes = null, pingIntervalMs = 15000) {
   let stallTimer = null;
   let chunkCount = 0;
   let totalBytes = 0;
@@ -249,7 +287,9 @@ export function pipeWithDisconnect(providerResponse, transformStream, streamCont
   return createDisconnectAwareStream(
     { readable: transformedBody, writable: { getWriter: () => ({ abort: () => Promise.resolve() }) } },
     wrappedController,
-    onAbortTerminal
+    onAbortTerminal,
+    pingBytes,
+    pingIntervalMs
   );
 }
 

--- a/tests/unit/claude-nonstream-translation.test.js
+++ b/tests/unit/claude-nonstream-translation.test.js
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}),
+  saveRequestUsage: vi.fn(async () => {})
+}));
+
+const { FORMATS } = await import("../../open-sse/translator/formats.js");
+const { translateNonStreamingResponse } = await import("../../open-sse/handlers/chatCore/nonStreamingHandler.js");
+const { handleForcedSSEToJson } = await import("../../open-sse/handlers/chatCore/sseToJsonHandler.js");
+
+const OPENAI_CHAT_COMPLETION = {
+  id: "chatcmpl-test-123",
+  object: "chat.completion",
+  created: 1700000000,
+  model: "claude-sonnet-4-6",
+  choices: [
+    {
+      index: 0,
+      message: {
+        role: "assistant",
+        content: "Hello from test!",
+        tool_calls: [
+          {
+            id: "call_tool_1",
+            type: "function",
+            function: { name: "Read", arguments: JSON.stringify({ file_path: "/test.txt" }) }
+          }
+        ]
+      },
+      finish_reason: "tool_calls"
+    }
+  ],
+  usage: {
+    prompt_tokens: 15,
+    completion_tokens: 25,
+    total_tokens: 40
+  }
+};
+
+const GEMINI_NONSTREAM_RESPONSE = {
+  response: {
+    responseId: "resp-gemini-123",
+    modelVersion: "gemini-3.8-flash",
+    createTime: "2026-09-04T00:00:00Z",
+    candidates: [
+      {
+        content: {
+          role: "model",
+          parts: [
+            { text: "Hello from Gemini non-stream!" }
+          ]
+        },
+        finishReason: "STOP"
+      }
+    ],
+    usageMetadata: {
+      promptTokenCount: 10,
+      candidatesTokenCount: 20,
+      totalTokenCount: 30
+    }
+  }
+};
+
+describe("Claude non-streaming response translation", () => {
+  it("translates OpenAI chat.completion to Claude message when sourceFormat is CLAUDE", () => {
+    const out = translateNonStreamingResponse(
+      OPENAI_CHAT_COMPLETION,
+      FORMATS.OPENAI,
+      FORMATS.CLAUDE
+    );
+
+    expect(out.type).toBe("message");
+    expect(out.role).toBe("assistant");
+    expect(out.id).toBe("test-123");
+    expect(Array.isArray(out.content)).toBe(true);
+
+    const textBlock = out.content.find(c => c.type === "text");
+    expect(textBlock?.text).toBe("Hello from test!");
+
+    const toolUseBlock = out.content.find(c => c.type === "tool_use");
+    expect(toolUseBlock?.id).toBe("call_tool_1");
+    expect(toolUseBlock?.name).toBe("Read");
+    expect(toolUseBlock?.input).toEqual({ file_path: "/test.txt" });
+
+    expect(out.stop_reason).toBe("tool_use");
+    expect(out.usage).toEqual({
+      input_tokens: 15,
+      output_tokens: 25
+    });
+  });
+
+  it("translates Gemini/Antigravity response to Claude message when sourceFormat is CLAUDE", () => {
+    const out = translateNonStreamingResponse(
+      GEMINI_NONSTREAM_RESPONSE,
+      FORMATS.ANTIGRAVITY,
+      FORMATS.CLAUDE
+    );
+
+    expect(out.type).toBe("message");
+    expect(out.role).toBe("assistant");
+    expect(Array.isArray(out.content)).toBe(true);
+    expect(out.content[0]).toEqual({ type: "text", text: "Hello from Gemini non-stream!" });
+    expect(out.stop_reason).toBe("end_turn");
+    expect(out.usage).toEqual({
+      input_tokens: 10,
+      output_tokens: 20
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Fix malformed response error**: When Anthropic Claude clients (e.g. Claude Code) send non-streaming requests (`stream: false`) to `/v1/messages`, providers whose target format is Gemini/Antigravity/Ollama were returning OpenAI `chat.completion` JSON envelopes instead of Anthropic `message` objects, causing clients to error out with:
  `API Error: API returned an empty or malformed response (HTTP 200) — body is JSON but not a Message`.
  Added `chatCompletionToClaudeMessage` in `open-sse/handlers/chatCore/claudeResponseConverter.js` and wired it to `nonStreamingHandler.js` and `sseToJsonHandler.js`.
- **Fix `StreamIdleTimeoutError` watchdog timeouts**: When upstream models (like Claude thinking or long prompt prefill on Antigravity/Vertex) take extended time without emitting tokens, Claude Code's 180s byte watchdog triggers a timeout. Added a 15s interval SSE `event: ping` heartbeat during silent gaps in `streamHandler.js` / `streamingHandler.js`.
- **Stop reasons**: Added mapping for `max_tokens` and `tool_calls`/`tool_use` in `finishReason.js`.
- **Unit test**: Added test coverage in `tests/unit/claude-nonstream-translation.test.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)