### PR TITLE
fix(security): guard cowork-mcp-tools probe against SSRF

### DIFF
--- a/src/app/api/cli-tools/cowork-mcp-tools/route.js
+++ b/src/app/api/cli-tools/cowork-mcp-tools/route.js
@@ -1,6 +1,8 @@
 "use server";
 
 import { NextResponse } from "next/server";
+import { assertPublicUrl } from "@/shared/utils/ssrfGuard.js";
+import { isLocalRequest } from "@/dashboardGuard";
 
 const TIMEOUT_MS = 8000;
 
@@ -86,6 +88,14 @@ export async function POST(request) {
     const { url } = await request.json();
     if (!url || typeof url !== "string") {
       return NextResponse.json({ error: "url required" }, { status: 400 });
+    }
+    // SSRF guard for remote callers; local host keeps self-hosted MCP servers.
+    if (!isLocalRequest(request)) {
+      try {
+        assertPublicUrl(url);
+      } catch {
+        return NextResponse.json({ error: "URL not allowed" }, { status: 400 });
+      }
     }
     const result = await probeMcp(url);
     return NextResponse.json(result);

--- a/tests/unit/cowork-mcp-ssrf-guard.test.js
+++ b/tests/unit/cowork-mcp-ssrf-guard.test.js
@@ -1,0 +1,61 @@
+/**
+ * SSRF guard on POST /api/cli-tools/cowork-mcp-tools (#3782).
+ *
+ * Remote callers must not be able to force server-side fetches to
+ * internal URLs; local-host use (self-hosted MCP servers) keeps working.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: (body, init) =>
+      new Response(JSON.stringify(body), {
+        status: init?.status ?? 200,
+        headers: { "content-type": "application/json" },
+      }),
+  },
+}));
+
+const { POST } = await import(
+  "../../src/app/api/cli-tools/cowork-mcp-tools/route.js"
+);
+
+function remoteRequest(url) {
+  return new Request("http://gateway.example.com/api/cli-tools/cowork-mcp-tools", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ url }),
+  });
+}
+
+describe("cowork-mcp-tools SSRF guard", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects loopback URLs from remote callers without fetching", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const res = await POST(remoteRequest("http://127.0.0.1:18731/internal-admin"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "URL not allowed" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects private-network URLs from remote callers", async () => {
+    for (const url of ["http://10.0.0.5/mcp", "http://192.168.1.1/mcp", "http://localhost:3000/mcp"]) {
+      const res = await POST(remoteRequest(url));
+      expect(res.status, `should reject ${url}`).toBe(400);
+    }
+  });
+
+  it("still requires a url", async () => {
+    const res = await POST(
+      new Request("http://gateway.example.com/api/cli-tools/cowork-mcp-tools", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

`POST /api/cli-tools/cowork-mcp-tools` passed its `url` straight into three server-side fetches with no SSRF guard, so any caller could make the gateway reach loopback/internal URLs and read back the "tool list". Same `assertPublicUrl` + local-requester exception the sibling provider-nodes route already uses, so self-hosted MCP servers keep working.

## How to test

1. POST `{ "url": "http://127.0.0.1:18731/internal-admin" }` from a non-local origin.
2. Observe 400 `URL not allowed` with no outbound fetch now. Before the fix, the internal server saw all 3 JSON-RPC POSTs and its tool list came back.
3. Run `vitest run unit/cowork-mcp-ssrf-guard.test.js unit/ssrf-guard-hardening.test.js unit/search-ssrf-guard.test.js` in `tests/`. All 26 pass, including the 3 new regression tests (2 red without the fix, green with it).