### PR TITLE
fix(translator): skip non-array messages in reasoning injector

### DIFF
--- a/open-sse/utils/reasoningContentInjector.js
+++ b/open-sse/utils/reasoningContentInjector.js
@@ -35,7 +35,7 @@ function shouldInject(message, scope) {
 }
 
 function applyRule(body, rule) {
-  if (!rule || !body?.messages) return body;
+  if (!rule || !Array.isArray(body?.messages)) return body;
   const messages = body.messages.map(m =>
     shouldInject(m, rule.scope) ? { ...m, reasoning_content: PLACEHOLDER } : m
   );

--- a/tests/unit/reasoningContentInjector.test.js
+++ b/tests/unit/reasoningContentInjector.test.js
@@ -158,3 +158,15 @@ describe("OpenCodeExecutor — issue #1543 regression", () => {
     expect(assistant.reasoning_content).toBeDefined();
   });
 });
+
+describe("malformed messages guard (#3784)", () => {
+  it.each(["hi", 42, { role: "user" }, null])(
+    "passes non-array messages through untouched (%p)",
+    (messages) => {
+      const body = { messages };
+      expect(
+        injectReasoningContent({ provider: "deepseek", model: "deepseek-chat", body })
+      ).toBe(body);
+    }
+  );
+});


### PR DESCRIPTION
## Summary

`injectReasoningContent` crashed with `TypeError: body.messages.map is not a function` on non-array `messages`, and the throw escaped uncaught past the executor. One-word guard (`Array.isArray`, same as every sibling transform), so malformed bodies pass through for upstream validation to 400.

## How to test

1. Call `injectReasoningContent` with `messages` as a string, number, or object.
2. Observe the body passes through untouched now. Before the fix, all three threw `TypeError`.
3. Run `vitest run unit/reasoningContentInjector.test.js` in `tests/`. All 16 pass, including the 4 new regression cases (3 red without the fix, green with it).