### PR TITLE
fix(translator): sum Gemini non-streaming total when absent

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -202,10 +202,13 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
     };
 
     if (usage) {
+      const promptTokens =
+        (usage.promptTokenCount || 0) + (usage.thoughtsTokenCount || 0);
+      const completionTokens = usage.candidatesTokenCount || 0;
       result.usage = {
-        prompt_tokens: (usage.promptTokenCount || 0) + (usage.thoughtsTokenCount || 0),
-        completion_tokens: usage.candidatesTokenCount || 0,
-        total_tokens: usage.totalTokenCount || 0
+        prompt_tokens: promptTokens,
+        completion_tokens: completionTokens,
+        total_tokens: usage.totalTokenCount || promptTokens + completionTokens
       };
       if (usage.thoughtsTokenCount > 0) {
         result.usage.completion_tokens_details = { reasoning_tokens: usage.thoughtsTokenCount };

--- a/tests/unit/gemini-nonstream-usage-total.test.js
+++ b/tests/unit/gemini-nonstream-usage-total.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}),
+  saveRequestUsage: vi.fn(async () => {})
+}));
+
+const { FORMATS } = await import("../../open-sse/translator/formats.js");
+const { translateNonStreamingResponse } = await import(
+  "../../open-sse/handlers/chatCore/nonStreamingHandler.js"
+);
+
+const GEMINI_BODY = (usageMetadata) => ({
+  candidates: [
+    { content: { parts: [{ text: "hi" }] }, finishReason: "STOP" }
+  ],
+  usageMetadata
+});
+
+const translate = (usageMetadata) =>
+  translateNonStreamingResponse(
+    GEMINI_BODY(usageMetadata),
+    FORMATS.ANTIGRAVITY,
+    FORMATS.GEMINI
+  );
+
+describe("gemini non-streaming usage totals (#3789)", () => {
+  it("falls back to summed parts when totalTokenCount is absent", () => {
+    expect(
+      translate({ promptTokenCount: 10, candidatesTokenCount: 20 }).usage
+    ).toMatchObject({
+      prompt_tokens: 10,
+      completion_tokens: 20,
+      total_tokens: 30
+    });
+  });
+
+  it("includes thoughts in the prompt part of the fallback sum", () => {
+    expect(
+      translate({
+        promptTokenCount: 10,
+        thoughtsTokenCount: 5,
+        candidatesTokenCount: 20
+      }).usage
+    ).toMatchObject({
+      prompt_tokens: 15,
+      completion_tokens: 20,
+      total_tokens: 35
+    });
+  });
+
+  it("prefers an explicit totalTokenCount when present", () => {
+    expect(
+      translate({
+        promptTokenCount: 10,
+        candidatesTokenCount: 20,
+        totalTokenCount: 35
+      }).usage.total_tokens
+    ).toBe(35);
+  });
+});


### PR DESCRIPTION
Closes #3789.

The non-streaming Gemini path reported `{prompt_tokens: 10, completion_tokens: 20, total_tokens: 0}` when the upstream response has no `totalTokenCount` — internally inconsistent, and the only branch in the file that does this (the siblings and the streaming normalizer all sum the parts). Now falls back to the sum of the derived parts, including `thoughtsTokenCount` which the prompt count already includes. An explicit `totalTokenCount` still wins.

How to test:

1. Translate a Gemini non-streaming body with `usageMetadata` lacking `totalTokenCount` toward an OpenAI-shaped target — `total_tokens` now equals prompt + completion.
2. Run `vitest run unit/gemini-nonstream-usage-total.test.js` in `tests/` — all 3 pass (the 2 fallback cases fail without the fix).
