### PR TITLE
fix(claude): normalize adaptive auto effort

### DIFF
--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -246,7 +246,7 @@ function applyFormat(fmt, body, cfg, caps, supportedLevels) {
       if (canDisable) body.thinking = { type: "adaptive" };
       else delete body.thinking;
       const level = toLevel(eff);
-      body.output_config = { effort: level === "xhigh" ? "high" : level };
+      body.output_config = { effort: level === "xhigh" || level === "auto" ? "high" : level };
       break;
     }
     case "claude-budget": {

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -82,6 +82,16 @@ describe("applyThinking per provider format", () => {
     // Sonnet 5). Both fields together are the documented adaptive shape.
     expect(out.thinking).toEqual({ type: "adaptive" });
   });
+  it("claude adaptive thinking maps auto effort to a supported level", () => {
+    const out = apply("claude", "claude-opus-4.7", { thinking: { type: "adaptive" } }, "claude");
+    expect(out.output_config).toEqual({ effort: "high" });
+    expect(out.thinking).toEqual({ type: "adaptive" });
+  });
+  it("permanently adaptive Claude maps auto effort without adding a thinking switch", () => {
+    const out = apply("claude", "claude-fable-5-1", { thinking: { type: "adaptive" } }, "claude");
+    expect(out.output_config).toEqual({ effort: "high" });
+    expect(out.thinking).toBeUndefined();
+  });
   it("Fable 5.1 → effort without a redundant thinking switch", () => {
     const out = apply("claude", "claude-fable-5-1", { reasoning_effort: "high" }, "claude");
     expect(out.output_config).toEqual({ effort: "high" });


### PR DESCRIPTION
## Summary

Fixes #3786.

Claude adaptive requests without an explicit effort are normalized to `output_config.effort: "high"` instead of forwarding the unsupported literal value `"auto"`.

## Problem

A client request such as:

```json
{
  "thinking": {
    "type": "adaptive"
  }
}
```

is captured as unified thinking mode `auto`. For models using the `claude-adaptive` format, 9router currently serializes that mode as:

```json
{
  "output_config": {
    "effort": "auto"
  }
}
```

Anthropic rejects this value with HTTP 400. That failed request can then contribute to connection backoff, causing a following valid request to appear unavailable.

## Root cause

`toLevel()` intentionally preserves unified auto mode as the string `"auto"`. The `claude-adaptive` branch only normalizes `"xhigh"` before assigning `output_config.effort`, so `"auto"` reaches the provider unchanged.

Other discrete-level branches already resolve auto mode to a supported concrete level.

## Change

Treat `"auto"` like the existing `"xhigh"` compatibility case in the `claude-adaptive` formatter and emit `"high"`.

This preserves the existing adaptive-thinking behavior:

- Claude models that support an explicit adaptive switch still receive `thinking: { "type": "adaptive" }`.
- Permanently adaptive models still omit the redundant `thinking` switch.
- Explicit supported effort levels are unchanged.

## Regression coverage

Added tests for both Claude adaptive capability paths:

1. `claude-opus-4.7` maps adaptive auto mode to `effort: "high"` and retains the adaptive switch.
2. `claude-fable-5-1` maps adaptive auto mode to `effort: "high"` without adding a redundant switch.

The first regression test fails on `upstream/master` with:

```text
expected { effort: 'auto' } to deeply equal { effort: 'high' }
```

## Validation

```text
thinking-unified.test.js: 62 passed
related applyThinking suites: 99 passed across 5 files
ESLint on changed files: passed
git diff --check: passed
```

The full translator suite has the same 11 unrelated Kiro, reasoning-bridge, and snapshot failures on both this branch and a clean `upstream/master` checkout.

## Scope

This PR only fixes adaptive auto-effort serialization. It does not change general HTTP 400 backoff policy or the separate `claude-budget` behavior discussed in #2894.