### PR TITLE
fix(search): allow configured private endpoints

### DIFF
--- a/open-sse/handlers/search/index.js
+++ b/open-sse/handlers/search/index.js
@@ -7,7 +7,7 @@
  *   provider.searchViaChat   → wrap chat-completions (chatSearch.js)
  */
 
-import { buildSearchRequest } from "./callers.js";
+import { buildSearchRequest, getProviderSetting } from "./callers.js";
 import { normalizeSearchResponse } from "./normalizers.js";
 import { handleChatSearch } from "./chatSearch.js";
 import { fetchPublic } from "../../../src/shared/utils/ssrfGuard.js";
@@ -86,6 +86,7 @@ async function tryDedicatedProvider({ provider, providerConfig, body, credential
   };
 
   let url, init;
+  const requiresPublicUrl = Boolean(getProviderSetting(params, "baseUrl"));
   try {
     ({ url, init } = buildSearchRequest({ id: provider.id, ...providerConfig }, params));
   } catch (err) {
@@ -101,7 +102,10 @@ async function tryDedicatedProvider({ provider, providerConfig, body, credential
   log?.info?.("SEARCH", `${provider.id} | "${params.query.slice(0, 80)}" | type=${params.searchType}`);
 
   try {
-    const resp = await fetchPublic(url, { ...init, headers: sanitizeHeaders(init.headers), signal: controller.signal });
+    // Request/account overrides remain SSRF-hardened. The provider config is
+    // administrator-controlled and may intentionally target an internal service.
+    const fetchEndpoint = requiresPublicUrl ? fetchPublic : fetch;
+    const resp = await fetchEndpoint(url, { ...init, headers: sanitizeHeaders(init.headers), signal: controller.signal });
     clearTimeout(timer);
     if (!resp.ok) {
       const errText = await resp.text().catch(() => "");

--- a/tests/unit/search-ssrf-guard.test.js
+++ b/tests/unit/search-ssrf-guard.test.js
@@ -1,5 +1,7 @@
+import http from "node:http";
 import { describe, it, expect } from "vitest";
 import { resolveBaseUrl } from "../../open-sse/handlers/search/callers.js";
+import { handleSearchCore } from "../../open-sse/handlers/search/index.js";
 
 const CONFIG = { id: "searxng", baseUrl: "https://searxng.example.com" };
 
@@ -45,5 +47,51 @@ describe("resolveBaseUrl SSRF guard", () => {
       const params = { providerOptions: { baseUrl: proto } };
       expect(() => resolveBaseUrl(CONFIG, params), `should reject ${proto}`).toThrow();
     }
+  });
+});
+
+describe("search endpoint trust boundary", () => {
+  it("allows an admin-configured SearXNG endpoint on the private network", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        results: [{ title: "Internal result", url: "https://example.com", content: "ok" }],
+      }));
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    try {
+      const address = server.address();
+      const result = await handleSearchCore({
+        body: { query: "test" },
+        provider: { id: "searxng" },
+        providerConfig: { authType: "none", baseUrl: `http://127.0.0.1:${address.port}` },
+        credentials: null,
+      });
+
+      expect(result.success, result.error).toBe(true);
+      expect(result.data.results[0]).toEqual(expect.objectContaining({
+        title: "Internal result",
+        url: "https://example.com",
+      }));
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  it("still rejects a client-supplied private baseUrl override", async () => {
+    const result = await handleSearchCore({
+      body: {
+        query: "test",
+        provider_options: { baseUrl: "http://127.0.0.1:18999" },
+      },
+      provider: { id: "searxng" },
+      providerConfig: { authType: "none", baseUrl: "https://searxng.example.com" },
+      credentials: null,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(400);
+    expect(result.error).toMatch(/Blocked URL/);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3756.

Restore support for administrator-configured search endpoints on private networks, such as a SearXNG container reached through `SEARXNG_URL=http://searxng:8080/search`, while keeping client and account base URL overrides behind the SSRF guard.

## Problem

Search request construction already distinguishes between two URL sources:

- `provider_options.baseUrl` or account-specific overrides, which are variable inputs and must be restricted to public HTTP(S) targets.
- `providerConfig.baseUrl`, which is configured by the administrator and may intentionally point to a Docker service, loopback listener, or another private-network endpoint.

`resolveBaseUrl()` applies that distinction correctly. However, every completed search request is later sent through `fetchPublic()`, regardless of where its base URL came from.

As a result, an admin-configured SearXNG endpoint resolves successfully inside Docker but is rejected before the request is sent:

```text
searxng error: Blocked URL: internal host
```

## Root cause

`tryDedicatedProvider()` unconditionally calls `fetchPublic(url, ...)`. This second validation step overrides the trust decision made by `resolveBaseUrl()` and treats provider configuration exactly like a request-controlled override.

## Change

Use the existing `getProviderSetting(params, "baseUrl")` boundary to select the fetch path:

| URL source | Fetch path | Result |
| --- | --- | --- |
| Request or account override | `fetchPublic()` | Public-only URL and redirect validation remains enforced |
| Administrator provider config | `fetch()` | Explicit private-network deployments remain reachable |

No provider-specific exception is added. The behavior follows the trust model already documented in `callers.js` for every dedicated search provider.

## Regression coverage

Added end-to-end handler tests that use a real ephemeral loopback HTTP server:

1. An admin-configured SearXNG endpoint on `127.0.0.1` is fetched and its result is normalized successfully.
2. A client-supplied `provider_options.baseUrl` targeting loopback is still rejected with HTTP 400 before any outbound request.

The first test fails on `upstream/master` with the blocked internal-host error and passes after this patch.

## Validation

```text
search and SSRF suites: 31 passed across 3 files
ESLint on changed files: passed
git diff --check: passed
```

Tested files:

- `tests/unit/search-ssrf-guard.test.js`
- `tests/unit/ssrf-guard-hardening.test.js`
- `tests/unit/xquik-search-provider.test.js`

## Scope

This change does not weaken validation for client or account base URL overrides, modify the SSRF guard implementation, change authentication, or add a SearXNG-only allowlist.