### PR TITLE
fix(anthropic-compatible): send Claude beta flags to nodes fronting Anthropic

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -154,7 +154,18 @@ export class DefaultExecutor extends BaseExecutor {
     for (const hook of desc.hooks || []) HEADER_HOOKS[hook]?.(headers, credentials);
     applyAuth(headers, desc, credentials);
 
-    if (this.provider === "claude" && model) {
+    // anthropic-compatible-* nodes serving a real Claude model sit in front of
+    // Anthropic itself (a rotating multi-account proxy, a corporate gateway),
+    // so the request needs the same beta flags the `claude` provider sends:
+    // without `context-management-2025-06-27` upstream rejects the
+    // `context_management` block Claude Code puts in every request with
+    // "context_management: Extra inputs are not permitted" (HTTP 400), and the
+    // combo silently falls through to the next model. The model id gates this:
+    // a node fronting Kimi or GLM answers on its own ids and never matches, so
+    // gateways that would choke on unknown beta flags are left untouched.
+    const isClaudeModel = typeof model === "string" && /^claude-/.test(model);
+    if (model && (this.provider === "claude"
+      || (this.provider?.startsWith?.("anthropic-compatible-") && isClaudeModel))) {
       headers["Anthropic-Beta"] = selectAnthropicBeta(model);
     }
 

--- a/tests/unit/claude-header-forwarding.test.js
+++ b/tests/unit/claude-header-forwarding.test.js
@@ -187,6 +187,46 @@ describe("DefaultExecutor.buildHeaders() — anthropic-compatible stripping", ()
       headers["Anthropic-Version"] || headers["anthropic-version"];
     expect(hasVersion).toBeDefined();
   });
+
+  // A node fronting Anthropic (rotating multi-account proxy, corporate gateway)
+  // needs the same beta flags the `claude` provider sends. Without
+  // context-management-2025-06-27 upstream answers HTTP 400
+  // "context_management: Extra inputs are not permitted" and the combo falls
+  // through to the next model without anyone noticing.
+  it("sends context-management beta for a Claude model on a custom host", () => {
+    const executor = new DefaultExecutor("anthropic-compatible-custom");
+    const headers = executor.buildHeaders(
+      {
+        apiKey: "key",
+        providerSpecificData: { baseUrl: "https://myproxy.example.com/v1" },
+      },
+      true,
+      undefined,
+      "claude-opus-5"
+    );
+
+    const betaFlags = (headers["Anthropic-Beta"] || headers["anthropic-beta"] || "")
+      .split(",").map(s => s.trim());
+    expect(betaFlags).toContain("context-management-2025-06-27");
+    // The first-party identity flag is still stripped for a non-Anthropic host.
+    expect(betaFlags).not.toContain("claude-code-20250219");
+  });
+
+  it("gates the beta flags on the model id, not the provider prefix", () => {
+    const executor = new DefaultExecutor("anthropic-compatible-custom");
+    const headers = executor.buildHeaders(
+      {
+        apiKey: "key",
+        providerSpecificData: { baseUrl: "https://myproxy.example.com/v1" },
+      },
+      true,
+      undefined,
+      "kimi-k3"
+    );
+
+    const betaVal = headers["Anthropic-Beta"] || headers["anthropic-beta"] || "";
+    expect(betaVal).not.toContain("context-management-2025-06-27");
+  });
 });
 
 // ─── proxyFetch anthropicFetch routing ────────────────────────────────────────


### PR DESCRIPTION
## The problem

An `anthropic-compatible-*` provider node that serves a real Claude model is not a third-party gateway speaking a dialect — it sits **in front of Anthropic itself**: a rotating multi-account proxy, a corporate egress, a self-hosted relay. Those requests need the same `Anthropic-Beta` set the built-in `claude` provider sends.

`selectAnthropicBeta()` was gated on `provider === "claude"`, so a custom node got no beta flags at all.

The visible failure is `context_management`. Claude Code puts a `context_management` block in every request; without `context-management-2025-06-27` upstream answers:

```
HTTP 400 {"type":"invalid_request_error",
          "message":"context_management: Extra inputs are not permitted"}
```

and the combo marks the model failed and falls through to the next one:

```
[COMBO] Trying model 1/12: mynode/claude-opus-5
[CHAT]  [anthropic-compatible-.../claude-opus-5] [400]: context_management: Extra inputs are not permitted
[COMBO] Model mynode/claude-opus-5 failed, trying next {"status":503}
...
[COMBO] Model glm/glm-5.3 succeeded
```

The request still gets an answer, from a different provider, so nothing looks broken — the node is simply **never used**. That is the worst shape a bug can take: a routing preference that silently does nothing.

## The fix

Apply `selectAnthropicBeta(model)` to `anthropic-compatible-*` nodes too, gated on the **model id** (`^claude-`) rather than the provider prefix.

A node fronting Kimi or GLM answers on its own model ids and never matches, so gateways that would choke on unknown beta flags are left exactly as they were.

The existing strip of the first-party `claude-code-20250219` flag for non-Anthropic hosts still runs afterwards and is unaffected — verified against a live Anthropic account: the request is accepted without it.

## Verification

Reproduced and fixed against a real deployment (9router → a multi-account Anthropic proxy → Claude Max accounts):

- **before**: every combo request 400s on the node and falls through to the next provider
- **after**: `[COMBO] Trying model 1/7: mynode/claude-haiku-4-5-20251001` → `succeeded`, and the proxy's own request counter increments

Isolated the exact flag by replaying the same payload with different `anthropic-beta` values:

| `anthropic-beta` | result |
|---|---|
| *(none)* | `context_management: Extra inputs are not permitted` |
| `claude-code-20250219` | same 400 |
| `context-1m-2025-08-07` | same 400 |
| `context-management-2025-06-27` | **accepted** |

## Tests

Two new cases in `tests/unit/claude-header-forwarding.test.js`, covering both directions:

- a Claude model on a custom host gets `context-management-2025-06-27` (and still loses `claude-code-20250219`)
- a non-Claude model on the same node gets nothing

`vitest run unit/claude-header-forwarding.test.js` → 19 passed. The one failing case (`proxyAwareFetch — routes api.anthropic.com to gotScraping`) fails identically on an unmodified checkout of `master`; it is unrelated to this change.
