### PR TITLE
fix(dashboard): dynamic mode label for local/remote detection

### DIFF
--- a/src/app/(dashboard)/dashboard/profile/page.js
+++ b/src/app/(dashboard)/dashboard/profile/page.js
@@ -81,6 +81,12 @@ export default function ProfilePage() {
   const [proxyLoading, setProxyLoading] = useState(false);
   const [proxyTestLoading, setProxyTestLoading] = useState(false);
 
+  const [isRemoteHost, setIsRemoteHost] = useState(false);
+  useEffect(() => {
+    if (typeof window !== "undefined")
+      setIsRemoteHost(!["localhost", "127.0.0.1", "::1"].includes(window.location.hostname));
+  }, []);
+
   useEffect(() => {
     fetch("/api/settings")
       .then((res) => res.json())
@@ -1639,7 +1645,7 @@ export default function ProfilePage() {
         {/* App Info */}
         <div className="text-center text-xs sm:text-sm text-text-muted py-4">
           <p>{APP_CONFIG.name} v{APP_CONFIG.version}</p>
-          <p className="mt-1">Local Mode - All data stored on your machine</p>
+          <p className="mt-1">{isRemoteHost ? "Remote Mode" : "Local Mode - All data stored on your machine"}</p>
         </div>
       </div>
 


### PR DESCRIPTION
Dynamically updates the application mode label in the profile footer to reflect whether the dashboard is accessed from a remote host or locally.

**Changes:**
- Introduces `isRemoteHost` state + `useEffect` hostname detection (localhost/127.0.0.1/::1 = local).
- Profile footer toggles between "Remote Mode" and "Local Mode - All data stored on your machine".

**Testing:**
- Local hosts → Local Mode.
- Non-local domain → Remote Mode.