### PR TITLE
feat(providers): align codebuddy-cn catalog/capabilities with server config

### DIFF
--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -178,33 +178,37 @@ export const PROVIDER_CAPABILITIES = {
   // CodeBuddy.cn — authoritative per-model metadata from the gateway's model
   // config (contextWindow=maxInputTokens, maxOutput=maxOutputTokens, vision=
   // supportsImages). Every model reasons via OpenAI-style reasoning_effort
-  // (see registry thinkingFormat). `onlyReasoning` models can't turn thinking
-  // off → thinkingCanDisable:false (clamped to minimal instead of disabled).
+  // (see registry thinkingFormat). For thinkingCanDisable use the server's
+  // reasoning.canDisableThinking flag — see the note in the codebuddy-cn block
+  // below; it is NOT the inverse of onlyReasoning.
   "codebuddy-cn": {
-    "glm-5.2":            { reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 1000000, maxOutput: 48000 },
-    "glm-5.1":            { reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 200000, maxOutput: 48000 },
+    "glm-5.2":            { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: true, contextWindow: 1000000, maxOutput: 48000 },
+    "glm-5.1":            { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 200000, maxOutput: 48000 },
     "glm-5.0":            { reasoning: true, thinkingFormat: "openai", contextWindow: 200000, maxOutput: 48000 },
-    "glm-5.0-turbo":      { reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 200000, maxOutput: 48000 },
-    "glm-5v-turbo":       { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 200000, maxOutput: 38000 },
+    // maxOutput 64000 per both the plugin-baked fallback and the live server
+    // table (the old 38000 had no source and truncated output).
+    "glm-5v-turbo":       { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 200000, maxOutput: 64000 },
     "glm-4.7":            { reasoning: true, thinkingFormat: "openai", contextWindow: 200000, maxOutput: 48000 },
-    "minimax-m3":         { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 512000, maxOutput: 48000 },
-    "minimax-m2.7":       { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 200000, maxOutput: 48000 },
+    "minimax-m3":         { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 512000, maxOutput: 128000 },
     "kimi-k2.7":          { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 256000, maxOutput: 32000 },
     "kimi-k2.6":          { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 256000, maxOutput: 32000 },
-    "kimi-k2.5":          { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 164000, maxOutput: 32000 },
-    "hy3-preview":        { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 192000, maxOutput: 64000 },
-    // hy3/hy3-x: 256K official (192K conservative, matches hy3-preview); hy4-preview: 1M official.
-    // glm-5.3: 1M (GLM-5.x gen); glm-5.3-flash window unverified (200K conservative).
+    // Per-model values mirror the server's product-config payload (the plugin
+    // fetches it from copilot.tencent.com; the `models[]` entries carry
+    // maxInputTokens/maxOutputTokens/supportsImages). contextWindow =
+    // maxInputTokens, maxOutput = maxOutputTokens. Where the server and the
+    // plugin-baked fallback disagree, the server table wins.
+    // ⚠️ thinkingCanDisable maps to the server's reasoning.canDisableThinking —
+    // it is NOT the inverse of onlyReasoning. onlyReasoning means "thinking is
+    // on by default"; canDisableThinking means "it CAN be turned off". glm-5.3
+    // and glm-5.3-flash are onlyReasoning:true BUT canDisableThinking:true, so
+    // their thinking is switchable; the hy* models are forced always-on.
     "hy3":                { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 192000, maxOutput: 64000 },
-    "hy3-x":              { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 192000, maxOutput: 64000 },
     "hy4-preview":        { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 1000000, maxOutput: 64000 },
-    "hy4-preview-x":      { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 1000000, maxOutput: 64000 },
-    "glm-5.3":            { reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 1000000, maxOutput: 48000 },
-    "glm-5.3-flash":      { reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 200000, maxOutput: 48000 },
-    "kimi-k3-1":          { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 256000, maxOutput: 32000 },
-    "deepseek-v4-pro":    { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 1000000, maxOutput: 50000 },
-    "deepseek-v4-flash":  { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 1000000, maxOutput: 50000 },
-    "deepseek-v3-2-volc": { reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 96000, maxOutput: 32000 },
+    "glm-5.3":            { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: true, contextWindow: 1000000, maxOutput: 48000 },
+    "glm-5.3-flash":      { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: true, contextWindow: 1000000, maxOutput: 32000 },
+    "kimi-k3-1":          { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: false, contextWindow: 1000000, maxOutput: 32000 },
+    "deepseek-v4-pro":    { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: true, contextWindow: 1000000, maxOutput: 50000 },
+    "deepseek-v4-flash":  { vision: true, reasoning: true, thinkingFormat: "openai", thinkingCanDisable: true, contextWindow: 1000000, maxOutput: 50000 },
   },
   // Poolside Laguna — OpenAI-compatible, all reasoning-capable (32K max output).
   "poolside": {

--- a/open-sse/providers/registry/codebuddy-cn.js
+++ b/open-sse/providers/registry/codebuddy-cn.js
@@ -47,27 +47,26 @@ export default {
   models: [
     { id: "glm-5.2", name: "GLM-5.2" },
     { id: "glm-5.1", name: "GLM-5.1" },
-    { id: "glm-5.0-turbo", name: "GLM-5.0-Turbo" },
     { id: "glm-5v-turbo", name: "GLM-5v-Turbo" },
     { id: "minimax-m3", name: "MiniMax-M3" },
-    { id: "minimax-m2.7", name: "MiniMax-M2.7" },
     { id: "kimi-k2.7", name: "Kimi-K2.7-Code" },
     { id: "kimi-k2.6", name: "Kimi-K2.6" },
-    { id: "kimi-k2.5", name: "Kimi-K2.5" },
-    // "-x" suffix = paid tier of the same model (free id rides the promo quota:
-    // hy3 free until 2026-08-31, hy4-preview until 2026-09-10). Server model table
-    // seen in client logs 2026-08-30; glm-5.0 / glm-4.7 removed (API 11102 dead).
-    { id: "hy3-preview", name: "Hy3 Preview" },
+    // Catalog mirrors the server's product-config payload (the plugin fetches
+    // it from copilot.tencent.com). Models the server no longer publishes are
+    // removed even when the chat endpoint still answers them — the published
+    // list is the contract. Drop log: glm-5.0 / glm-4.7 and hy4-preview-x
+    // (endpoint returns 11102 "model service info not found"), plus
+    // glm-5.0-turbo / minimax-m2.7 / kimi-k2.5 / hy3-preview /
+    // deepseek-v3-2-volc (absent from the server list, though still answering
+    // 200) and hy3-x (paid tier, not used here).
+    // "-x" suffix = paid tier of the same model (free id rides the promo quota).
     { id: "hy3", name: "Hy3" },
-    { id: "hy3-x", name: "Hy3 (Paid)" },
     { id: "hy4-preview", name: "Hy4-Preview" },
-    { id: "hy4-preview-x", name: "Hy4-Preview (Paid)" },
     { id: "glm-5.3", name: "GLM-5.3" },
     { id: "glm-5.3-flash", name: "GLM-5.3-Flash" },
     { id: "kimi-k3-1", name: "Kimi-K3" },
     { id: "deepseek-v4-pro", name: "DeepSeek-V4-Pro" },
     { id: "deepseek-v4-flash", name: "DeepSeek-V4-Flash" },
-    { id: "deepseek-v3-2-volc", name: "DeepSeek-V3.2" },
   ],
   oauth: {
     baseUrl: "https://copilot.tencent.com",

--- a/open-sse/providers/registry/glm-cn.js
+++ b/open-sse/providers/registry/glm-cn.js
@@ -25,6 +25,7 @@ export default {
     { id: "glm-5.3-flash", name: "GLM 5.3 Flash (Vision)" },
     { id: "glm-5.2", name: "GLM 5.2" },
     { id: "glm-5.1", name: "GLM 5.1" },
+    { id: "glm-5-turbo", name: "GLM 5 Turbo" },
     { id: "glm-5", name: "GLM 5" },
     { id: "glm-4.7", name: "GLM-4.7" },
     { id: "glm-4.6v", name: "GLM 4.6V (Vision)" },

--- a/open-sse/providers/registry/glm.js
+++ b/open-sse/providers/registry/glm.js
@@ -49,6 +49,7 @@ export default {
     { id: "glm-5.3-flash", name: "GLM 5.3 Flash (Vision)" },
     { id: "glm-5.2", name: "GLM 5.2" },
     { id: "glm-5.1", name: "GLM 5.1" },
+    { id: "glm-5-turbo", name: "GLM 5 Turbo" },
     { id: "glm-5", name: "GLM 5" },
     { id: "glm-4.7", name: "GLM 4.7" },
     { id: "glm-4.6v", name: "GLM 4.6V (Vision)" },

--- a/open-sse/providers/thinkingLevels.js
+++ b/open-sse/providers/thinkingLevels.js
@@ -39,10 +39,15 @@ const PATTERN_THINKING = [
   { provider: "codex", pattern: "*gpt-5.6-terra*", levels: [...CODEX_GPT_5_6_LEVELS, "ultra"] },
   { provider: "codex", pattern: "*gpt-5.6-luna*", levels: CODEX_GPT_5_6_LEVELS },
   { pattern: "*codex*", levels: ["low", "medium", "high", "xhigh"] }, // codex cannot disable thinking
-  // codebuddy-cn per-model effort sets — read off the client picker (server-
-  // delivered supportedEfforts), 2026-08-30. Gateway uses thinkingFormat "openai"
-  // but rejects levels outside each model's set.
+  // codebuddy-cn per-model effort sets — the server's product-config payload
+  // publishes `reasoning.supportedEfforts` per model. NOTE: the chat endpoint
+  // accepts any level you send (probed none/minimal/low/medium/high/xhigh/max
+  // → all 200), but values outside a model's supportedEfforts are silently
+  // clamped, so the declared set stays authoritative for the picker. Models
+  // that publish no supportedEfforts (glm-5.1 / glm-5v-turbo / kimi-k2.x /
+  // kimi-k3-1 / minimax-m3) fall through to the openai format default.
   { provider: "codebuddy-cn", pattern: "glm-5.3*",     levels: ["low", "high", "max"] },
+  { provider: "codebuddy-cn", pattern: "glm-5.2",      levels: ["high", "xhigh"] },
   { provider: "codebuddy-cn", pattern: "deepseek-v4*", levels: ["low", "high", "xhigh"] },
   { provider: "codebuddy-cn", pattern: "hy3*",         levels: ["low", "high"] },
   { provider: "codebuddy-cn", pattern: "hy4*",         levels: ["high"] },


### PR DESCRIPTION
Sync codebuddy-cn against the product-config payload the plugin fetches from `copilot.tencent.com`, and add the missing `glm-5-turbo` id to the GLM registries.

## CodeBuddy CN registry

Removed models (13 remaining, matching the server list 1:1):

| Model | Reason |
|---|---|
| `hy4-preview-x` | Endpoint returns `11102` — "model [hy4-preview-x] service info not found" (paid tier delisted) |
| `glm-5.0-turbo`, `minimax-m2.7`, `kimi-k2.5`, `hy3-preview`, `deepseek-v3-2-volc` | Absent from the server product-config list |
| `hy3-x` | Paid tier, unused here |

> Note: the five "absent from list" models still return **200** when called
> directly — the gateway does not reject them. They are removed because the
> published catalog is the contract for the model picker; keeping them offers
> ids the vendor no longer advertises.

`glm-5.0` / `glm-4.7` capability entries are **kept** even though they are not in the catalog: they intercept the `PATTERN_CAPABILITIES` fallback. Deleting them would flip `thinkingFormat` from `openai` to `zai` and change `maxOutput` to 128000 — verified by resolving capabilities with and without the entries.

## capabilities.js

Values now come from the server payload (`maxInputTokens` / `maxOutputTokens` / `supportsImages`), with the server table winning over the plugin-baked fallback where the two disagree.

| Model | Field | Before | After |
|---|---|---|---|
| glm-5v-turbo | maxOutput | 38000 | **64000** |
| glm-5.3-flash | maxOutput | 48000 | **32000** |
| minimax-m3 | maxOutput | 48000 | **128000** |
| glm-5.3-flash | contextWindow | 200000 | **1000000** |
| kimi-k3-1 | contextWindow | 256000 | **1000000** |
| glm-5.1 | vision | (absent → false) | **true** |

**`thinkingCanDisable` semantics fix** — it must map to the server's `reasoning.canDisableThinking`, which is *not* the inverse of `onlyReasoning`:

- `onlyReasoning` = thinking is **on by default**
- `canDisableThinking` = it **can** be turned off

`glm-5.3` and `glm-5.3-flash` are `onlyReasoning:true` **but** `canDisableThinking:true`, so their thinking is switchable. The `hy*` models carry `canDisableThinking:false` and stay forced-on. The previous code conflated the two and marked glm-5.3 / glm-5.3-flash as non-switchable.

## thinkingLevels.js

- Added the missing `glm-5.2` set (`high`, `xhigh`)
- Documented that the chat endpoint **accepts any** `reasoning_effort` value (probed `none/minimal/low/medium/high/xhigh/max` → all HTTP 200), but values outside a model's `supportedEfforts` are silently clamped. The declared set therefore stays authoritative for the picker.

## glm.js / glm-cn.js

- Added `glm-5-turbo` — present in the GLM `/v4/models` listing and confirmed answering 200 with a model echo.

## Test plan

- [x] `npx vitest run tests/__baseline__/ tests/unit/capabilities.test.js` → 5 passed
- [x] Resolved every codebuddy-cn model through `getCapabilitiesForModel` / `getThinkingLevels` and diffed field-by-field against the server payload → 0 conflicts
- [x] Hot-patched a running production instance and verified `/api/health` plus live chat calls through the gateway
- [x] `hy3` (kept) still resolves to ctx 192000 / `openai` format / `low,high`; `hy3-x` (removed) now falls through to the pattern fallback as expected

Notes: `tests/unit/providers-status-filter.test.js` fails both with and without this change (vitest is missing the `@/app/...` alias) — pre-existing, unrelated. Local Dockerfile mirror edits are deliberately excluded from this PR.
