### PR TITLE
fix(antigravity): prevent Google anti-abuse rate limits on multi-account refresh

### DIFF
--- a/open-sse/services/projectId.js
+++ b/open-sse/services/projectId.js
@@ -203,7 +203,8 @@ async function onboardUser(accessToken, tierID, externalSignal, endpoints, provi
 
     const reqBody = { tierId: tierID, metadata: LOAD_CODE_ASSIST_METADATA };
     const headers = provider === "antigravity" ? ANTIGRAVITY_LOAD_CODE_ASSIST_HEADERS : LOAD_CODE_ASSIST_HEADERS;
-    const MAX_ATTEMPTS = 5;
+    const MAX_ATTEMPTS = Number(process.env.ONBOARD_MAX_ATTEMPTS) || 2;
+    const BASE_RETRY_DELAY_MS = Number(process.env.ONBOARD_RETRY_DELAY_MS) || 12_000;
 
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
         // Bail out immediately if the connection was removed
@@ -241,9 +242,10 @@ async function onboardUser(accessToken, tierID, externalSignal, endpoints, provi
                 throw new Error("onboardUser done but no project_id in response");
             }
 
-            // Server not done yet – wait and retry
+            // Server not done yet – wait and retry with jitter
+            const jitter = Math.floor(Math.random() * 5000);
             console.log(`[ProjectId] Onboard attempt ${attempt}/${MAX_ATTEMPTS}: not done yet, waiting...`);
-            await new Promise(resolve => setTimeout(resolve, 2000));
+            await new Promise(resolve => setTimeout(resolve, BASE_RETRY_DELAY_MS + jitter));
 
         } catch (error) {
             clearTimeout(timeoutId);
@@ -256,9 +258,10 @@ async function onboardUser(accessToken, tierID, externalSignal, endpoints, provi
                 console.warn(`[ProjectId] onboardUser failed after ${MAX_ATTEMPTS} attempts: ${error.message}`);
                 return null;
             }
-            // Continue to next attempt instead of throwing (which would skip remaining retries)
+            // Wait with jitter before retrying
+            const jitter = Math.floor(Math.random() * 5000);
             console.warn(`[ProjectId] onboardUser attempt ${attempt} failed: ${error.message}, retrying...`);
-            await new Promise(resolve => setTimeout(resolve, 2000));
+            await new Promise(resolve => setTimeout(resolve, BASE_RETRY_DELAY_MS + jitter));
         } finally {
             clearTimeout(timeoutId);
             externalSignal?.removeEventListener("abort", forwardAbort);

--- a/src/sse/services/backgroundTokenRefresh.js
+++ b/src/sse/services/backgroundTokenRefresh.js
@@ -111,23 +111,32 @@ export async function runBackgroundTokenRefreshTick(deps = {}) {
       ids: due.map((c) => c.id).filter(Boolean),
     });
 
-    await Promise.allSettled(
-      due.map(async (conn) => {
-        try {
-          await refresh(conn);
-          log.info("BG_TOKEN_REFRESH", "Connection refresh finished", {
-            id: conn.id,
-            provider: conn.provider,
-          });
-        } catch (err) {
-          log.warn("BG_TOKEN_REFRESH", "Connection refresh failed (swallowed)", {
-            id: conn?.id,
-            provider: conn?.provider,
-            error: err?.message ?? String(err),
-          });
-        }
-      })
-    );
+    const isSensitiveProvider = (p) => p === "antigravity" || p === "gemini-cli";
+    const baseSensitiveDelay = Number(process.env.BG_REFRESH_GOOGLE_DELAY_MS) || 12_000;
+    const baseNormalDelay = Number(process.env.BG_REFRESH_DELAY_MS) || 1_500;
+
+    for (const conn of due) {
+      try {
+        await refresh(conn);
+        log.info("BG_TOKEN_REFRESH", "Connection refresh finished", {
+          id: conn.id,
+          email: conn.email || conn.name || conn.id,
+          provider: conn.provider,
+        });
+      } catch (err) {
+        log.warn("BG_TOKEN_REFRESH", "Connection refresh failed (swallowed)", {
+          id: conn?.id,
+          email: conn?.email || conn?.name || conn?.id,
+          provider: conn?.provider,
+          error: err?.message ?? String(err),
+        });
+      }
+
+      // Sequential delay between accounts to prevent bursting upstream providers (especially Google Cloud)
+      const baseDelay = isSensitiveProvider(conn.provider) ? baseSensitiveDelay : baseNormalDelay;
+      const jitter = isSensitiveProvider(conn.provider) ? Math.floor(Math.random() * 4000) : 200;
+      await new Promise((res) => setTimeout(res, baseDelay + jitter));
+    }
   } catch (err) {
     log.warn("BG_TOKEN_REFRESH", "Tick failed (swallowed)", {
       error: err?.message ?? String(err),

--- a/src/sse/services/tokenRefresh.js
+++ b/src/sse/services/tokenRefresh.js
@@ -124,25 +124,30 @@ function needsProjectId(provider) {
 function _refreshProjectId(provider, connectionId, accessToken) {
   if (!needsProjectId(provider) || !connectionId || !accessToken) return;
 
-  // Evict the stale cached entry so getProjectIdForConnection does a real fetch
+  // Invalidate the stale cached entry so getProjectIdForConnection does a real fetch
   invalidateProjectId(connectionId);
 
-  getProjectIdForConnection(connectionId, accessToken)
-    .then((projectId) => {
-      if (!projectId) return;
-      updateProviderCredentials(connectionId, { projectId }).catch((err) => {
-        log.debug("TOKEN_REFRESH", "Failed to persist refreshed projectId", {
+  // Lazy resolution: Do not eagerly trigger onboardUser during background token refresh.
+  // Eagerly fetching projectId across multiple accounts simultaneously triggers Google Cloud anti-abuse / rate limits.
+  // Runtime handlers (e.g. chat handler) will lazily call getProjectIdForConnection() on demand.
+  if (process.env.EAGER_PROJECT_ID_REFRESH === "true") {
+    getProjectIdForConnection(connectionId, accessToken, provider)
+      .then((projectId) => {
+        if (!projectId) return;
+        updateProviderCredentials(connectionId, { projectId }).catch((err) => {
+          log.debug("TOKEN_REFRESH", "Failed to persist refreshed projectId", {
+            connectionId,
+            error: err?.message ?? err,
+          });
+        });
+      })
+      .catch((err) => {
+        log.debug("TOKEN_REFRESH", "Failed to fetch projectId after token refresh", {
           connectionId,
           error: err?.message ?? err,
         });
       });
-    })
-    .catch((err) => {
-      log.debug("TOKEN_REFRESH", "Failed to fetch projectId after token refresh", {
-        connectionId,
-        error: err?.message ?? err,
-      });
-    });
+  }
 }
 
 // ─── Local-specific: persist credentials to localDb ──────────────────────────


### PR DESCRIPTION
### Problem & Context
When running 9router with multiple Google accounts (Antigravity / Gemini-CLI), background token refreshes trigger a massive burst of requests to Google Cloud Code internal APIs from the same IP address. This causes Google's automated anti-abuse systems to shadow-restrict project allocation and can lead to account suspensions.

Users experience errors like this repeatedly:
```text
[ProjectId] Onboarding user with tier: standard-tier
[ProjectId] onboardUser attempt 1 failed: onboardUser done but no project_id in response, retrying...
...
[ProjectId] onboardUser failed after 5 attempts: onboardUser done but no project_id in response
[ProjectId] could not fetch projectId for connection 709681e5
```
Related issues: #1059, #2461.

### Root Cause
1. **Parallel Burst:** `backgroundTokenRefresh.js` used `Promise.allSettled()` to refresh all due accounts concurrently without pacing or throttling.
2. **Eager Project ID Fetch:** Every background token refresh immediately called `_refreshProjectId()`, bombarding Google's `onboardUser` endpoint across all accounts simultaneously.
3. **Aggressive Retry Loop:** `onboardUser` in `projectId.js` retried 5 times per account with only a 2-second sleep (`50 accounts × 5 retries = 250 requests` in seconds).

### Key Changes
- **Sequential Queue in Background Refresh:** Replaced `Promise.allSettled` with a sequential loop in `backgroundTokenRefresh.js`. Added configurable throttle delay with random jitter (`BG_REFRESH_GOOGLE_DELAY_MS`, default 12s + jitter for Google; `BG_REFRESH_DELAY_MS`, default 1.5s for others).
- **Lazy Project ID Resolution:** Background token refresh now only refreshes credentials and invalidates cache. Project IDs are lazily resolved on demand when incoming requests actually require them (runtime handler already handles this). Backwards compatibility preserved via `EAGER_PROJECT_ID_REFRESH=true`.
- **Tamed Retry & Backoff Jitter:** Lowered `MAX_ATTEMPTS` from 5 to 2 (configurable via `ONBOARD_MAX_ATTEMPTS`) and increased retry backoff delay with randomized jitter (`ONBOARD_RETRY_DELAY_MS`, default 12s + jitter).
- **Log Visibility:** Included account `email` / identifier in `Connection refresh finished` logs for easier monitoring.

### Verification
- Tested locally with 40+ active Google accounts.
- Background refresh now progresses steadily one account at a time without triggering burst detection.
- Chat completions route normally through accounts without onboarding failures.