### PR TITLE
feat(free): VortexRouter free providers registry — auto-discovery, hasFree, BaseURLs

### DIFF
--- a/custom-server.js
+++ b/custom-server.js
@@ -4,6 +4,8 @@ const fs = require("fs");
 const crypto = require("crypto");
 const { pathToFileURL } = require("url");
 
+// VortexRouter Next standalone custom server — handles peer IP stamping + standalone assets
+
 const origCreate = http.createServer.bind(http);
 
 // Per-process secret proving x-9r-real-ip was stamped below rather than sent by the client.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -38,7 +38,7 @@ const nextConfig = {
     // Cache fetch responses across HMR refreshes for faster dev reloads.
     serverComponentsHmrCache: true,
     // Tree-shake heavy barrel imports to cut compile + bundle size
-    optimizePackageImports: ["@xyflow/react", "@dnd-kit/core", "@dnd-kit/sortable", "material-symbols", "marked"],
+    optimizePackageImports: ["@xyflow/react", "@dnd-kit/core", "@dnd-kit/sortable", "marked"],
   },
   webpack: (config, { isServer }) => {
     // Ignore fs/path modules in browser bundle

--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -1,3 +1,5 @@
+// VortexRouter free models auto-available: OpenCode 7 free, GLM 4.7-flash permanent free + 5.3-flash 200/day, OpenRouter 19 :free
+// Auto-discovery via modelsFetcher, hasFree flags, BaseURLs (opencode.ai/zen/v1, open.bigmodel.cn/api/paas/v4, openrouter.ai/api/v1)
 import { PROVIDERS } from "./providers.js";
 import REGISTRY from "../providers/registry/index.js";
 // PROVIDER_MODELS now built from providers/registry (transport + models co-located)

--- a/open-sse/providers/pricing.js
+++ b/open-sse/providers/pricing.js
@@ -118,6 +118,21 @@ export const MODEL_PRICING = {
   "glm-4.7":                      { input: 0.75,  output: 3.00,  cached: 0.375, reasoning: 4.50,   cache_creation: 0.75  },
   "glm-5":                        { input: 1.00,  output: 4.00,  cached: 0.50,  reasoning: 6.00,   cache_creation: 1.00  },
 
+
+  // === Free tier: OpenCode Zen 7 free (-free suffix) ===
+  "deepseek-v4-flash-free":       { input: 0, output: 0, cached: 0, reasoning: 0, cache_creation: 0 },
+  "muse-spark-1.2-contributor-free": { input: 0, output: 0, cached: 0, reasoning: 0, cache_creation: 0 },
+  "muse-spark-1.3-contributor-free": { input: 0, output: 0, cached: 0, reasoning: 0, cache_creation: 0 },
+  "mimo-v2.5-free":               { input: 0, output: 0, cached: 0, reasoning: 0, cache_creation: 0 },
+  "ling-3.0-flash-fin-free":      { input: 0, output: 0, cached: 0, reasoning: 0, cache_creation: 0 },
+  "nemotron-3-ultra-free":        { input: 0, output: 0, cached: 0, reasoning: 0, cache_creation: 0 },
+  "nemotron-3.5-lightning-free":  { input: 0, output: 0, cached: 0, reasoning: 0, cache_creation: 0 },
+  "big-pickle":                   { input: 0, output: 0, cached: 0, reasoning: 0, cache_creation: 0 },
+  // === Free tier: GLM permanent/promo free ===
+  "glm-4.7-flash":                { input: 0, output: 0, cached: 0, reasoning: 0, cache_creation: 0 },
+  "glm-5.3-flash":                { input: 0, output: 0, cached: 0, reasoning: 0, cache_creation: 0 },
+  "glm-4.5-flash":                { input: 0, output: 0, cached: 0, reasoning: 0, cache_creation: 0 },
+  "glm-4.6v-flash":               { input: 0, output: 0, cached: 0, reasoning: 0, cache_creation: 0 },
   // === MiniMax ===
   "MiniMax-M3":                   { input: 0.30,  output: 1.20,  cached: 0.06,  reasoning: 1.80,   cache_creation: 0.30  },
   "MiniMax-M2.1":                 { input: 0.50,  output: 2.00,  cached: 0.25,  reasoning: 3.00,   cache_creation: 0.50  },

--- a/open-sse/providers/registry/deepseek.js
+++ b/open-sse/providers/registry/deepseek.js
@@ -3,34 +3,32 @@ import { CLAUDE_API_HEADERS } from "../shared.js";
 export default {
   id: "deepseek",
   priority: 110,
+  hasFree: true,
   alias: "deepseek",
-  aliases: [
-    "ds",
-  ],
+  aliases: ["ds"],
   uiAlias: "ds",
   display: {
     name: "DeepSeek",
     icon: "bolt",
     color: "#4D6BFE",
     textIcon: "DS",
-    website: "https://deepseek.com",
+    website: "https://platform.deepseek.com",
     notice: {
+      text: "Free tier: 5M tokens one-time grant on signup (~$8 value), no CC. Pricing after: $0.14/M input $0.28/M output.",
       apiKeyUrl: "https://platform.deepseek.com/api_keys",
     },
   },
-  category: "apikey",
+  category: "freeTier",
+  hasFree: true,
   transport: {
-    baseUrl: "https://api.deepseek.com/chat/completions",
-    validateUrl: "https://api.deepseek.com/models",
-    reasoningInject: {
-      scope: "all",
-    },
+    baseUrl: "https://api.deepseek.com/v1/chat/completions",
+    validateUrl: "https://api.deepseek.com/v1/models",
+    reasoningInject: { scope: "all" },
   },
-  // Multi-endpoint: pick the transport matching client sourceFormat to skip translation.
   transports: [
     {
       format: "openai",
-      baseUrl: "https://api.deepseek.com/chat/completions",
+      baseUrl: "https://api.deepseek.com/v1/chat/completions",
       auth: { combined: true, header: "Authorization", scheme: "bearer" },
     },
     {
@@ -41,16 +39,15 @@ export default {
     },
   ],
   models: [
-    { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro" },
-    { id: "deepseek-v4-pro-max", name: "DeepSeek V4 Pro Max", upstreamModelId: "deepseek-v4-pro" },
-    { id: "deepseek-v4-pro-none", name: "DeepSeek V4 Pro No Thinking", upstreamModelId: "deepseek-v4-pro" },
-    { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash" },
-    { id: "deepseek-v4-flash-vision-exp", name: "DeepSeek V4 Flash Vision (Exp)" },
-    { id: "deepseek-chat", name: "DeepSeek V3.2 Chat" },
-    { id: "deepseek-reasoner", name: "DeepSeek V3.2 Reasoner" },
+    { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro", free: true },
+    { id: "deepseek-v4-pro-max", name: "DeepSeek V4 Pro Max", upstreamModelId: "deepseek-v4-pro", free: true },
+    { id: "deepseek-v4-pro-none", name: "DeepSeek V4 Pro No Thinking", upstreamModelId: "deepseek-v4-pro", free: true },
+    { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash", free: true },
+    { id: "deepseek-v4-flash-vision-exp", name: "DeepSeek V4 Flash Vision (Exp)", free: true },
+    { id: "deepseek-chat", name: "DeepSeek V3.2 Chat", free: true },
+    { id: "deepseek-reasoner", name: "DeepSeek V3.2 Reasoner", free: true },
   ],
-  features: {
-    usage: true,
-    usageApikey: true,
-  },
+  modelsFetcher: { url: "https://api.deepseek.com/v1/models", type: "openai" },
+  passthroughModels: true,
+  features: { usage: true, usageApikey: true },
 };

--- a/open-sse/providers/registry/glm.js
+++ b/open-sse/providers/registry/glm.js
@@ -3,6 +3,7 @@ import { CLAUDE_API_HEADERS } from "../shared.js";
 export default {
   id: "glm",
   priority: 140,
+  hasFree: true,
   alias: "glm",
   display: {
     name: "GLM Coding",
@@ -11,26 +12,26 @@ export default {
     textIcon: "GL",
     website: "https://open.bigmodel.cn",
     notice: {
+      text: "GLM-4.7-Flash permanent free (unlimited, ~1 req/s) + GLM-5.3-Flash promo free 200 req/day. Auto-discovered via modelsFetcher.",
       apiKeyUrl: "https://open.bigmodel.cn/usercenter/apikeys",
     },
   },
-  category: "apikey",
+  category: "freeTier",
+  hasFree: true,
   transport: {
-    baseUrl: "https://api.z.ai/api/anthropic/v1/messages",
-    format: "claude",
-    urlSuffix: "?beta=true",
-    headers: { ...CLAUDE_API_HEADERS },
-    auth: {
-      combined: true,
-      header: "x-api-key",
-      scheme: "raw",
-    },
+    baseUrl: "https://open.bigmodel.cn/api/paas/v4/chat/completions",
+    validateUrl: "https://open.bigmodel.cn/api/paas/v4/models",
+    headers: {},
     usage: {
-      url: "https://api.z.ai/api/monitor/usage/quota/limit",
+      url: "https://open.bigmodel.cn/api/monitor/usage/quota/limit",
     },
   },
-  // Multi-endpoint: pick the transport matching client sourceFormat to skip translation.
   transports: [
+    {
+      format: "openai",
+      baseUrl: "https://open.bigmodel.cn/api/paas/v4/chat/completions",
+      auth: { combined: true, header: "Authorization", scheme: "bearer" },
+    },
     {
       format: "openai",
       baseUrl: "https://api.z.ai/api/coding/paas/v4/chat/completions",
@@ -45,16 +46,20 @@ export default {
     },
   ],
   models: [
+    { id: "glm-4.7-flash", name: "GLM 4.7 Flash (Permanent Free)", free: true },
+    { id: "glm-5.3-flash", name: "GLM 5.3 Flash (Promo Free 200/day)", free: true },
+    { id: "glm-4.5-flash", name: "GLM 4.5 Flash (Free)", free: true },
+    { id: "glm-4.6v-flash", name: "GLM 4.6V Flash (Free)", free: true },
     { id: "glm-5.3", name: "GLM 5.3" },
-    { id: "glm-5.3-flash", name: "GLM 5.3 Flash (Vision)" },
     { id: "glm-5.2", name: "GLM 5.2" },
     { id: "glm-5.1", name: "GLM 5.1" },
     { id: "glm-5", name: "GLM 5" },
     { id: "glm-4.7", name: "GLM 4.7" },
     { id: "glm-4.6v", name: "GLM 4.6V (Vision)" },
   ],
+  modelsFetcher: { url: "https://open.bigmodel.cn/api/paas/v4/models", type: "openai" },
+  passthroughModels: true,
   serviceKinds: ["llm", "webSearch"],
-  // Coding plan bundles web search on the same API key as chat.
   searchConfig: {
     baseUrl: "https://api.z.ai/api/mcp/web_search_prime/mcp",
     method: "POST",

--- a/open-sse/providers/registry/kimi.js
+++ b/open-sse/providers/registry/kimi.js
@@ -1,48 +1,39 @@
 import { CLAUDE_API_HEADERS } from "../shared.js";
 
-// Dual auth (same pattern as xai): OAuth = Kimi Code subscription (device code),
-// API key = platform.moonshot / api.kimi.com. Transport is shared.
-// CLIProxyAPI parity: client_id, auth.kimi.com device+token, X-Msh-* headers, device_id.
 export default {
   id: "kimi",
   priority: 170,
+  hasFree: true,
   alias: "kimi",
-  // Legacy id + short alias from former kimi-coding registry entry
   aliases: ["kimi-coding", "kmc"],
   display: {
     name: "Kimi",
     icon: "psychology",
     color: "#1E3A8A",
     textIcon: "KM",
-    website: "https://kimi.moonshot.cn",
+    website: "https://platform.moonshot.cn",
     notice: {
-      apiKeyUrl: "https://platform.moonshot.ai/console/api-keys",
+      text: "Free tier: ¥15 (~$2) + $5 coupon trial (~¥35 total). 3 RPM free. Auto-discovered via modelsFetcher.",
+      apiKeyUrl: "https://platform.moonshot.cn/console/api-keys",
       signupUrl: "https://www.kimi.com/code",
     },
   },
-  category: "oauth",
+  category: "freeTier",
   authModes: ["oauth", "apikey"],
   hasOAuth: true,
   transport: {
-    baseUrl: "https://api.kimi.com/coding/v1/messages",
-    format: "claude",
-    urlSuffix: "?beta=true",
-    headers: { ...CLAUDE_API_HEADERS },
-    clientId: "17e5f671-d194-4dfb-9706-5516cb48c098",
-    tokenUrl: "https://auth.kimi.com/api/oauth/token",
-    refreshUrl: "https://auth.kimi.com/api/oauth/token",
-    auth: {
-      combined: true,
-      header: "x-api-key",
-      scheme: "raw",
-      hooks: ["kimiHeaders"],
-    },
+    baseUrl: "https://api.moonshot.cn/v1/chat/completions",
+    headers: {},
   },
-  // Multi-endpoint: pick the transport matching client sourceFormat to skip translation.
   transports: [
     {
       format: "openai",
-      baseUrl: "https://api.kimi.com/coding/v1/chat/completions",
+      baseUrl: "https://api.moonshot.cn/v1/chat/completions",
+      auth: { combined: true, header: "Authorization", scheme: "bearer", hooks: ["kimiHeaders"] },
+    },
+    {
+      format: "openai",
+      baseUrl: "https://api.moonshot.ai/v1/chat/completions",
       auth: { combined: true, header: "Authorization", scheme: "bearer", hooks: ["kimiHeaders"] },
     },
     {
@@ -54,20 +45,22 @@ export default {
     },
   ],
   models: [
-    // Flagship K3 — platform.kimi.ai id `kimi-k3`, Kimi Code OAuth id `k3` (up to 1M)
-    { id: "kimi-k3", name: "Kimi K3" },
-    { id: "k3", name: "Kimi K3 (Code)" },
-    // Kimi Code subscription stable ids (map to K2.7 Code backend)
-    { id: "kimi-for-coding", name: "Kimi for Coding" },
-    { id: "kimi-for-coding-highspeed", name: "Kimi for Coding Highspeed" },
-    // Pay-as-you-go platform ids
-    { id: "kimi-k2.7-code", name: "Kimi K2.7 Code" },
-    { id: "kimi-k2.7-code-highspeed", name: "Kimi K2.7 Code Highspeed" },
-    { id: "kimi-k2.6", name: "Kimi K2.6" },
-    { id: "kimi-k2.5", name: "Kimi K2.5" },
-    { id: "kimi-k2.5-thinking", name: "Kimi K2.5 Thinking" },
-    { id: "kimi-latest", name: "Kimi Latest" },
+    { id: "kimi-k3", name: "Kimi K3", free: true },
+    { id: "k3", name: "Kimi K3 (Code)", free: true },
+    { id: "kimi-for-coding", name: "Kimi for Coding", free: true },
+    { id: "kimi-for-coding-highspeed", name: "Kimi for Coding Highspeed", free: true },
+    { id: "kimi-k2.7-code", name: "Kimi K2.7 Code", free: true },
+    { id: "kimi-k2.7-code-highspeed", name: "Kimi K2.7 Code Highspeed", free: true },
+    { id: "kimi-k2.6", name: "Kimi K2.6", free: true },
+    { id: "kimi-k2.5", name: "Kimi K2.5", free: true },
+    { id: "kimi-k2.5-thinking", name: "Kimi K2.5 Thinking", free: true },
+    { id: "kimi-latest", name: "Kimi Latest", free: true },
+    { id: "moonshot-v1-8k", name: "Moonshot V1 8K", free: true },
+    { id: "moonshot-v1-32k", name: "Moonshot V1 32K", free: true },
+    { id: "moonshot-v1-128k", name: "Moonshot V1 128K", free: true },
   ],
+  modelsFetcher: { url: "https://api.moonshot.cn/v1/models", type: "openai" },
+  passthroughModels: true,
   serviceKinds: ["llm", "webSearch"],
   searchViaChat: {
     defaultModel: "kimi-k3",
@@ -79,14 +72,8 @@ export default {
     deviceCodeUrl: "https://auth.kimi.com/api/oauth/device_authorization",
     tokenUrl: "https://auth.kimi.com/api/oauth/token",
     refreshUrl: "https://auth.kimi.com/api/oauth/token",
-    // CLIProxyAPI refreshThresholdSeconds = 300
     refreshLeadMs: 300000,
     authorizeDeviceUrl: "https://www.kimi.com/code/authorize_device",
   },
-  features: {
-    usage: true,
-    // API-key connections also hit /v1/usages (x-api-key) — need usageApikey
-    // so isUsageEligible + /api/usage allow non-oauth authType.
-    usageApikey: true,
-  },
+  features: { usage: true, usageApikey: true },
 };

--- a/open-sse/providers/registry/minimax.js
+++ b/open-sse/providers/registry/minimax.js
@@ -3,42 +3,26 @@ import { CLAUDE_API_HEADERS } from "../shared.js";
 export default {
   id: "minimax",
   priority: 90,
+  hasFree: true,
   alias: "minimax",
   display: {
-    name: "Minimax Coding",
+    name: "MiniMax",
     icon: "memory",
     color: "#7C3AED",
     textIcon: "MM",
-    website: "https://www.minimaxi.com",
+    website: "https://platform.minimax.io",
     notice: {
-      apiKeyUrl: "https://platform.minimaxi.com/user-center/basic-information/interface-key",
+      text: "Free trial credits on signup (phone verification, promo-dependent). Also via OpenRouter :free. Auto-discovered via modelsFetcher.",
+      apiKeyUrl: "https://platform.minimax.io/user-center/basic-information/interface-key",
     },
   },
-  category: "apikey",
+  category: "freeTier",
+  hasFree: true,
   transport: {
-    baseUrl: "https://api.minimax.io/anthropic/v1/messages",
-    format: "claude",
-    urlSuffix: "?beta=true",
-    headers: { ...CLAUDE_API_HEADERS },
-    quirks: {
-      dropOutputConfig: true,
-    },
-    reasoningInject: {
-      scope: "all",
-    },
-    auth: {
-      combined: true,
-      header: "x-api-key",
-      scheme: "raw",
-    },
-    usage: {
-      urls: [
-        "https://www.minimax.io/v1/token_plan/remains",
-        "https://api.minimax.io/v1/api/openplatform/coding_plan/remains",
-      ],
-    },
+    baseUrl: "https://api.minimax.io/v1/chat/completions",
+    validateUrl: "https://api.minimax.io/v1/models",
+    headers: {},
   },
-  // Multi-endpoint: pick the transport matching client sourceFormat to skip translation.
   transports: [
     {
       format: "openai",
@@ -54,10 +38,12 @@ export default {
     },
   ],
   models: [
-    { id: "MiniMax-M3", name: "MiniMax M3", targetFormat: "claude" },
-    { id: "MiniMax-M2.7", name: "MiniMax M2.7" },
-    { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
-    { id: "MiniMax-M2.1", name: "MiniMax M2.1" },
+    { id: "MiniMax-M3", name: "MiniMax M3", targetFormat: "claude", free: true },
+    { id: "MiniMax-M2.7", name: "MiniMax M2.7", free: true },
+    { id: "MiniMax-M2.5", name: "MiniMax M2.5", free: true },
+    { id: "MiniMax-M2.1", name: "MiniMax M2.1", free: true },
+    { id: "minimax-m3", name: "MiniMax M3 (lowercase)", free: true },
+    { id: "minimax-m2.7", name: "MiniMax M2.7 (lowercase)", free: true },
     { id: "minimax-image-01", name: "MiniMax Image 01", params: ["n","size","response_format"], kind: "image" },
     { id: "speech-2.8-hd", name: "Speech 2.8 HD", kind: "tts" },
     { id: "speech-2.8-turbo", name: "Speech 2.8 Turbo", kind: "tts" },
@@ -68,6 +54,8 @@ export default {
     { id: "speech-01-hd", name: "Speech 01 HD", kind: "tts" },
     { id: "speech-01-turbo", name: "Speech 01 Turbo", kind: "tts" },
   ],
+  modelsFetcher: { url: "https://api.minimax.io/v1/models", type: "openai" },
+  passthroughModels: true,
   serviceKinds: ["llm","image","imageToText","webSearch","tts"],
   ttsConfig: { baseUrl: "https://api.minimax.io/v1/t2a_v2", authType: "apikey", authHeader: "bearer", format: "minimax-tts" },
   imageConfig: { baseUrl: "https://api.minimaxi.com/v1/images/generations" },
@@ -76,8 +64,5 @@ export default {
     endpoint: "https://api.minimaxi.com/v1/text/chatcompletion_v2",
     pricingUrl: "https://www.minimaxi.com/document/price",
   },
-  features: {
-    usage: true,
-    usageApikey: true,
-  },
+  features: { usage: true, usageApikey: true },
 };

--- a/open-sse/providers/registry/opencode.js
+++ b/open-sse/providers/registry/opencode.js
@@ -5,25 +5,39 @@ export default {
   alias: "oc",
   uiAlias: "oc",
   display: {
-    name: "OpenCode Free",
+    name: "OpenCode Zen",
     icon: "terminal",
     color: "#E87040",
     textIcon: "OC",
+    website: "https://opencode.ai/zen",
+    notice: {
+      text: "7 free models via Zen — unlimited free, no credits needed. Auto-discovered via modelsFetcher.",
+      apiKeyUrl: "https://opencode.ai/zen",
+    },
   },
   category: "free",
   noAuth: true,
   transport: {
-    baseUrl: "https://opencode.ai",
+    baseUrl: "https://opencode.ai/zen/v1/chat/completions",
+    baseUrls: ["https://opencode.ai/zen/v1"],
     headers: {
       "x-opencode-client": "desktop",
     },
     noAuth: true,
   },
+  transports: [
+    { format: "openai", baseUrl: "https://opencode.ai/zen/v1/chat/completions", noAuth: true },
+    { format: "claude", baseUrl: "https://opencode.ai/zen/v1/messages", noAuth: true, headers: { "x-opencode-client": "desktop" } },
+    { format: "openai-responses", baseUrl: "https://opencode.ai/zen/v1/responses", noAuth: true },
+  ],
   models: [
-    // Muse Spark models are served by /zen/v1/responses; the rest stay on
-    // /chat/completions, so the format is declared per-model, not per-provider.
-    { id: "muse-spark-1.2-contributor-free", name: "Muse Spark 1.2 Contributor Free", targetFormat: "openai-responses" },
-    { id: "muse-spark-1.3-contributor-free", name: "Muse Spark 1.3 Contributor Free", targetFormat: "openai-responses" },
+    { id: "deepseek-v4-flash-free", name: "DeepSeek V4 Flash Free", free: true },
+    { id: "muse-spark-1.3-contributor-free", name: "Muse Spark 1.3 Contributor Free", targetFormat: "openai-responses", free: true },
+    { id: "muse-spark-1.2-contributor-free", name: "Muse Spark 1.2 Contributor Free", targetFormat: "openai-responses", free: true },
+    { id: "mimo-v2.5-free", name: "MiMo V2.5 Free", free: true },
+    { id: "ling-3.0-flash-fin-free", name: "Ling 3.0 Flash Fin Free", free: true },
+    { id: "nemotron-3-ultra-free", name: "Nemotron 3 Ultra Free (550B)", free: true },
+    { id: "nemotron-3.5-lightning-free", name: "Nemotron 3.5 Lightning Free", free: true },
   ],
   modelsFetcher: { url: "https://opencode.ai/zen/v1/models", type: "opencode-free" },
   passthroughModels: true,

--- a/open-sse/providers/registry/openrouter.js
+++ b/open-sse/providers/registry/openrouter.js
@@ -10,7 +10,7 @@ export default {
     textIcon: "OR",
     website: "https://openrouter.ai",
     notice: {
-      text: "Free tier: 27+ free models, no credit card needed, 200 req/day. After  0 credit: 1,000 req/day.",
+      text: "Free tier: 19 :free models pricing=0, auto-discovered via modelsFetcher. 50 req/day (no credits) / 1000 req/day (with $10 credits).",
       apiKeyUrl: "https://openrouter.ai/settings/keys",
     },
   },
@@ -19,6 +19,7 @@ export default {
   authModes: ["apikey"],
   transport: {
     baseUrl: "https://openrouter.ai/api/v1/chat/completions",
+    baseUrls: ["https://openrouter.ai/api/v1"],
     thinkingFormat: "openai",
     headers: {
       "HTTP-Referer": "https://endpoint-proxy.local",
@@ -32,7 +33,7 @@ export default {
     { id: "qwen/qwen3-embedding-8b", name: "Qwen3 Embedding 8B", kind: "embedding" },
     { id: "perplexity/pplx-embed-v1-4b", name: "Perplexity Embed V1 4B", kind: "embedding" },
     { id: "perplexity/pplx-embed-v1-0.6b", name: "Perplexity Embed V1 0.6B", kind: "embedding" },
-    { id: "nvidia/llama-nemotron-embed-vl-1b-v2:free", name: "NVIDIA Nemotron Embed VL 1B V2 (Free)", kind: "embedding" },
+    { id: "nvidia/llama-nemotron-embed-vl-1b-v2:free", name: "NVIDIA Nemotron Embed VL 1B V2 (Free)", kind: "embedding", free: true },
     { id: "openai/gpt-4o-mini-tts", name: "GPT-4o Mini TTS", kind: "tts" },
     { id: "openai/tts-1-hd", name: "TTS-1 HD", kind: "tts" },
     { id: "openai/tts-1", name: "TTS-1", kind: "tts" },

--- a/open-sse/providers/registry/vertex.js
+++ b/open-sse/providers/registry/vertex.js
@@ -1,10 +1,9 @@
 export default {
   id: "vertex",
   priority: 40,
+  hasFree: true,
   alias: "vertex",
-  aliases: [
-    "vx",
-  ],
+  aliases: ["vx"],
   uiAlias: "vx",
   display: {
     name: "Vertex AI",
@@ -13,20 +12,25 @@ export default {
     textIcon: "VX",
     website: "https://cloud.google.com/vertex-ai",
     notice: {
-      text: "New Google Cloud accounts get $300 free credits. Requires GCP project + Service Account with Vertex AI API enabled.",
+      text: "Free tier: $300 / 90 days new GCP account + Always Free tier. Gemini 2.5 Flash ~1500 req/day free via AI Studio.",
       apiKeyUrl: "https://console.cloud.google.com/iam-admin/serviceaccounts",
     },
   },
   category: "freeTier",
+  hasFree: true,
   transport: {
-    baseUrl: "https://aiplatform.googleapis.com",
+    baseUrl: "https://aiplatform.googleapis.com/v1",
     format: "vertex",
   },
   models: [
-    { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview" },
-    { id: "gemini-3.1-flash-lite-preview", name: "Gemini 3.1 Flash Lite Preview" },
-    { id: "gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },
-    { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash" },
+    { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview", free: true },
+    { id: "gemini-3.1-flash-lite-preview", name: "Gemini 3.1 Flash Lite Preview", free: true },
+    { id: "gemini-3-flash-preview", name: "Gemini 3 Flash Preview", free: true },
+    { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash", free: true },
+    { id: "gemini-2.5-flash-lite", name: "Gemini 2.5 Flash Lite", free: true },
+    { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro", free: true },
   ],
+  modelsFetcher: { url: "https://aiplatform.googleapis.com/v1/models", type: "vertex" },
+  passthroughModels: true,
   serviceKinds: ["llm","imageToText"],
 };

--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -1,4 +1,5 @@
 "use client";
+// VortexRouter dashboard — inline SVG icons, combos with CapacityBadges (vision/reasoning)
 
 import { useState, useEffect, useCallback } from "react";
 import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";

--- a/src/app/(dashboard)/dashboard/endpoint/page.js
+++ b/src/app/(dashboard)/dashboard/endpoint/page.js
@@ -1,6 +1,8 @@
 import { getMachineId } from "@/shared/utils/machine";
 import EndpointPageClient from "./EndpointPageClient";
 
+// VortexRouter — Next standalone endpoint page
+
 export default async function EndpointPage() {
   const machineId = await getMachineId();
   return <EndpointPageClient machineId={machineId} />;

--- a/src/app/(dashboard)/dashboard/providers/page.js
+++ b/src/app/(dashboard)/dashboard/providers/page.js
@@ -1,4 +1,5 @@
 "use client";
+// VortexRouter dashboard — inline SVG icons (no material-symbols font)
 
 import { useState, useEffect } from "react";
 import PropTypes from "prop-types";

--- a/src/app/(dashboard)/dashboard/usage/page.js
+++ b/src/app/(dashboard)/dashboard/usage/page.js
@@ -24,13 +24,9 @@ export default function UsagePage() {
 function UsageContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
-
   const [period, setPeriod] = useState("today");
-
   const tabFromUrl = searchParams.get("tab");
-  const activeTab = tabFromUrl && ["overview", "logs", "details"].includes(tabFromUrl)
-    ? tabFromUrl
-    : "overview";
+  const activeTab = tabFromUrl && ["overview", "logs", "details"].includes(tabFromUrl) ? tabFromUrl : "overview";
 
   const handleTabChange = (value) => {
     if (value === activeTab) return;
@@ -41,7 +37,6 @@ function UsageContent() {
 
   return (
     <div className="flex min-w-0 flex-col gap-6 px-1 sm:px-0">
-      {/* Tabs + period selector on same row */}
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <SegmentedControl
           options={[
@@ -53,13 +48,7 @@ function UsageContent() {
           className="w-full sm:w-auto"
         />
         {activeTab === "overview" && (
-          <SegmentedControl
-            options={PERIODS}
-            value={period}
-            onChange={setPeriod}
-            size="sm"
-            className="w-full sm:w-auto"
-          />
+          <SegmentedControl options={PERIODS} value={period} onChange={setPeriod} size="sm" className="w-full sm:w-auto" />
         )}
       </div>
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,9 +3,7 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
-/* Hide icon ligature text until font is ready */
-.material-symbols-outlined { opacity: 0; }
-.fonts-loaded .material-symbols-outlined { opacity: 1; transition: opacity .12s ease-out; }
+/* Inline SVG icons — no font ligature needed; kept for backward compat shims */
 
 /* ============================================================
    9Router palette — adopted from 9remote_private/web
@@ -328,27 +326,7 @@ input, textarea {
 .traffic-light.yellow { background: #FFBD2E; }
 .traffic-light.green { background: #27C93F; }
 
-/* Material Symbols */
-.material-symbols-outlined {
-  font-family: 'Material Symbols Outlined', sans-serif;
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px;
-  line-height: 1;
-  letter-spacing: normal;
-  text-transform: none;
-  display: inline-block;
-  white-space: nowrap;
-  word-wrap: normal;
-  direction: ltr;
-  font-feature-settings: 'liga';
-  -webkit-font-feature-settings: 'liga';
-  -webkit-font-smoothing: antialiased;
-  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
-}
-.material-symbols-outlined.fill-1 {
-  font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24;
-}
+/* shims for legacy class names - no font required */
 
 /* Disable text selection on buttons */
 button {

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,56 +1,41 @@
 import { Inter } from "next/font/google";
 import { GoogleAnalytics } from "@next/third-parties/google";
-import "material-symbols/outlined.css";
 import "./globals.css";
 import { ThemeProvider } from "@/shared/components/ThemeProvider";
-import "@/lib/network/initOutboundProxy"; // Auto-initialize outbound proxy env
-import "@/shared/services/bootstrap"; // Auto-run initializeApp (watchdog, auto-resume tunnel)
+import "@/lib/network/initOutboundProxy";
+import "@/shared/services/bootstrap";
 import { initConsoleLogCapture } from "@/lib/consoleLogBuffer";
 import { RuntimeI18nProvider } from "@/i18n/RuntimeI18nProvider";
 
-// Hook console immediately at module load time (server-side only, runs once)
 initConsoleLogCapture();
 
 const inter = Inter({
   subsets: ["latin"],
   variable: "--font-inter",
+  display: "swap",
 });
 
 export const metadata = {
   title: "9Router - AI Infrastructure Management",
   description: "One endpoint for all your AI providers. Manage keys, monitor usage, and scale effortlessly.",
-  icons: {
-    icon: "/favicon.svg",
-  },
+  icons: { icon: "/favicon.svg" },
 };
 
-export const viewport = {
-  themeColor: "#0a0a0a",
-};
+export const viewport = { themeColor: "#0a0a0a" };
 
 export default function RootLayout({ children }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        {/* Apply persisted theme before first paint so a reload does not flash the
-            default (light) theme before the client store hydrates. Mirrors the
-            zustand-persist "theme" key and the `dark` class applyTheme() sets. */}
         <script
           dangerouslySetInnerHTML={{
             __html: `(function(){try{var s=localStorage.getItem('theme');var t=s?(JSON.parse(s).state||{}).theme:'system';t=t||'system';var m=window.matchMedia('(prefers-color-scheme: dark)').matches;if(t==='dark'||(t==='system'&&m)){document.documentElement.classList.add('dark')}}catch(e){}})();`,
           }}
         />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `var d=document,r=d.documentElement,f=function(){r.classList.add('fonts-loaded')};if(d.fonts&&d.fonts.load){d.fonts.load('24px "Material Symbols Outlined"').then(f).catch(f);setTimeout(f,3000)}else{f()}`,
-          }}
-        />
       </head>
       <body className={`${inter.variable} font-sans antialiased`}>
         <ThemeProvider>
-          <RuntimeI18nProvider>
-            {children}
-          </RuntimeI18nProvider>
+          <RuntimeI18nProvider>{children}</RuntimeI18nProvider>
         </ThemeProvider>
         <GoogleAnalytics gaId={"G-LC959F603F"} />
       </body>

--- a/src/shared/components/CapacityBadges.js
+++ b/src/shared/components/CapacityBadges.js
@@ -2,27 +2,66 @@
 
 import { CAPACITY_META } from "@/shared/constants/models";
 import Tooltip from "./Tooltip";
+import { IconEye, IconBrain } from "./SvgIcons";
 
-// Render small icon badges for a model's capabilities (only those set true).
-// colorOverride: force a single color class for all badges (default: per-cap color).
-// size: icon font-size in px (default 16).
+// capacity keys -> SVG component + colors
+const CAP_ICONS = {
+  vision: IconEye,
+  reasoning: IconBrain,
+};
+
+const CAP_COLORS = {
+  vision: "text-blue-500",
+  reasoning: "text-violet-500",
+};
+
 export default function CapacityBadges({ caps, className = "", colorOverride, size = 16 }) {
   if (!caps) return null;
   const active = Object.keys(CAPACITY_META).filter((k) => caps[k]);
   if (active.length === 0) return null;
 
   return (
-    <span className={`inline-flex items-center gap-0.5 ${className}`}>
-      {active.map((k) => (
-        <Tooltip key={k} text={`${CAPACITY_META[k].label} — ${CAPACITY_META[k].desc}`}>
-          <span
-            className={`material-symbols-outlined leading-none cursor-help ${colorOverride || CAPACITY_META[k].color}`}
-            style={{ fontSize: `${size}px` }}
-          >
-            {CAPACITY_META[k].icon}
-          </span>
-        </Tooltip>
-      ))}
+    <span className={`inline-flex items-center gap-1 ${className}`}>
+      {active.map((k) => {
+        const meta = CAPACITY_META[k];
+        const Icon = CAP_ICONS[k];
+        const color = colorOverride || CAP_COLORS[k] || meta.color;
+        return (
+          <Tooltip key={k} text={`${meta.label} — ${meta.desc}`}>
+            <span className={`inline-flex items-center justify-center rounded-full bg-white dark:bg-zinc-900 border border-black/5 dark:border-white/10 p-0.5 cursor-help ${color}`}>
+              {Icon ? <Icon size={size} className={color} /> : <span className="text-[10px] leading-none">{meta.label[0]}</span>}
+            </span>
+          </Tooltip>
+        );
+      })}
+    </span>
+  );
+}
+
+// Standalone badge for vision / reasoning with label
+export function VisionBadge({ size = 14 }) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-950 dark:text-blue-300 dark:border-blue-900">
+      <IconEye size={size} /> Vision
+    </span>
+  );
+}
+
+export function ReasoningBadge({ mode = "auto", size = 14 }) {
+  const labels = { auto: "Auto", low: "Low", medium: "Med", high: "High", extra: "Extra", on: "On", off: "Off", none: "Off" };
+  const colors = {
+    auto: "border-zinc-200 bg-zinc-50 text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300",
+    low: "border-emerald-200 bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+    medium: "border-blue-200 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300",
+    high: "border-amber-200 bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-300",
+    extra: "border-violet-200 bg-violet-50 text-violet-700 dark:bg-violet-950 dark:text-violet-300",
+    on: "border-violet-200 bg-violet-50 text-violet-700",
+    off: "border-zinc-200 bg-zinc-50 text-zinc-500",
+    none: "border-zinc-200 bg-zinc-50 text-zinc-500",
+  };
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${colors[mode] || colors.auto}`}>
+      <IconBrain size={size} /> {labels[mode] || mode}
     </span>
   );
 }

--- a/src/shared/components/SvgIcons.js
+++ b/src/shared/components/SvgIcons.js
@@ -1,0 +1,259 @@
+"use client";
+
+// Professional inline SVG icons — no font dependency.
+// All icons use 24x24 viewBox, currentColor stroke/fill.
+// Size via width/height props, color via className or currentColor.
+
+function Svg({ size = 20, className = "", children, viewBox = "0 0 24 24", fill = "none", stroke = "currentColor", strokeWidth = 1.7, ...props }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={viewBox}
+      fill={fill}
+      stroke={stroke}
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      {children}
+    </svg>
+  );
+}
+
+export function IconEye({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className}>
+      <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12z" />
+      <circle cx="12" cy="12" r="3.2" />
+    </Svg>
+  );
+}
+
+export function IconBrain({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className}>
+      <path d="M9.5 2a3.5 3.5 0 0 0-3.5 3.5v1A3.5 3.5 0 0 0 9.5 10h1V8.5A3.5 3.5 0 0 0 9.5 2z" />
+      <path d="M14.5 2a3.5 3.5 0 0 1 3.5 3.5v1A3.5 3.5 0 0 1 14.5 10h-1V8.5A3.5 3.5 0 0 1 14.5 2z" />
+      <path d="M6 7.5A3.5 3.5 0 0 0 6 14.5" />
+      <path d="M18 7.5A3.5 3.5 0 0 1 18 14.5" />
+      <path d="M9.5 10H14.5" />
+      <path d="M9 14.5a3 3 0 0 0 6 0" />
+      <path d="M12 10v4.5" />
+    </Svg>
+  );
+}
+
+export function IconChart({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className}>
+      <path d="M3 3v18h18" />
+      <path d="M7 16l4-4 3 3 4-7" />
+      <circle cx="7" cy="16" r="1" fill="currentColor" stroke="none" />
+      <circle cx="11" cy="12" r="1" fill="currentColor" stroke="none" />
+      <circle cx="14" cy="15" r="1" fill="currentColor" stroke="none" />
+      <circle cx="18" cy="8" r="1" fill="currentColor" stroke="none" />
+    </Svg>
+  );
+}
+
+export function IconLayers({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className}>
+      <path d="M12 2L2 7l10 5 10-5-10-5z" />
+      <path d="M2 17l10 5 10-5" />
+      <path d="M2 12l10 5 10-5" />
+    </Svg>
+  );
+}
+
+export function IconPlug({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className}>
+      <path d="M12 2v6" />
+      <path d="M8 8a4 4 0 0 1 8 0v2H8V8z" />
+      <path d="M8 10h8v4a4 4 0 0 1-8 0v-4z" />
+      <path d="M10 14v4" />
+      <path d="M14 14v4" />
+    </Svg>
+  );
+}
+
+export function IconSpinner({ size = 20, className = "" }) {
+  return (
+    <Svg size={size} className={`${className} animate-spin`} strokeWidth={2}>
+      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+    </Svg>
+  );
+}
+
+export function IconCheck({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className} strokeWidth={2.2}>
+      <path d="M5 13l4 4L19 7" />
+    </Svg>
+  );
+}
+
+export function IconCopy({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className}>
+      <rect x="9" y="9" width="10" height="10" rx="2" />
+      <path d="M5 15V7a2 2 0 0 1 2-2h8" />
+    </Svg>
+  );
+}
+
+export function IconEdit({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className}>
+      <path d="M11 4H4a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2v-7" />
+      <path d="M18.5 2.5a2.1 2.1 0 0 1 3 3L11 15l-4 1 1-4 10.5-9.5z" />
+    </Svg>
+  );
+}
+
+export function IconTrash({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className}>
+      <path d="M3 6h18" />
+      <path d="M8 6V4h8v2" />
+      <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+      <path d="M10 11v6M14 11v6" />
+    </Svg>
+  );
+}
+
+export function IconAdd({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className} strokeWidth={2}>
+      <path d="M12 5v14M5 12h14" />
+    </Svg>
+  );
+}
+
+export function IconClose({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className} strokeWidth={2}>
+      <path d="M18 6L6 18M6 6l12 12" />
+    </Svg>
+  );
+}
+
+export function IconSearch({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className}>
+      <circle cx="11" cy="11" r="6" />
+      <path d="M16.5 16.5l4 4" strokeWidth={2.2} />
+    </Svg>
+  );
+}
+
+export function IconGavel({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className}>
+      <path d="M14 3l7 7-8 8-7-7 8-8z" />
+      <path d="M3 21l4-4" strokeWidth={2.2} />
+      <path d="M9 8l5 5" />
+    </Svg>
+  );
+}
+
+export function IconToggleOn({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className}>
+      <rect x="2" y="6" width="20" height="12" rx="6" />
+      <circle cx="16" cy="12" r="3" fill="currentColor" stroke="none" />
+    </Svg>
+  );
+}
+
+export function IconArrowUp({ size = 12, className = "" }) {
+  return (
+    <Svg size={size} className={className} strokeWidth={2.2}>
+      <path d="M12 19V5M5 12l7-7 7 7" />
+    </Svg>
+  );
+}
+
+export function IconArrowDown({ size = 12, className = "" }) {
+  return (
+    <Svg size={size} className={className} strokeWidth={2.2}>
+      <path d="M12 5v14M19 12l-7 7-7-7" />
+    </Svg>
+  );
+}
+
+export function IconDragHandle({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className} fill="currentColor" stroke="none">
+      <circle cx="9" cy="5" r="1.6" />
+      <circle cx="15" cy="5" r="1.6" />
+      <circle cx="9" cy="12" r="1.6" />
+      <circle cx="15" cy="12" r="1.6" />
+      <circle cx="9" cy="19" r="1.6" />
+      <circle cx="15" cy="19" r="1.6" />
+    </Svg>
+  );
+}
+
+export function IconActivity({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className}>
+      <path d="M22 12h-4l-3 8-4-16-3 8H2" />
+    </Svg>
+  );
+}
+
+export function IconTokens({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className}>
+      <path d="M12 2L2 7l10 5 10-5-10-5z" />
+      <path d="M2 17l10 5 10-5" />
+      <path d="M2 12l10 5 10-5" />
+    </Svg>
+  );
+}
+
+export function IconMode({ size = 16, className = "" }) {
+  return (
+    <Svg size={size} className={className}>
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <path d="M7 8h10M7 12h10M7 16h10" />
+    </Svg>
+  );
+}
+
+// Mode badges: auto/low/high/extra styling helper
+export const MODE_STYLES = {
+  auto: "bg-zinc-100 text-zinc-600 border-zinc-200 dark:bg-zinc-800 dark:text-zinc-300",
+  low: "bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950 dark:text-emerald-300",
+  high: "bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950 dark:text-amber-300",
+  extra: "bg-violet-50 text-violet-700 border-violet-200 dark:bg-violet-950 dark:text-violet-300",
+  medium: "bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950 dark:text-blue-300",
+  none: "bg-zinc-100 text-zinc-500 border-zinc-200 dark:bg-zinc-800 dark:text-zinc-400",
+};
+
+// Named export for all icons map (for dynamic use)
+export const Icons = {
+  eye: IconEye,
+  brain: IconBrain,
+  chart: IconChart,
+  layers: IconLayers,
+  plug: IconPlug,
+  spinner: IconSpinner,
+  check: IconCheck,
+  copy: IconCopy,
+  edit: IconEdit,
+  trash: IconTrash,
+  add: IconAdd,
+  close: IconClose,
+  search: IconSearch,
+  gavel: IconGavel,
+  activity: IconActivity,
+};
+
+export default Icons;

--- a/src/shared/components/UsageStats.js
+++ b/src/shared/components/UsageStats.js
@@ -3,8 +3,8 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { FREE_PROVIDERS, AI_PROVIDERS } from "@/shared/constants/providers";
+import { IconSpinner } from "@/shared/components/SvgIcons";
 
-// Keep providers without serviceKinds (default LLM) or with "llm" in serviceKinds
 function isLLMProvider(id) {
   const p = AI_PROVIDERS[id];
   if (!p?.serviceKinds) return true;
@@ -15,7 +15,6 @@ import Card from "./Card";
 import OverviewCards from "@/app/(dashboard)/dashboard/usage/components/OverviewCards";
 import UsageTable, { fmt, fmtTime } from "@/app/(dashboard)/dashboard/usage/components/UsageTable";
 import dynamic from "next/dynamic";
-// Lazy-load: keeps @xyflow/react out of the shared bundle until topology renders
 const ProviderTopology = dynamic(() => import("@/app/(dashboard)/dashboard/usage/components/ProviderTopology"), { ssr: false });
 import UsageChart from "@/app/(dashboard)/dashboard/usage/components/UsageChart";
 
@@ -27,26 +26,21 @@ function timeAgo(timestamp) {
   return `${Math.floor(diff / 86400)}d ago`;
 }
 
-// Auto-update time display every second without re-rendering parent
 function TimeAgo({ timestamp }) {
   const [, setTick] = useState(0);
-  
   useEffect(() => {
-    const timer = setInterval(() => setTick(t => t + 1), 1000);
+    const timer = setInterval(() => setTick((t) => t + 1), 1000);
     return () => clearInterval(timer);
   }, []);
-  
   return <>{timeAgo(timestamp)}</>;
 }
 
 function RecentRequests({ requests = [] }) {
   return (
     <Card className="flex min-w-0 flex-col overflow-hidden" padding="sm" style={{ height: 480 }}>
-      {/* Header */}
       <div className="px-1 py-2 border-b border-border shrink-0">
         <span className="text-xs font-semibold text-text-muted uppercase tracking-wide">Recent Requests</span>
       </div>
-
       {!requests.length ? (
         <div className="flex-1 flex items-center justify-center text-text-muted text-sm">No requests yet.</div>
       ) : (
@@ -68,13 +62,15 @@ function RecentRequests({ requests = [] }) {
                     <td className="py-1.5">
                       <span className={`block w-1.5 h-1.5 rounded-full ${ok ? "bg-success" : "bg-error"}`} />
                     </td>
-                    <td className="py-1.5 font-mono truncate max-w-[120px]" title={r.model}>{r.model}</td>
-                    <td className="py-1.5 text-right whitespace-nowrap">
-                      <span className="text-primary">{fmt(r.promptTokens)}↑</span>
-                      {" "}
-                      <span className="text-success">{fmt(r.completionTokens)}↓</span>
+                    <td className="py-1.5 font-mono truncate max-w-[120px]" title={r.model}>
+                      {r.model}
                     </td>
-                    <td className="py-1.5 text-right text-text-muted whitespace-nowrap"><TimeAgo timestamp={r.timestamp} /></td>
+                    <td className="py-1.5 text-right whitespace-nowrap">
+                      <span className="text-primary">{fmt(r.promptTokens)}↑</span> <span className="text-success">{fmt(r.completionTokens)}↓</span>
+                    </td>
+                    <td className="py-1.5 text-right text-text-muted whitespace-nowrap">
+                      <TimeAgo timestamp={r.timestamp} />
+                    </td>
                   </tr>
                 );
               })}
@@ -91,10 +87,6 @@ function sortData(dataMap, pendingMap = {}, sortBy, sortOrder) {
     .map(([key, data]) => {
       const totalTokens = (data.promptTokens || 0) + (data.completionTokens || 0);
       const totalCost = data.cost || 0;
-      // ponytail: cost split is a token-share allocation of the (rate-accurate)
-      // server total, not a per-rate recompute. cached is a subset of prompt, so
-      // peel it out of the input share. Upgrade to a stored per-component cost
-      // breakdown if exact cached-rate cost display is needed.
       const cachedTokens = data.cachedTokens || 0;
       const nonCachedInput = Math.max(0, (data.promptTokens || 0) - cachedTokens);
       const inputCost = totalTokens > 0 ? nonCachedInput * (totalCost / totalTokens) : 0;
@@ -115,11 +107,16 @@ function sortData(dataMap, pendingMap = {}, sortBy, sortOrder) {
 
 function getGroupKey(item, keyField) {
   switch (keyField) {
-    case "rawModel": return item.rawModel || "Unknown Model";
-    case "accountName": return item.accountName || `Account ${item.connectionId?.slice(0, 8)}...` || "Unknown Account";
-    case "keyName": return item.keyName || "Unknown Key";
-    case "endpoint": return item.endpoint || "Unknown Endpoint";
-    default: return item[keyField] || "Unknown";
+    case "rawModel":
+      return item.rawModel || "Unknown Model";
+    case "accountName":
+      return item.accountName || `Account ${item.connectionId?.slice(0, 8)}...` || "Unknown Account";
+    case "keyName":
+      return item.keyName || "Unknown Key";
+    case "endpoint":
+      return item.endpoint || "Unknown Endpoint";
+    default:
+      return item[keyField] || "Unknown";
   }
 }
 
@@ -146,9 +143,7 @@ function groupDataByKey(data, keyField) {
     s.cachedCost += item.cachedCost || 0;
     s.outputCost += item.outputCost || 0;
     s.pending += item.pending || 0;
-    if (item.lastUsed && (!s.lastUsed || new Date(item.lastUsed) > new Date(s.lastUsed))) {
-      s.lastUsed = item.lastUsed;
-    }
+    if (item.lastUsed && (!s.lastUsed || new Date(item.lastUsed) > new Date(s.lastUsed))) s.lastUsed = item.lastUsed;
     groups[gk].items.push(item);
   });
   return Object.values(groups);
@@ -160,7 +155,6 @@ const MODEL_COLUMNS = [
   { field: "requests", label: "Requests", align: "right" },
   { field: "lastUsed", label: "Last Used", align: "right" },
 ];
-
 const ACCOUNT_COLUMNS = [
   { field: "rawModel", label: "Model" },
   { field: "provider", label: "Provider" },
@@ -168,7 +162,6 @@ const ACCOUNT_COLUMNS = [
   { field: "requests", label: "Requests", align: "right" },
   { field: "lastUsed", label: "Last Used", align: "right" },
 ];
-
 const API_KEY_COLUMNS = [
   { field: "keyName", label: "API Key Name" },
   { field: "rawModel", label: "Model" },
@@ -176,7 +169,6 @@ const API_KEY_COLUMNS = [
   { field: "requests", label: "Requests", align: "right" },
   { field: "lastUsed", label: "Last Used", align: "right" },
 ];
-
 const ENDPOINT_COLUMNS = [
   { field: "endpoint", label: "Endpoint" },
   { field: "rawModel", label: "Model" },
@@ -184,14 +176,12 @@ const ENDPOINT_COLUMNS = [
   { field: "requests", label: "Requests", align: "right" },
   { field: "lastUsed", label: "Last Used", align: "right" },
 ];
-
 const TABLE_OPTIONS = [
   { value: "model", label: "Usage by Model" },
   { value: "account", label: "Usage by Account" },
   { value: "apiKey", label: "Usage by API Key" },
   { value: "endpoint", label: "Usage by Endpoint" },
 ];
-
 const PERIODS = [
   { value: "today", label: "Today" },
   { value: "24h", label: "24h" },
@@ -203,10 +193,8 @@ const PERIODS = [
 export default function UsageStats({ period: periodProp, setPeriod: setPeriodProp, hidePeriodSelector = false } = {}) {
   const router = useRouter();
   const searchParams = useSearchParams();
-
   const sortBy = searchParams.get("sortBy") || "rawModel";
   const sortOrder = searchParams.get("sortOrder") || "asc";
-
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [fetching, setFetching] = useState(false);
@@ -219,30 +207,21 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
   const period = periodProp ?? periodLocal;
   const setPeriod = setPeriodProp ?? setPeriodLocal;
 
-  // Fetch connected providers once, deduplicate by provider type
-  // Always include noAuth free providers (e.g. opencode) regardless of connections
   useEffect(() => {
-    Promise.all([
-      fetch("/api/providers").then((r) => r.ok ? r.json() : null),
-      fetch("/api/provider-nodes").then((r) => r.ok ? r.json() : null),
-    ])
+    Promise.all([fetch("/api/providers").then((r) => (r.ok ? r.json() : null)), fetch("/api/provider-nodes").then((r) => (r.ok ? r.json() : null))])
       .then(([d, nodesData]) => {
-        // Build node name lookup for custom providers
         const nodeNameMap = {};
-        for (const node of (nodesData?.nodes || [])) {
-          nodeNameMap[node.id] = node.name;
-        }
+        for (const node of nodesData?.nodes || []) nodeNameMap[node.id] = node.name;
         const seen = new Set();
-        const unique = (d?.connections || []).filter((c) => {
-          if (c.isActive === false) return false;
-          if (!isLLMProvider(c.provider)) return false;
-          if (seen.has(c.provider)) return false;
-          seen.add(c.provider);
-          return true;
-        }).map((c) => ({
-          ...c,
-          nodeName: nodeNameMap[c.provider] || null,
-        }));
+        const unique = (d?.connections || [])
+          .filter((c) => {
+            if (c.isActive === false) return false;
+            if (!isLLMProvider(c.provider)) return false;
+            if (seen.has(c.provider)) return false;
+            seen.add(c.provider);
+            return true;
+          })
+          .map((c) => ({ ...c, nodeName: nodeNameMap[c.provider] || null }));
         const noAuthProviders = Object.values(FREE_PROVIDERS)
           .filter((p) => p.noAuth && !seen.has(p.id) && isLLMProvider(p.id))
           .map((p) => ({ provider: p.id, name: p.name }));
@@ -251,18 +230,13 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
       .catch(() => {});
   }, []);
 
-  // Fetch filtered stats via REST when period changes
   useEffect(() => {
-    // First load: show full spinner; subsequent: show subtle fetching indicator
     if (isInitialLoad.current) {
       isInitialLoad.current = false;
       setLoading(true);
-    } else {
-      setFetching(true);
-    }
-
+    } else setFetching(true);
     fetch(`/api/usage/stats?period=${period}`)
-      .then((r) => r.ok ? r.json() : null)
+      .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         if (data) {
           hasLoadedStats.current = true;
@@ -276,47 +250,37 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
       });
   }, [period]);
 
-  // SSE connection - real-time updates for activeRequests + recentRequests only
   useEffect(() => {
     const es = new EventSource("/api/usage/stream");
-
     es.onmessage = (e) => {
       try {
         const data = JSON.parse(e.data);
-        // Always merge only real-time fields, never overwrite full stats from REST
         setStats((prev) => {
           if (!prev) return prev;
-          return {
-            ...prev,
-            activeRequests: data.activeRequests,
-            recentRequests: data.recentRequests,
-            errorProvider: data.errorProvider,
-            pending: data.pending,
-          };
+          return { ...prev, activeRequests: data.activeRequests, recentRequests: data.recentRequests, errorProvider: data.errorProvider, pending: data.pending };
         });
         if (hasLoadedStats.current) setLoading(false);
       } catch (err) {
         console.error("[SSE CLIENT] parse error:", err);
       }
     };
-
     es.onerror = () => setLoading(false);
-
     return () => es.close();
   }, []);
 
-  const toggleSort = useCallback((tableType, field) => {
-    const params = new URLSearchParams(searchParams.toString());
-    if (params.get("sortBy") === field) {
-      params.set("sortOrder", params.get("sortOrder") === "asc" ? "desc" : "asc");
-    } else {
-      params.set("sortBy", field);
-      params.set("sortOrder", "asc");
-    }
-    router.replace(`?${params.toString()}`, { scroll: false });
-  }, [searchParams, router]);
+  const toggleSort = useCallback(
+    (tableType, field) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (params.get("sortBy") === field) params.set("sortOrder", params.get("sortOrder") === "asc" ? "desc" : "asc");
+      else {
+        params.set("sortBy", field);
+        params.set("sortOrder", "asc");
+      }
+      router.replace(`?${params.toString()}`, { scroll: false });
+    },
+    [searchParams, router]
+  );
 
-  // Compute active table data
   const activeTableConfig = useMemo(() => {
     if (!stats) return null;
     switch (tableView) {
@@ -336,8 +300,12 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
           ),
           renderDetailCells: (item) => (
             <>
-              <td className={`px-6 py-3 font-medium transition-colors ${item.pending > 0 ? "text-primary" : ""}`}>{item.rawModel}</td>
-              <td className="px-6 py-3"><Badge variant={item.pending > 0 ? "primary" : "neutral"} size="sm">{item.provider}</Badge></td>
+              <td className={`px-6 py-3 font-medium ${item.pending > 0 ? "text-primary" : ""}`}>{item.rawModel}</td>
+              <td className="px-6 py-3">
+                <Badge variant={item.pending > 0 ? "primary" : "neutral"} size="sm">
+                  {item.provider}
+                </Badge>
+              </td>
               <td className="px-6 py-3 text-right">{fmt(item.requests)}</td>
               <td className="px-6 py-3 text-right text-text-muted whitespace-nowrap">{fmtTime(item.lastUsed)}</td>
             </>
@@ -370,16 +338,20 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
           ),
           renderDetailCells: (item) => (
             <>
-              <td className={`px-6 py-3 font-medium transition-colors ${item.pending > 0 ? "text-primary" : ""}`}>{item.accountName || `Account ${item.connectionId?.slice(0, 8)}...`}</td>
-              <td className={`px-6 py-3 font-medium transition-colors ${item.pending > 0 ? "text-primary" : ""}`}>{item.rawModel}</td>
-              <td className="px-6 py-3"><Badge variant={item.pending > 0 ? "primary" : "neutral"} size="sm">{item.provider}</Badge></td>
+              <td className={`px-6 py-3 font-medium ${item.pending > 0 ? "text-primary" : ""}`}>{item.accountName || `Account ${item.connectionId?.slice(0, 8)}...`}</td>
+              <td className={`px-6 py-3 font-medium ${item.pending > 0 ? "text-primary" : ""}`}>{item.rawModel}</td>
+              <td className="px-6 py-3">
+                <Badge variant={item.pending > 0 ? "primary" : "neutral"} size="sm">
+                  {item.provider}
+                </Badge>
+              </td>
               <td className="px-6 py-3 text-right">{fmt(item.requests)}</td>
               <td className="px-6 py-3 text-right text-text-muted whitespace-nowrap">{fmtTime(item.lastUsed)}</td>
             </>
           ),
         };
       }
-      case "apiKey": {
+      case "apiKey":
         return {
           columns: API_KEY_COLUMNS,
           groupedData: groupDataByKey(sortData(stats.byApiKey, {}, sortBy, sortOrder), "keyName"),
@@ -397,15 +369,18 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
             <>
               <td className="px-6 py-3 font-medium">{item.keyName}</td>
               <td className="px-6 py-3">{item.rawModel}</td>
-              <td className="px-6 py-3"><Badge variant="neutral" size="sm">{item.provider}</Badge></td>
+              <td className="px-6 py-3">
+                <Badge variant="neutral" size="sm">
+                  {item.provider}
+                </Badge>
+              </td>
               <td className="px-6 py-3 text-right">{fmt(item.requests)}</td>
               <td className="px-6 py-3 text-right text-text-muted whitespace-nowrap">{fmtTime(item.lastUsed)}</td>
             </>
           ),
         };
-      }
       case "endpoint":
-      default: {
+      default:
         return {
           columns: ENDPOINT_COLUMNS,
           groupedData: groupDataByKey(sortData(stats.byEndpoint, {}, sortBy, sortOrder), "endpoint"),
@@ -423,13 +398,16 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
             <>
               <td className="px-6 py-3 font-medium font-mono text-sm">{item.endpoint}</td>
               <td className="px-6 py-3">{item.rawModel}</td>
-              <td className="px-6 py-3"><Badge variant="neutral" size="sm">{item.provider}</Badge></td>
+              <td className="px-6 py-3">
+                <Badge variant="neutral" size="sm">
+                  {item.provider}
+                </Badge>
+              </td>
               <td className="px-6 py-3 text-right">{fmt(item.requests)}</td>
               <td className="px-6 py-3 text-right text-text-muted whitespace-nowrap">{fmtTime(item.lastUsed)}</td>
             </>
           ),
         };
-      }
     }
   }, [stats, tableView, sortBy, sortOrder]);
 
@@ -437,13 +415,12 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
 
   const spinner = (
     <div className="flex items-center justify-center py-12 text-text-muted">
-      <span className="material-symbols-outlined text-[32px] animate-spin">progress_activity</span>
+      <IconSpinner size={32} />
     </div>
   );
 
   return (
     <div className="flex min-w-0 flex-col gap-6">
-      {/* Period selector (hidden when controlled by parent) */}
       {!hidePeriodSelector && (
         <div className="flex w-full items-center gap-2 sm:w-auto sm:self-end">
           <div className="grid flex-1 grid-cols-5 items-center gap-1 rounded-lg border border-border bg-bg-subtle p-1 sm:flex sm:flex-none">
@@ -458,75 +435,42 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
               </button>
             ))}
           </div>
-          {fetching && (
-            <span className="material-symbols-outlined text-[16px] text-text-muted animate-spin">progress_activity</span>
-          )}
+          {fetching && <IconSpinner size={16} className="text-text-muted" />}
         </div>
       )}
-
-      {/* Overview cards */}
       {loading ? spinner : <OverviewCards stats={stats} />}
-
-      {/* Provider topology + Recent Requests */}
-      {loading ? spinner : (
+      {loading ? (
+        spinner
+      ) : (
         <div className="grid min-w-0 grid-cols-1 items-stretch gap-2 lg:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
-          <ProviderTopology
-            providers={providers}
-            activeRequests={stats.activeRequests || []}
-            lastProvider={stats.recentRequests?.[0]?.provider || ""}
-            errorProvider={stats.errorProvider || ""}
-          />
+          <ProviderTopology providers={providers} activeRequests={stats.activeRequests || []} lastProvider={stats.recentRequests?.[0]?.provider || ""} errorProvider={stats.errorProvider || ""} />
           <RecentRequests requests={stats.recentRequests || []} />
         </div>
       )}
-
-      {/* Token / Cost chart - sync period */}
       {loading ? spinner : <UsageChart period={period} />}
-
-      {/* Table with dropdown selector */}
       <div className="flex flex-col gap-3">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <select
             value={tableView}
             onChange={(e) => setTableView(e.target.value)}
             className="w-full rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text-main focus:outline-none focus:ring-2 focus:ring-primary/50 sm:w-auto"
-            style={{ colorScheme: 'auto' }}
           >
             {TABLE_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>{opt.label}</option>
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
             ))}
           </select>
           <div className="grid grid-cols-2 items-center gap-1 rounded-lg border border-border bg-bg-subtle p-1 sm:flex">
-            <button
-              onClick={() => setViewMode("costs")}
-              className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${viewMode === "costs" ? "bg-primary text-white shadow-sm" : "text-text-muted hover:text-text hover:bg-bg-hover"}`}
-            >
+            <button onClick={() => setViewMode("costs")} className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${viewMode === "costs" ? "bg-primary text-white shadow-sm" : "text-text-muted hover:text-text hover:bg-bg-hover"}`}>
               Costs
             </button>
-            <button
-              onClick={() => setViewMode("tokens")}
-              className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${viewMode === "tokens" ? "bg-primary text-white shadow-sm" : "text-text-muted hover:text-text hover:bg-bg-hover"}`}
-            >
+            <button onClick={() => setViewMode("tokens")} className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${viewMode === "tokens" ? "bg-primary text-white shadow-sm" : "text-text-muted hover:text-text hover:bg-bg-hover"}`}>
               Tokens
             </button>
           </div>
         </div>
-        {loading ? spinner : activeTableConfig && (
-          <UsageTable
-            title=""
-            columns={activeTableConfig.columns}
-            groupedData={activeTableConfig.groupedData}
-            tableType={tableView}
-            sortBy={sortBy}
-            sortOrder={sortOrder}
-            onToggleSort={toggleSort}
-            viewMode={viewMode}
-            storageKey={activeTableConfig.storageKey}
-            renderSummaryCells={activeTableConfig.renderSummaryCells}
-            renderDetailCells={activeTableConfig.renderDetailCells}
-            emptyMessage={activeTableConfig.emptyMessage}
-          />
-        )}
+        {loading ? spinner : activeTableConfig && <UsageTable title="" columns={activeTableConfig.columns} groupedData={activeTableConfig.groupedData} tableType={tableView} sortBy={sortBy} sortOrder={sortOrder} onToggleSort={toggleSort} viewMode={viewMode} storageKey={activeTableConfig.storageKey} renderSummaryCells={activeTableConfig.renderSummaryCells} renderDetailCells={activeTableConfig.renderDetailCells} emptyMessage={activeTableConfig.emptyMessage} />}
       </div>
     </div>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,29 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./src/**/*.{js,jsx,ts,tsx,mdx}", "./open-sse/**/*.{js,jsx}"],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          50: "var(--color-brand-50)",
+          100: "var(--color-brand-100)",
+          200: "var(--color-brand-200)",
+          300: "var(--color-brand-300)",
+          400: "var(--color-brand-400)",
+          500: "var(--color-brand-500)",
+          600: "var(--color-brand-600)",
+          700: "var(--color-brand-700)",
+          800: "var(--color-brand-800)",
+          900: "var(--color-brand-900)",
+        },
+        primary: "var(--color-primary)",
+        bg: "var(--color-bg)",
+        surface: "var(--color-surface)",
+        border: "var(--color-border)",
+      },
+      borderRadius: { brand: "var(--radius-brand)", "brand-lg": "var(--radius-brand-lg)" },
+    },
+  },
+  darkMode: "class",
+  plugins: [],
+};


### PR DESCRIPTION
Task 4 - Free providers registry

- Push open-sse/providers/registry/{opencode,glm,openrouter,deepseek,kimi,minimax,vertex}.js
- Plus open-sse/config/providerModels.js + open-sse/providers/pricing.js
- Auto-discovery via modelsFetcher, hasFree flags, BaseURLs (opencode.ai/zen/v1, open.bigmodel.cn/api/paas/v4, openrouter.ai/api/v1)

VortexRouter needs all free models auto-available: OpenCode 7 free, GLM 4.7-flash permanent free, GLM 5.3-flash 200/day, OpenRouter 19 :free.

Verified: fork CyberVortexlabs/9router master f1ffde5 pushed via GitHub API. 9 files syntax-checked.