### PR TITLE
feat(opencode-go): add muse-spark-1.3-contributor + fix parallel tool-call merging on Responses paths

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -50,7 +50,7 @@ export function findModelName(aliasOrId, modelId) {
 }
 
 export function getModelTargetFormat(aliasOrId, modelId) {
-  if ((!aliasOrId || aliasOrId === "oc" || aliasOrId === "opencode") && isMuseSparkModel(modelId)) {
+  if ((!aliasOrId || aliasOrId === "oc" || aliasOrId === "opencode" || aliasOrId === "ocg" || aliasOrId === "opencode-go") && isMuseSparkModel(modelId)) {
     return FORMATS.OPENAI_RESPONSES;
   }
   const models = PROVIDER_MODELS[aliasOrId];

--- a/open-sse/executors/index.js
+++ b/open-sse/executors/index.js
@@ -10,6 +10,7 @@ import { CodexExecutor } from "./codex.js";
 import { CursorExecutor } from "./cursor.js";
 import { VertexExecutor } from "./vertex.js";
 import { OpenCodeExecutor } from "./opencode.js";
+import { OpenCodeGoExecutor } from "./opencode-go.js";
 import { GrokWebExecutor } from "./grok-web.js";
 import { GrokCliExecutor } from "./grok-cli.js";
 import { PerplexityWebExecutor } from "./perplexity-web.js";
@@ -40,6 +41,7 @@ const executors = {
   vertex: new VertexExecutor("vertex"),
   "vertex-partner": new VertexExecutor("vertex-partner"),
   opencode: new OpenCodeExecutor(),
+  "opencode-go": new OpenCodeGoExecutor(),
   "grok-web": new GrokWebExecutor(),
   "grok-cli": new GrokCliExecutor(),
   gcli: new GrokCliExecutor(), // Alias
@@ -84,6 +86,7 @@ export { CursorExecutor } from "./cursor.js";
 export { VertexExecutor } from "./vertex.js";
 export { DefaultExecutor } from "./default.js";
 export { OpenCodeExecutor } from "./opencode.js";
+export { OpenCodeGoExecutor } from "./opencode-go.js";
 export { GrokWebExecutor } from "./grok-web.js";
 export { GrokCliExecutor } from "./grok-cli.js";
 export { PerplexityWebExecutor } from "./perplexity-web.js";

--- a/open-sse/executors/opencode-go.js
+++ b/open-sse/executors/opencode-go.js
@@ -1,0 +1,115 @@
+import { DefaultExecutor } from "./default.js";
+import { isMuseSparkModel } from "../providers/models/helpers.js";
+import {
+  normalizeResponsesInput,
+  clampResponsesCallId,
+  coerceResponsesArguments,
+  coerceResponsesOutput,
+} from "../translator/formats/responsesApi.js";
+
+const RESPONSES_BASE_URL = "https://opencode.ai/zen/go/v1/responses";
+const MAX_TOOL_NAME_LEN = 128;
+
+// Strip the thinking suffix "model(level)" so checks hit the base id.
+function baseModelId(model) {
+  return String(model || "").replace(/\([^()]+\)\s*$/, "").trim();
+}
+
+function isResponsesModel(model) {
+  return isMuseSparkModel(baseModelId(model));
+}
+
+// Flatten Chat Completions tool declarations into the Responses flat shape and
+// drop hosted/nameless tools the /responses endpoint rejects.
+function normalizeResponsesTools(body) {
+  if (!Array.isArray(body.tools)) return;
+  const validNames = new Set();
+  body.tools = body.tools.filter((tool) => {
+    if (!tool || typeof tool !== "object" || Array.isArray(tool)) return false;
+    const fn = tool.function && typeof tool.function === "object" && !Array.isArray(tool.function) ? tool.function : null;
+    const rawName = typeof tool.name === "string" ? tool.name : (typeof fn?.name === "string" ? fn.name : "");
+    const name = rawName.trim();
+    if (!name) return false;
+    const description = typeof tool.description === "string" ? tool.description : (typeof fn?.description === "string" ? fn.description : "");
+    const parameters = (tool.parameters && typeof tool.parameters === "object" && !Array.isArray(tool.parameters))
+      ? tool.parameters
+      : (fn?.parameters && typeof fn.parameters === "object" && !Array.isArray(fn.parameters) ? fn.parameters : { type: "object", properties: {} });
+    for (const k of Object.keys(tool)) delete tool[k];
+    tool.type = "function";
+    tool.name = name.slice(0, MAX_TOOL_NAME_LEN);
+    if (description) tool.description = description;
+    tool.parameters = parameters;
+    validNames.add(tool.name);
+    return true;
+  });
+  if (body.tool_choice && typeof body.tool_choice === "object" && !Array.isArray(body.tool_choice)) {
+    if (body.tool_choice.type === "function") {
+      const n = typeof body.tool_choice.name === "string" ? body.tool_choice.name.trim() : "";
+      if (!n || !validNames.has(n)) delete body.tool_choice;
+    }
+  }
+}
+
+// Last line of defense for native Responses clients (sourceFormat === targetFormat
+// skips translation): coerce items in place so malformed tool payloads 400 here
+// with a clear shape instead of upstream as InputValidationError.
+function sanitizeResponsesItems(body) {
+  if (!Array.isArray(body.input)) return;
+  body.input = body.input.filter((item) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return true;
+    if (item.type === "function_call") {
+      if (!item.name || typeof item.name !== "string" || item.name.trim() === "") return false;
+      item.name = item.name.trim().slice(0, MAX_TOOL_NAME_LEN);
+      item.call_id = clampResponsesCallId(item.call_id);
+      item.arguments = coerceResponsesArguments(item.arguments);
+      return true;
+    }
+    if (item.type === "function_call_output") {
+      item.call_id = clampResponsesCallId(item.call_id);
+      item.output = coerceResponsesOutput(item.output);
+      return true;
+    }
+    return true;
+  });
+}
+
+export class OpenCodeGoExecutor extends DefaultExecutor {
+  constructor() {
+    super("opencode-go");
+  }
+
+  buildUrl(model, stream, urlIndex = 0, credentials = null) {
+    // Muse Spark lives on /responses even when a stale runtimeTransport leaks in.
+    if (isResponsesModel(model)) return RESPONSES_BASE_URL;
+    return super.buildUrl(model, stream, urlIndex, credentials);
+  }
+
+  transformRequest(model, body, stream, credentials) {
+    const out = super.transformRequest(model, body);
+    if (!isResponsesModel(model || body?.model)) return out;
+    const normalized = normalizeResponsesInput(out.input);
+    if (normalized) out.input = normalized;
+    if (!Array.isArray(out.input) || out.input.length === 0) {
+      out.input = [{ type: "message", role: "user", content: [{ type: "input_text", text: "..." }] }];
+    }
+    // Responses names the output cap max_output_tokens, not max_tokens.
+    if (out.max_output_tokens === undefined) {
+      if (out.max_completion_tokens !== undefined) out.max_output_tokens = out.max_completion_tokens;
+      else if (out.max_tokens !== undefined) out.max_output_tokens = out.max_tokens;
+    }
+    delete out.max_tokens;
+    delete out.max_completion_tokens;
+    if (out.reasoning_effort !== undefined && out.reasoning === undefined) {
+      out.reasoning = { effort: out.reasoning_effort, summary: "auto" };
+    }
+    if (out.reasoning && typeof out.reasoning === "object" && !Array.isArray(out.reasoning)) {
+      if (!out.reasoning.summary) out.reasoning.summary = "auto";
+    }
+    delete out.reasoning_effort;
+    out.stream = true;
+    out.store = false;
+    normalizeResponsesTools(out);
+    sanitizeResponsesItems(out);
+    return out;
+  }
+}

--- a/open-sse/providers/registry/opencode-go.js
+++ b/open-sse/providers/registry/opencode-go.js
@@ -47,5 +47,8 @@ export default {
     { id: "qwen3.7-max", name: "Qwen 3.7 Max", supportedFormats: ["openai", "claude"] },
     { id: "qwen3.7-plus", name: "Qwen 3.7 Plus", supportedFormats: ["openai", "claude"] },
     { id: "qwen3.6-plus", name: "Qwen 3.6 Plus", supportedFormats: ["openai", "claude"] },
+    // Muse Spark is served by /zen/go/v1/responses only — responses-only entry forces
+    // chatCore past the sourceFormat-matched transports into translation (see chatCore guard).
+    { id: "muse-spark-1.3-contributor", name: "Muse Spark 1.3 Contributor", targetFormat: "openai-responses", supportedFormats: ["openai-responses"] },
   ],
 };

--- a/open-sse/translator/formats/responsesApi.js
+++ b/open-sse/translator/formats/responsesApi.js
@@ -23,6 +23,46 @@ export function normalizeResponsesInput(input) {
   return null;
 }
 
+// Strict Responses upstreams reject overlong call_ids with InputValidationError (#393).
+export const MAX_RESPONSES_CALL_ID_LEN = 64;
+
+export function clampResponsesCallId(id) {
+  if (typeof id !== "string" || !id) return `call_${Date.now()}`;
+  return id.length > MAX_RESPONSES_CALL_ID_LEN ? id.substring(0, MAX_RESPONSES_CALL_ID_LEN) : id;
+}
+
+// Single-stringify: objects → JSON once; valid JSON strings pass through untouched;
+// anything else (partial fragments, empty) falls back to "{}" instead of
+// double-encoding and tripping upstream InputValidationError.
+export function coerceResponsesArguments(value) {
+  if (value === undefined || value === null || value === "") return "{}";
+  if (typeof value !== "string") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return "{}";
+    }
+  }
+  try {
+    JSON.parse(value);
+    return value;
+  } catch {
+    return "{}";
+  }
+}
+
+// function_call_output.output must be a string — never null/object.
+export function coerceResponsesOutput(value) {
+  if (typeof value === "string") return value;
+  if (value === undefined || value === null) return "";
+  if (Array.isArray(value)) return value.map((c) => c?.text ?? JSON.stringify(c)).join("");
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
 /**
  * Convert OpenAI Responses API format to standard chat completions format
  * Responses API uses: { input: [...], instructions: "..." }

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -6,12 +6,15 @@
  */
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
-import { normalizeResponsesInput } from "../formats/responsesApi.js";
+import {
+  normalizeResponsesInput,
+  clampResponsesCallId,
+  coerceResponsesArguments,
+  coerceResponsesOutput,
+} from "../formats/responsesApi.js";
 import { ROLE, OPENAI_BLOCK, RESPONSES_ITEM } from "../schema/index.js";
 
-// Responses API enforces max 64 chars on call_id (#393)
-const MAX_CALL_ID_LEN = 64;
-const clampCallId = (id) => (typeof id === "string" && id.length > MAX_CALL_ID_LEN ? id.substring(0, MAX_CALL_ID_LEN) : id);
+const MAX_TOOL_NAME_LEN = 128;
 
 /**
  * Convert OpenAI Responses API request to OpenAI Chat Completions format
@@ -250,6 +253,23 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
 }
 
 /**
+ * Extract plain text from a system/developer message for Responses instructions.
+ * Array content (text parts) is joined; anything else falls back to "" rather
+ * than leaking "[object Object]" upstream.
+ */
+function extractInstructionsText(content) {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map((c) => {
+      if (typeof c?.text === "string") return c.text;
+      if (typeof c?.content === "string") return c.content;
+      return "";
+    }).filter(Boolean).join("\n");
+  }
+  return "";
+}
+
+/**
  * Ensure object schema always has properties field (required by Codex Responses API)
  */
 function normalizeToolParameters(params) {
@@ -327,7 +347,7 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
       // Use the first instruction-bearing message as instructions.
       // OpenAI recommends role="developer" for GPT-5/Codex as the system-level prompt.
       if (!hasSystemMessage) {
-        result.instructions = typeof msg.content === "string" ? msg.content : "";
+        result.instructions = extractInstructionsText(msg.content);
         hasSystemMessage = true;
       }
       continue; // Skip instruction messages in input
@@ -378,26 +398,24 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
     // Convert tool calls
     if (msg.role === ROLE.ASSISTANT && msg.tool_calls) {
       for (const tc of msg.tool_calls) {
+        // Skip nameless calls — strict Responses upstreams reject them (#444)
+        const name = typeof tc.function?.name === "string" ? tc.function.name.trim() : "";
+        if (!name) continue;
         result.input.push({
           type: RESPONSES_ITEM.FUNCTION_CALL,
-          call_id: clampCallId(tc.id),
-          name: tc.function?.name || "_unknown",
-          arguments: tc.function?.arguments || "{}"
+          call_id: clampResponsesCallId(tc.id),
+          name: name.slice(0, MAX_TOOL_NAME_LEN),
+          arguments: coerceResponsesArguments(tc.function?.arguments)
         });
       }
     }
 
     // Convert tool results - output must be a string for Responses API
     if (msg.role === ROLE.TOOL) {
-      const output = typeof msg.content === "string"
-        ? msg.content
-        : Array.isArray(msg.content)
-          ? msg.content.map(c => c.text || JSON.stringify(c)).join("")
-          : JSON.stringify(msg.content);
       result.input.push({
         type: RESPONSES_ITEM.FUNCTION_CALL_OUTPUT,
-        call_id: clampCallId(msg.tool_call_id),
-        output
+        call_id: clampResponsesCallId(msg.tool_call_id),
+        output: coerceResponsesOutput(msg.content)
       });
     }
   }
@@ -411,16 +429,19 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
   if (body.tools && Array.isArray(body.tools)) {
     result.tools = body.tools.map(tool => {
       if (tool.type === OPENAI_BLOCK.FUNCTION) {
+        // Strict upstreams reject nameless/overlong tool declarations
+        const name = typeof tool.function?.name === "string" ? tool.function.name.trim() : "";
+        if (!name) return null;
         return {
           type: OPENAI_BLOCK.FUNCTION,
-          name: tool.function.name,
+          name: name.slice(0, MAX_TOOL_NAME_LEN),
           description: String(tool.function.description || ""),
           parameters: normalizeToolParameters(tool.function.parameters),
           strict: tool.function.strict
         };
       }
       return tool;
-    });
+    }).filter(Boolean);
   }
 
   // Pass through other relevant fields

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -446,6 +446,13 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
     state.created = Math.floor(Date.now() / 1000);
     state.toolCallIndex = 0;
     state.currentToolCallId = null;
+    // item_id → chat tool_calls index. Deltas carry item_id; keying on it (not
+    // stream position) keeps parallel calls separate when upstream emits all
+    // output_item.added events before any done/delta. Lazily created so callers
+    // that build their own state object (stream.js) need no changes.
+    state.respToolChatIndex ??= new Map();
+    // Indices that already received argument deltas (guards done-with-args).
+    state.respToolArgsEmitted ??= new Set();
   }
 
   // Text content delta
@@ -464,16 +471,29 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
     return null;
   }
 
-  // Function call started (standard function_call or custom_tool_call)
+  // Function call started (standard function_call or custom_tool_call).
+  // Index is assigned here (not on done): attributing deltas by stream position
+  // merges parallel calls into index 0 whenever upstream emits all addeds
+  // before dones — the client then concatenates N JSON payloads into one
+  // tool input and fails validation. The server item id is the correlator.
   if (eventType === "response.output_item.added" && (data.item?.type === RESPONSES_ITEM.FUNCTION_CALL || data.item?.type === "custom_tool_call")) {
     const item = data.item;
     state.currentToolCallId = item.call_id || fallbackToolCallId();
+    state.respToolChatIndex ??= new Map();
+    const key = item.id || data.item_id || state.currentToolCallId;
+    let idx;
+    if (key && state.respToolChatIndex.has(key)) {
+      idx = state.respToolChatIndex.get(key); // duplicate added (retry) — reuse
+    } else {
+      idx = state.toolCallIndex++;
+      if (key) state.respToolChatIndex.set(key, idx);
+    }
 
     return buildChunk(
       { id: state.chatId, created: state.created, model: state.model || MODEL_FALLBACK },
       {
         tool_calls: [{
-          index: state.toolCallIndex,
+          index: idx,
           id: state.currentToolCallId,
           type: OPENAI_BLOCK.FUNCTION,
           function: { name: item.name || "", arguments: "" }
@@ -482,20 +502,39 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
     );
   }
 
-  // Function call arguments delta (standard or custom_tool_call variant)
+  // Function call arguments delta (standard or custom_tool_call variant).
+  // Routed by item_id so interleaved parallel fragments stay on their own call.
   if (eventType === "response.function_call_arguments.delta" || eventType === "response.custom_tool_call_input.delta") {
     const argsDelta = data.delta || "";
     if (!argsDelta) return null;
 
+    const known = data.item_id ? state.respToolChatIndex?.get(data.item_id) : undefined;
+    const idx = known ?? Math.max(0, (state.toolCallIndex || 1) - 1);
+    state.respToolArgsEmitted ??= new Set();
+    state.respToolArgsEmitted.add(idx);
     return buildChunk(
       { id: state.chatId, created: state.created, model: state.model || MODEL_FALLBACK },
-      { tool_calls: [{ index: state.toolCallIndex, function: { arguments: argsDelta } }] }
+      { tool_calls: [{ index: idx, function: { arguments: argsDelta } }] }
     );
   }
 
-  // Function call done (standard or custom_tool_call variant)
+  // Function call done (standard or custom_tool_call variant).
+  // Index was assigned at added-time; nothing to advance. Some upstreams send
+  // complete arguments only here (no deltas) — emit them once in that case.
   if (eventType === "response.output_item.done" && (data.item?.type === RESPONSES_ITEM.FUNCTION_CALL || data.item?.type === "custom_tool_call")) {
-    state.toolCallIndex++;
+    const key = data.item?.id || data.item_id;
+    const idx = (key && state.respToolChatIndex?.get(key)) ?? Math.max(0, (state.toolCallIndex || 1) - 1);
+    const fullArgs = data.item?.arguments;
+    if (typeof fullArgs === "string" && fullArgs) {
+      state.respToolArgsEmitted ??= new Set();
+      if (!state.respToolArgsEmitted.has(idx)) {
+        state.respToolArgsEmitted.add(idx);
+        return buildChunk(
+          { id: state.chatId, created: state.created, model: state.model || MODEL_FALLBACK },
+          { tool_calls: [{ index: idx, function: { arguments: fullArgs } }] }
+        );
+      }
+    }
     return null;
   }
 

--- a/tests/unit/opencode-go-models.test.js
+++ b/tests/unit/opencode-go-models.test.js
@@ -27,6 +27,7 @@ describe("OpenCode Go model catalog", () => {
       "mimo-v2.5", "mimo-v2.5-pro",
       "minimax-m3", "minimax-m2.7", "minimax-m2.5",
       "qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus",
+      "muse-spark-1.3-contributor",
     ]);
   });
 });

--- a/tests/unit/opencode-go-muse-spark-responses.test.js
+++ b/tests/unit/opencode-go-muse-spark-responses.test.js
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import { PROVIDER_MODELS, getModelTargetFormat, getModelSupportedFormats } from "../../open-sse/config/providerModels.js";
+import { PROVIDERS } from "../../open-sse/config/providers.js";
+import { resolveTransport } from "../../open-sse/services/provider.js";
+import { getCapabilitiesForModel } from "../../open-sse/providers/capabilities.js";
+import { getThinkingLevels } from "../../open-sse/providers/thinkingLevels.js";
+import { getExecutor } from "../../open-sse/executors/index.js";
+import { OpenCodeGoExecutor } from "../../open-sse/executors/opencode-go.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import "../translator/registerAll.js";
+import { translateRequest } from "../../open-sse/translator/index.js";
+
+const MODEL = "muse-spark-1.3-contributor";
+const PROVIDER = "opencode-go";
+
+// Mirror of chatCore's per-model transport guard
+function pickTransport(provider, sourceFormat, alias, model) {
+  const supported = getModelSupportedFormats(alias, model);
+  const rt = resolveTransport(provider, sourceFormat);
+  return supported?.includes(sourceFormat) ? rt : null;
+}
+
+describe("ocg/muse-spark-1.3-contributor catalog", () => {
+  it("is registered responses-only", () => {
+    const entry = (PROVIDER_MODELS["opencode-go"] || []).find((m) => m.id === MODEL);
+    expect(entry).toBeDefined();
+    expect(entry.targetFormat).toBe("openai-responses");
+    expect(getModelSupportedFormats("opencode-go", MODEL)).toEqual(["openai-responses"]);
+    expect(getModelTargetFormat("ocg", MODEL)).toBe(FORMATS.OPENAI_RESPONSES);
+    expect(getModelTargetFormat("opencode-go", MODEL)).toBe(FORMATS.OPENAI_RESPONSES);
+  });
+
+  it("never takes the sourceFormat-matched transport (always translates)", () => {
+    expect(pickTransport(PROVIDER, "openai", "opencode-go", MODEL)).toBeNull();
+    expect(pickTransport(PROVIDER, "claude", "opencode-go", MODEL)).toBeNull();
+    expect(pickTransport(PROVIDER, "openai-responses", "opencode-go", MODEL)?.baseUrl)
+      .toBe("https://opencode.ai/zen/go/v1/responses");
+  });
+
+  it("advertises reasoning via the shared muse-spark pattern", () => {
+    expect(getCapabilitiesForModel(PROVIDER, MODEL)).toMatchObject({
+      vision: true,
+      reasoning: true,
+      thinkingFormat: "openai",
+    });
+    expect(getThinkingLevels(PROVIDER, MODEL)).toContain("xhigh");
+  });
+});
+
+describe("OpenCodeGoExecutor routing + sanitization", () => {
+  it("is wired for opencode-go and routes muse-spark to /responses", () => {
+    expect(getExecutor("opencode-go")).toBeInstanceOf(OpenCodeGoExecutor);
+    const ex = new OpenCodeGoExecutor();
+    expect(ex.buildUrl(MODEL)).toBe("https://opencode.ai/zen/go/v1/responses");
+    // Even a stale runtimeTransport must not drag muse-spark onto chat/messages
+    expect(ex.buildUrl(MODEL, true, 0, {
+      runtimeTransport: { baseUrl: "https://opencode.ai/zen/go/v1/chat/completions" },
+    })).toBe("https://opencode.ai/zen/go/v1/responses");
+  });
+
+  it("leaves non-muse models on the default/runtime transport", () => {
+    const ex = new OpenCodeGoExecutor();
+    expect(ex.buildUrl("kimi-k2.6")).toBe("https://opencode.ai/zen/go/v1/chat/completions");
+    expect(ex.buildUrl("minimax-m3", true, 0, {
+      runtimeTransport: { baseUrl: "https://opencode.ai/zen/go/v1/messages" },
+    })).toBe("https://opencode.ai/zen/go/v1/messages");
+  });
+
+  it("normalizes caps + reasoning and coerces tool items exactly once", () => {
+    const ex = new OpenCodeGoExecutor();
+    const args = { path: "a\"b\nc\\d", emoji: "🚀 ü", nested: { q: "x'y\"z" } };
+    const body = {
+      model: MODEL,
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+        { type: "function_call", call_id: "x".repeat(100), name: "read", arguments: args },
+        { type: "function_call", call_id: "bad", name: "   ", arguments: "{}" },
+        { type: "function_call", call_id: "frag", name: "exec", arguments: "{not json" },
+        { type: "function_call_output", call_id: "c1", output: { ok: true, text: "héllo \"w\"" } },
+        { type: "function_call_output", call_id: "c2", output: null },
+      ],
+      tools: [
+        { type: "function", function: { name: "read", description: "r", parameters: { type: "object", properties: {} } } },
+        { type: "function", function: { name: "  ", parameters: {} } },
+      ],
+      max_tokens: 2048,
+      reasoning_effort: "high",
+    };
+    const out = ex.transformRequest(MODEL, body, true, {});
+    expect(out.max_output_tokens).toBe(2048);
+    expect(out.max_tokens).toBeUndefined();
+    expect(out.reasoning).toEqual({ effort: "high", summary: "auto" });
+    expect(out.stream).toBe(true);
+    expect(out.store).toBe(false);
+    // nameless declaration dropped, nameless call dropped
+    expect(out.tools.map((t) => t.name)).toEqual(["read"]);
+    const calls = out.input.filter((i) => i.type === "function_call");
+    expect(calls.map((c) => c.name)).toEqual(["read", "exec"]);
+    // overlong id clamped, object args stringified exactly once
+    expect(calls[0].call_id).toHaveLength(64);
+    expect(JSON.parse(calls[0].arguments)).toEqual(args);
+    // invalid fragment coerced, never double-encoded
+    expect(calls[1].arguments).toBe("{}");
+    const outputs = out.input.filter((i) => i.type === "function_call_output");
+    expect(JSON.parse(outputs[0].output)).toEqual({ ok: true, text: "héllo \"w\"" });
+    expect(outputs[1].output).toBe("");
+  });
+});
+
+describe("chat/claude clients translate to Responses without breaking tools", () => {
+  const tricky = { cmd: "echo \"hi\"\nnewline\ttab\\slash", emoji: "🎉 café naïve", nested: { a: [1, "x'y"] } };
+
+  it("openai chat → responses keeps arguments parseable", () => {
+    const translated = translateRequest(
+      FORMATS.OPENAI,
+      FORMATS.OPENAI_RESPONSES,
+      MODEL,
+      {
+        model: `ocg/${MODEL}`,
+        messages: [
+          { role: "system", content: [{ type: "text", text: "sys one" }, { type: "text", text: "sys two" }] },
+          { role: "user", content: "run it" },
+          {
+            role: "assistant", content: null,
+            tool_calls: [{ id: "call_1", type: "function", function: { name: "exec", arguments: tricky } }],
+          },
+          { role: "tool", tool_call_id: "call_1", content: tricky },
+        ],
+        tools: [{ type: "function", function: { name: "exec", description: "e", parameters: { type: "object", properties: {} } } }],
+      },
+      true, {}, PROVIDER,
+    );
+    expect(translated.instructions).toBe("sys one\nsys two");
+    const fc = translated.input.find((i) => i.type === "function_call");
+    expect(JSON.parse(fc.arguments)).toEqual(tricky);
+    const fco = translated.input.find((i) => i.type === "function_call_output");
+    expect(JSON.parse(fco.output)).toEqual(tricky);
+  });
+
+  it("claude messages → responses double-hop keeps tool input intact", () => {
+    const viaOpenAI = translateRequest(FORMATS.CLAUDE, FORMATS.OPENAI, MODEL, {
+      system: "be terse",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "go" }] },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "calling" },
+            { type: "tool_use", id: "tu_1", name: "exec", input: tricky },
+          ],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "tu_1", content: [{ type: "text", text: JSON.stringify(tricky) }] }],
+        },
+      ],
+      tools: [{ name: "exec", description: "e", input_schema: { type: "object", properties: {} } }],
+    }, true, {}, PROVIDER);
+    const translated = translateRequest(FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, MODEL, viaOpenAI, true, {}, PROVIDER);
+    const fc = translated.input.find((i) => i.type === "function_call");
+    expect(JSON.parse(fc.arguments)).toEqual(tricky);
+    const fco = translated.input.find((i) => i.type === "function_call_output");
+    expect(JSON.parse(fco.output)).toEqual(tricky);
+  });
+});

--- a/tests/unit/responses-parallel-tool-calls.test.js
+++ b/tests/unit/responses-parallel-tool-calls.test.js
@@ -1,0 +1,140 @@
+// Parallel function_calls from a Responses upstream must stay on separate
+// chat tool_calls indices. Regression: response/openai-responses.js attributed
+// every arguments delta to the positional toolCallIndex (advanced only on
+// output_item.done), so all-added-then-deltas ordering concatenated N JSON
+// payloads into index 0 and clients failed with InputValidationError.
+import { describe, expect, it } from "vitest";
+import "../translator/registerAll.js";
+import { openaiResponsesToOpenAIResponse } from "../../open-sse/translator/response/openai-responses.js";
+import { initState, translateResponse } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+const added = (id, call_id, name, type = "function_call") => ({
+  type: "response.output_item.added",
+  item: { id, type, call_id, name, arguments: "" },
+});
+const delta = (item_id, text) => ({
+  type: "response.function_call_arguments.delta",
+  item_id,
+  delta: text,
+});
+const done = (id, call_id, name) => ({
+  type: "response.output_item.done",
+  item: { id, type: "function_call", call_id, name },
+});
+
+// Reassemble translated chunks the way an OpenAI client accumulator does.
+function accumulate(calls, chunks) {
+  for (const chunk of chunks) {
+    if (!chunk) continue;
+    for (const tc of chunk.choices?.[0]?.delta?.tool_calls || []) {
+      const slot = (calls[tc.index] ??= { id: null, name: "", args: "" });
+      if (tc.id) slot.id = tc.id;
+      if (tc.function?.name) slot.name = tc.function.name;
+      if (tc.function?.arguments) slot.args += tc.function.arguments;
+    }
+  }
+  return calls;
+}
+
+function runStream(events) {
+  const state = {};
+  const chunks = [];
+  for (const ev of events) {
+    const out = openaiResponsesToOpenAIResponse(ev, state);
+    if (out) chunks.push(out);
+  }
+  const flush = openaiResponsesToOpenAIResponse(null, state);
+  if (flush) chunks.push(flush);
+  return { state, chunks };
+}
+
+const PAYLOADS = [
+  '{"file_path":"/docs/PRODUCT.md"}',
+  '{"file_path":"/docs/ROADMAP.md"}',
+  '{"file_path":"/docs/openapi.custom.yaml"}',
+  '{"file_path":"/docs/.gitignore"}',
+];
+
+function hostileOrdering() {
+  const events = PAYLOADS.map((_, i) => added(`fc_${i}`, `call_${i}`, "read_file"));
+  // Interleaved deltas AFTER all addeds — the ordering that used to merge all
+  // four payloads into index 0.
+  PAYLOADS.forEach((p, i) => events.push(delta(`fc_${i}`, p.slice(0, 20)), delta(`fc_${i}`, p.slice(20))));
+  PAYLOADS.forEach((_, i) => events.push(done(`fc_${i}`, `call_${i}`, "read_file")));
+  return events;
+}
+
+describe("responses parallel tool calls keep their own index", () => {
+  it("all-added-then-deltas ordering yields 4 separately parseable calls", () => {
+    const { chunks } = runStream(hostileOrdering());
+    const calls = accumulate({}, chunks);
+    expect(Object.keys(calls)).toHaveLength(4);
+    PAYLOADS.forEach((p, i) => {
+      expect(calls[i].id).toBe(`call_${i}`);
+      expect(calls[i].name).toBe("read_file");
+      expect(JSON.parse(calls[i].args)).toEqual(JSON.parse(p));
+    });
+  });
+
+  it("sequential ordering still yields indices 0,1 in order", () => {
+    const events = [
+      added("fc_0", "call_0", "read_file"),
+      delta("fc_0", PAYLOADS[0]),
+      done("fc_0", "call_0", "read_file"),
+      added("fc_1", "call_1", "read_file"),
+      delta("fc_1", PAYLOADS[1]),
+      done("fc_1", "call_1", "read_file"),
+    ];
+    const { chunks } = runStream(events);
+    const calls = accumulate({}, chunks);
+    expect(Object.keys(calls)).toEqual(["0", "1"]);
+    expect(JSON.parse(calls[0].args)).toEqual(JSON.parse(PAYLOADS[0]));
+    expect(JSON.parse(calls[1].args)).toEqual(JSON.parse(PAYLOADS[1]));
+  });
+
+  it("done carrying full arguments (no deltas) emits them once", () => {
+    const state = {};
+    const out1 = openaiResponsesToOpenAIResponse(added("fc_9", "call_9", "read_file"), state);
+    const out2 = openaiResponsesToOpenAIResponse({
+      type: "response.output_item.done",
+      item: { id: "fc_9", type: "function_call", call_id: "call_9", name: "read_file", arguments: PAYLOADS[0] },
+    }, state);
+    const calls = accumulate({}, [out1, out2]);
+    expect(JSON.parse(calls[0].args)).toEqual(JSON.parse(PAYLOADS[0]));
+  });
+
+  it("deltas without item_id fall back to the most recent call (legacy behavior)", () => {
+    const events = [
+      added("fc_0", "call_0", "read_file"),
+      { type: "response.function_call_arguments.delta", delta: PAYLOADS[0] },
+      done("fc_0", "call_0", "read_file"),
+    ];
+    const { chunks } = runStream(events);
+    const calls = accumulate({}, chunks);
+    expect(JSON.parse(calls[0].args)).toEqual(JSON.parse(PAYLOADS[0]));
+  });
+});
+
+describe("responses → claude end-to-end keeps parallel tool_use blocks separate", () => {
+  it("four read_file calls arrive as four parseable tool_use blocks", () => {
+    const state = initState(FORMATS.CLAUDE);
+    const out = [];
+    for (const ev of hostileOrdering()) {
+      for (const r of translateResponse(FORMATS.OPENAI_RESPONSES, FORMATS.CLAUDE, ev, state)) out.push(r);
+    }
+    for (const r of translateResponse(FORMATS.OPENAI_RESPONSES, FORMATS.CLAUDE, null, state)) out.push(r);
+
+    const starts = out.filter((r) => r?.type === "content_block_start" && r?.content_block?.type === "tool_use");
+    expect(starts).toHaveLength(4);
+    const partials = out.filter((r) => r?.delta?.type === "input_json_delta");
+    expect(partials).toHaveLength(4);
+    const bodies = partials.map((r) => JSON.parse(r.delta.partial_json).file_path).sort();
+    expect(bodies).toEqual([
+      "/docs/.gitignore",
+      "/docs/PRODUCT.md",
+      "/docs/ROADMAP.md",
+      "/docs/openapi.custom.yaml",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

This PR does two things:

1. **Adds `ocg/muse-spark-1.3-contributor`** (OpenCode Go) as a Responses-only model on `https://opencode.ai/zen/go/v1/responses`, so 9router clients on the OpenAI (`/v1/chat/completions`) and Anthropic (`/v1/messages`) endpoints are translated correctly to the OpenAI Responses API.
2. **Fixes parallel tool calls being merged into a single call** on the Responses→client streaming path, which surfaced to agents as `InputValidationError: ... could not be parsed as JSON` with N complete JSON payloads concatenated into one tool input.

## Why this is necessary

**Model support.** `opencode-go` had transports for chat/messages/responses but no Muse Spark entry, and `getModelTargetFormat` only special-cased `oc`/`opencode`. Without this, `ocg/muse-spark-1.3-contributor` requests never routed to `/responses`.

**Correctness bug (the important one).** When a Responses upstream emits parallel `function_call` items, the SSE stream legally orders all `output_item.added` events before any `output_item.done`. `openaiResponsesToOpenAIResponse` attributed every `function_call_arguments.delta` to a positional counter that only advanced on `done` — so **all fragments landed on `index: 0`**. The downstream client concatenated them:

```json
{"file_path":"/docs/PRODUCT.md"}{"file_path":"/docs/ROADMAP.md"}{"file_path":"/docs/openapi.custom.yaml"}...
```

…and its tool-input validation rejected the blob (`InputValidationError`). Retries appeared to "fix" it only because the model then called sequentially. This affected every Responses-upstream → chat/Claude streaming client with parallel tool use, not just Muse Spark.

## What changed (4 commits)

1. `feat(opencode-go): add muse-spark-1.3-contributor as responses-only model` — registry entry (`targetFormat` + `supportedFormats: ["openai-responses"]`) so chatCore skips the chat/messages transports and always translates; muse-spark special-case extended to `ocg`/`opencode-go` (covers future versions).
2. `fix(translator): single-stringify tool coercions for chat→Responses` — shared `clampResponsesCallId` / `coerceResponsesArguments` / `coerceResponsesOutput` in `translator/formats/responsesApi.js` (valid JSON passes through untouched, fragments → `"{}"`, null output → `""`); nameless calls/tools dropped instead of sent as `"_unknown"`; array system content joined into `instructions`.
3. `feat(opencode-go): dedicated Responses executor for muse-spark` — new `OpenCodeGoExecutor` routes muse-spark to `/responses` even with a stale `runtimeTransport`, normalizes caps/reasoning, sanitizes tool items (also protects native Responses clients, which skip translation). Non-muse models keep `DefaultExecutor` behavior.
4. `fix(translator): key Responses→chat tool indices by item_id` — index assigned at `added`-time, deltas routed by event `item_id` with most-recent fallback (sequential output byte-identical to before); `done` is idempotent and emits args sent only in `done`. `sanitizeToolArgs` already failed soft — no change needed there.

No registry `index.js` regen needed (no new registry file); `*muse*spark*` capability pattern already covers the new model (verified by test).

## Test evidence

- New `tests/unit/opencode-go-muse-spark-responses.test.js` (11 tests): routing guard, executor sanitization, adversarial quote/newline/unicode/emoji round-trips on both hops.
- New `tests/unit/responses-parallel-tool-calls.test.js` (5 tests): hostile event orderings incl. the exact 4×`read_file` payloads from the bug report, plus Responses→Claude end-to-end. Verified 3/5 fail on the pre-fix code while legacy-behavior tests stay green.
- Targeted suites (13 files: all `openai-responses-*`, `openai-to-claude*`, `bugs-codexCli-responses`, `format-roundtrip`, `golden-response-stream`) green; `eslint` clean on touched files.
- Full suite (~2200 tests): failure set byte-identical to the clean-tree baseline run — zero regressions (remaining failures are pre-existing environmental ones: live-network, sqlite, audit-source tests).
