### PR TITLE
fix(db): fail closed before migrating corrupted databases

### DIFF
--- a/src/lib/db/driver.js
+++ b/src/lib/db/driver.js
@@ -1,8 +1,14 @@
 import { ensureDirs, DATA_FILE } from "./paths.js";
+import { asDatabaseCorruptionError } from "./integrity.js";
 
 // Use global to survive Next.js dev hot-reload (module state resets on reload)
 if (!global._dbAdapter) global._dbAdapter = { instance: null, initPromise: null, logged: false };
 const state = global._dbAdapter;
+
+function stopOnCorruption(error) {
+  const corruption = asDatabaseCorruptionError(error, DATA_FILE);
+  if (corruption) throw corruption;
+}
 
 async function tryBunSqlite() {
   // Bun runtime only — built-in, no install needed
@@ -11,6 +17,7 @@ async function tryBunSqlite() {
     const { createBunSqliteAdapter } = await import("./adapters/bunSqliteAdapter.js");
     return await createBunSqliteAdapter(DATA_FILE);
   } catch (e) {
+    stopOnCorruption(e);
     console.warn(`[DB] bun:sqlite unavailable: ${e.message}`);
     return null;
   }
@@ -23,6 +30,7 @@ async function tryBetterSqlite() {
     const { createBetterSqliteAdapter } = await import("./adapters/betterSqliteAdapter.js");
     return createBetterSqliteAdapter(DATA_FILE);
   } catch (e) {
+    stopOnCorruption(e);
     console.warn(`[DB] better-sqlite3 unavailable: ${e.message}`);
     return null;
   }
@@ -37,6 +45,7 @@ async function tryNodeSqlite() {
     const { createNodeSqliteAdapter } = await import("./adapters/nodeSqliteAdapter.js");
     return await createNodeSqliteAdapter(DATA_FILE);
   } catch (e) {
+    stopOnCorruption(e);
     console.warn(`[DB] node:sqlite unavailable: ${e.message}`);
     return null;
   }
@@ -47,6 +56,7 @@ async function trySqlJs() {
     const { createSqlJsAdapter } = await import("./adapters/sqljsAdapter.js");
     return await createSqlJsAdapter(DATA_FILE);
   } catch (e) {
+    stopOnCorruption(e);
     console.warn(`[DB] sql.js unavailable: ${e.message}`);
     return null;
   }

--- a/src/lib/db/integrity.js
+++ b/src/lib/db/integrity.js
@@ -1,0 +1,57 @@
+import { BACKUPS_DIR, DATA_FILE } from "./paths.js";
+
+const CORRUPTION_CODES = new Set(["SQLITE_CORRUPT", "SQLITE_NOTADB"]);
+const CORRUPTION_PATTERNS = [
+  /database disk image is malformed/i,
+  /database corruption/i,
+  /file is not a database/i,
+  /malformed database schema/i,
+];
+
+function recoveryMessage(filePath, detail) {
+  return [
+    `[DB] Integrity check failed for ${filePath}: ${detail}.`,
+    "Startup stopped before schema migration or backup pruning.",
+    "No backup was restored automatically.",
+    `Preserve the damaged database, verify a candidate under ${BACKUPS_DIR} with PRAGMA quick_check, then restore it manually.`,
+  ].join(" ");
+}
+
+export class DatabaseCorruptionError extends Error {
+  constructor(filePath, detail, options = {}) {
+    super(recoveryMessage(filePath, detail), options);
+    this.name = "DatabaseCorruptionError";
+    this.code = "SQLITE_CORRUPT";
+    this.databasePath = filePath;
+  }
+}
+
+export function asDatabaseCorruptionError(error, filePath = DATA_FILE) {
+  if (error instanceof DatabaseCorruptionError) return error;
+
+  const code = String(error?.code || "").toUpperCase();
+  const message = String(error?.message || error || "unknown SQLite error");
+  const isCorruption = CORRUPTION_CODES.has(code)
+    || CORRUPTION_PATTERNS.some((pattern) => pattern.test(message));
+
+  if (!isCorruption) return null;
+  return new DatabaseCorruptionError(filePath, message, { cause: error });
+}
+
+export function assertDatabaseIntegrity(adapter, filePath = DATA_FILE) {
+  let rows;
+  try {
+    rows = adapter.all("PRAGMA quick_check");
+  } catch (error) {
+    throw asDatabaseCorruptionError(error, filePath)
+      || new DatabaseCorruptionError(filePath, String(error?.message || error), { cause: error });
+  }
+
+  const results = Array.isArray(rows)
+    ? rows.flatMap((row) => Object.values(row || {}).map((value) => String(value).trim()))
+    : [];
+  if (results.length === 1 && results[0].toLowerCase() === "ok") return;
+
+  const detail = results.length > 0 ? results.join("; ") : "PRAGMA quick_check returned no result";
+  throw new DatabaseCorruptionError(filePath, detail);
+}

--- a/src/lib/db/migrate.js
+++ b/src/lib/db/migrate.js
@@ -1,12 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
-import { LEGACY_FILES, DB_DIR } from "./paths.js";
+import { LEGACY_FILES, DB_DIR, DATA_FILE } from "./paths.js";
 import { TABLES, buildCreateTableSql, SCHEMA_VERSION } from "./schema.js";
 import { MIGRATIONS, latestVersion } from "./migrations/index.js";
 import { getMetaSync, setMetaSync } from "./helpers/metaStore.js";
 import { makeBackupDir, backupFile, backupDbLite, pruneOldBackups } from "./backup.js";
 import { getAppVersion } from "./version.js";
 import { stringifyJson } from "./helpers/jsonCol.js";
+import { assertDatabaseIntegrity } from "./integrity.js";
 
 // Marker file: prevents re-importing legacy JSON when user wipes data.sqlite.
 const MIGRATED_MARKER = path.join(DB_DIR, ".migrated-from-json");
@@ -215,6 +216,10 @@ function importLegacyDetails(adapter, data) {
 // ─── Main entry ──────────────────────────────────────────────────────────
 export async function runMigrationOnce(adapter) {
   if (_migratedAdapters.has(adapter)) return;
+
+  // Fail closed before any schema mutation or backup pruning. Recovery is
+  // deliberately manual so startup never replaces newer data with a backup.
+  assertDatabaseIntegrity(adapter, DATA_FILE);
   _migratedAdapters.add(adapter);
 
   // Capture freshness BEFORE migrations stamp _meta (otherwise we'd misclassify

--- a/tests/unit/db-integrity-safety.test.js
+++ b/tests/unit/db-integrity-safety.test.js
@@ -1,0 +1,113 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let tempDir;
+const originalDataDir = process.env.DATA_DIR;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-integrity-"));
+  process.env.DATA_DIR = tempDir;
+  delete global._dbAdapter;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  try { global._dbAdapter?.instance?.close?.(); } catch {}
+  delete global._dbAdapter;
+  vi.restoreAllMocks();
+  vi.doUnmock("@/lib/db/adapters/betterSqliteAdapter.js");
+  vi.doUnmock("@/lib/db/adapters/nodeSqliteAdapter.js");
+  vi.doUnmock("@/lib/db/adapters/sqljsAdapter.js");
+  vi.resetModules();
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+});
+
+function createBackupSentinels(count = 5) {
+  const root = path.join(tempDir, "db", "backups");
+  fs.mkdirSync(root, { recursive: true });
+  for (let i = 0; i < count; i += 1) {
+    const dir = path.join(root, `backup-${i}`);
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, "sentinel.txt"), String(i));
+    const timestamp = new Date(1_700_000_000_000 + i * 1_000);
+    fs.utimesSync(dir, timestamp, timestamp);
+  }
+  return root;
+}
+
+describe("database startup integrity gate", () => {
+  it("fails closed before schema mutation or backup pruning", async () => {
+    const backupsDir = createBackupSentinels();
+    const mutations = [];
+    const adapter = {
+      all(sql) {
+        if (/PRAGMA\s+quick_check/i.test(sql)) {
+          return [{ quick_check: "database disk image is malformed" }];
+        }
+        return [];
+      },
+      get() { return undefined; },
+      exec(sql) {
+        mutations.push(sql);
+        throw new Error(`unexpected mutation: ${sql}`);
+      },
+      transaction(fn) { return fn(); },
+      run() { throw new Error("unexpected mutation"); },
+    };
+
+    const { runMigrationOnce } = await import("@/lib/db/migrate.js");
+
+    let failure;
+    try {
+      await runMigrationOnce(adapter);
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toMatchObject({
+      name: "DatabaseCorruptionError",
+      code: "SQLITE_CORRUPT",
+    });
+    expect(failure.message).toContain("Startup stopped before schema migration or backup pruning");
+    expect(failure.message).toContain("No backup was restored automatically");
+    expect(mutations).toEqual([]);
+    expect(fs.readdirSync(backupsDir).sort()).toEqual([
+      "backup-0", "backup-1", "backup-2", "backup-3", "backup-4",
+    ]);
+  });
+
+  it("does not fall through to another driver after corruption is reported", async () => {
+    const dbDir = path.join(tempDir, "db");
+    fs.mkdirSync(dbDir, { recursive: true });
+    fs.writeFileSync(path.join(dbDir, "data.sqlite"), "damaged sqlite database");
+
+    const nodeFactory = vi.fn();
+    const sqlJsFactory = vi.fn();
+    vi.doMock("@/lib/db/adapters/betterSqliteAdapter.js", () => ({
+      createBetterSqliteAdapter() {
+        const error = new Error("database disk image is malformed");
+        error.code = "SQLITE_CORRUPT";
+        throw error;
+      },
+    }));
+    vi.doMock("@/lib/db/adapters/nodeSqliteAdapter.js", () => ({
+      createNodeSqliteAdapter: nodeFactory,
+    }));
+    vi.doMock("@/lib/db/adapters/sqljsAdapter.js", () => ({
+      createSqlJsAdapter: sqlJsFactory,
+    }));
+
+    const { getAdapter } = await import("@/lib/db/driver.js");
+
+    await expect(getAdapter()).rejects.toMatchObject({
+      name: "DatabaseCorruptionError",
+      code: "SQLITE_CORRUPT",
+    });
+    expect(nodeFactory).not.toHaveBeenCalled();
+    expect(sqlJsFactory).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Add a startup integrity gate that refuses to migrate a malformed SQLite database, preserves existing backups, and reports an actionable manual recovery path.

This addresses the detection and fail-closed portion of #3817.

## Problem

A malformed `data.sqlite` is not distinguished from an unavailable SQLite driver during startup:

1. Each adapter factory is wrapped in a catch-all fallback. Errors such as `SQLITE_CORRUPT` and `database disk image is malformed` are logged as "driver unavailable", then startup tries another adapter.
2. Once an adapter opens, `runMigrationOnce()` prunes old backups before checking database integrity.
3. `isFreshDb()` treats any `_meta` query failure as a fresh database, so a corruption error can enter the schema bootstrap path instead of producing a clear recovery failure.

The result is a misleading empty or unavailable database state, loss of the original corruption signal, and possible backup pruning before operators know recovery is required.

## Root cause

There is no integrity boundary between opening the database and mutating startup work. Driver fallback also conflates two different conditions:

- a runtime driver is unavailable, where fallback is correct;
- the database file is corrupt, where fallback must stop immediately.

The physical truncation risk in the `sql.js` full-image writer is real and independently reproducible, but an existing contribution already addresses it in #3523. This PR intentionally does not duplicate that patch.

## Changes

- Run `PRAGMA quick_check` before freshness detection, schema migration, additive schema sync, or backup pruning.
- Add a typed `DatabaseCorruptionError` for SQLite corruption codes and known malformed-database messages.
- Stop the adapter fallback chain when corruption is detected, while preserving fallback for actual driver availability failures.
- Emit a recovery message that identifies the database and backup directory, states that startup stopped before mutation/pruning, and tells the operator to verify a backup before restoring it manually.

## Recovery behavior

This change deliberately does not restore a backup automatically. Automatic rollback could overwrite newer recoverable data or select a stale backup without operator review.

On corruption, startup fails closed and leaves both the damaged database and existing backups untouched. Recovery remains an explicit operator action after running `PRAGMA quick_check` against candidate backups.

## Before and after

Before:

- corruption could be reported as a missing driver;
- fallback continued after `SQLITE_CORRUPT`;
- backup pruning and schema bootstrap had no preceding integrity check.

After:

- corruption retains a specific `SQLITE_CORRUPT` failure;
- no secondary adapter is attempted;
- no schema statement runs;
- no backup is pruned or auto-restored.

## Tests

Added `tests/unit/db-integrity-safety.test.js` covering:

1. A malformed `quick_check` result fails before schema mutation and preserves all backup sentinels.
2. A corruption error from the first adapter stops the fallback chain before node:sqlite or sql.js is attempted.

Validation:

- New regression tests fail on unpatched `upstream/master` and pass after the change.
- Core DB suites: 29/29 passed.
  - integrity safety: 2/2
  - driver fallback: 3/3
  - migration chain: 4/4
  - SQLite API parity: 20/20
- ESLint passed for all changed files.
- `git diff --check` passed.
- Five unrelated existing failures in concurrency aggregation and request-details tests reproduce identically on a clean `upstream/master` checkout.

## Scope

- No schema changes.
- No automatic backup restore.
- No WAL checkpoint or `synchronous` policy changes.
- No changes to provider data or application configuration.
- Atomic sql.js publishing remains scoped to #3523.
