### PR TITLE
fix(open-sse/codebuddy-cn): stop stripping legitimate agent system prompts over 2000 chars

### DIFF
--- a/open-sse/executors/codebuddy-cn.js
+++ b/open-sse/executors/codebuddy-cn.js
@@ -20,11 +20,12 @@ export class CodeBuddyExecutor extends DefaultExecutor {
 
     // Tencent's content filter flags CLI agent system prompts ("You are Claude
     // Code, Anthropic's official CLI...") as prompt injection / sensitive content
-    // and rejects the whole request. Detect agent system prompts (length catch-all
-    // + identity-marker regex) and replace them with a neutral one, while leaving
-    // legitimate user system prompts untouched. content may be a string or typed
-    // blocks ([{type:"text",text}]) depending on the incoming client format, so
-    // flatten before matching and preserve the original shape on replacement.
+    // and rejects the whole request. Detect agent system prompts via the
+    // Claude-Code-specific identity-marker regex below and replace them with a
+    // neutral one, while leaving legitimate user system prompts untouched.
+    // content may be a string or typed blocks ([{type:"text",text}]) depending
+    // on the incoming client format, so flatten before matching and preserve
+    // the original shape on replacement.
     const NEUTRAL_PROMPT = "You are a helpful AI assistant that helps with software engineering tasks.";
     const AGENT_PATTERN = /you are claude code|claude.?code.+official.+cli|anthropic.+official.+cli|anxthxropic.+official.+cli|you are (?:cursor|windsurf|cline|aider|continue|copilot|cody)|you are an? (?:ai )?(?:coding |code )?agent|cc_entrypoint\s*=\s*(?:cli|vscode|jetbrains|gui)|claude.?code.+issues|give feedback.+claude.?code|you are .{0,30}(?:powerful )?ai agent|orchestration capabilities|OhMyOpenCode|<agent-identity>|<Role>|<Behavior_Instructions>/i;
     const flatten = (content) =>
@@ -38,7 +39,7 @@ export class CodeBuddyExecutor extends DefaultExecutor {
         if (!message || message.role !== "system") return message;
         const text = flatten(message.content);
         if (!text) return message;
-        if (text.length > 2000 || AGENT_PATTERN.test(text)) {
+        if (AGENT_PATTERN.test(text)) {
           return typeof message.content === "string"
             ? { ...message, content: NEUTRAL_PROMPT }
             : { ...message, content: [{ type: "text", text: NEUTRAL_PROMPT }] };


### PR DESCRIPTION
## Summary

`CodeBuddyExecutor.prototype.transformRequest` in `open-sse/executors/codebuddy-cn.js` currently rewrites any `system` message to a generic 78-character `NEUTRAL_PROMPT` when `text.length > 2000` **OR** when it matches `AGENT_PATTERN`:

```javascript
// Current logic
if (text.length > 2000 || AGENT_PATTERN.test(text)) {
  return { ...message, content: NEUTRAL_PROMPT };
}
```

This PR removes the blanket `text.length > 2000` catch-all so legitimate large system prompts are no longer discarded, while keeping the `AGENT_PATTERN` identity-marker regex intact.

## The Problem

1. **False-positive persona wiping for multi-agent & orchestration frameworks.** Agent frameworks routinely send system prompts between 10k–50k characters containing behavioral instructions, tool specs, persona/SOUL guidelines, and workflow state.
2. The `text.length > 2000` catch-all causes **100% of these system prompts to be replaced** with:
   `"You are a helpful AI assistant that helps with software engineering tasks."`
   This drops `prompt_tokens` from ~8,000+ down to ~25 and wipes agent identity/instructions — models reply as generic default assistants instead of honoring the system prompt.
3. Tencent Copilot's WAF targets **Claude Code / Copilot spoofing signatures**, not generic large system messages. The existing `AGENT_PATTERN` regex already matches those specific signatures, so the length check is redundant for the filter it was meant to serve.

## Change

Remove the length catch-all, keeping only the signature-based detection:

```diff
-        if (text.length > 2000 || AGENT_PATTERN.test(text)) {
+        if (AGENT_PATTERN.test(text)) {
```

The `AGENT_PATTERN` regex is intentionally left unchanged — it already targets the Claude-Code/agent signatures that actually trigger Tencent's filter, without over-matching legitimate agent declarations.

## Verification & Testing

Tested against a live 9router native instance (v0.5.65 / current source v0.5.69) using `cbcn/deepseek-v4-flash`:

- **Before:** a 33,176-char system prompt → `prompt_tokens: 27`, generic assistant identity.
- **After:** the same 33,176-char system prompt → `prompt_tokens: 8254`, HTTP 200, model accurately complies with the configured persona/instructions.

The sanitizer still replaces messages whose content matches the Claude-Code-specific `AGENT_PATTERN` (unchanged behavior for the actual filter-triggering cases).
