### PR TITLE
fix(claude): decloak tool names on every claude→claude response path

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -117,7 +117,16 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   const clientRequestedStreaming = body.stream === true || sourceFormat === FORMATS.ANTIGRAVITY || sourceFormat === FORMATS.GEMINI || sourceFormat === FORMATS.GEMINI_CLI;
   const providerRequiresStreaming = PROVIDERS[provider]?.forceStream === true;
-  let stream = providerRequiresStreaming ? true : (body.stream !== false);
+  // Claude-format clients speak the Anthropic Messages API, where `stream`
+  // defaults to false — an omitted field is a non-streaming request. The old
+  // `!== false` default routed those into the streaming handler, where a
+  // same-format claude provider returned the upstream's complete-message JSON
+  // body through the raw passthrough stream with a spurious trailing
+  // "data: [DONE]" — and skipped OAuth tool-name decloaking (leaked the
+  // *_ide-suffixed names). Route them to the non-streaming handler, which
+  // decloaks (nonStreamingHandler) and returns clean JSON.
+  const defaultStreaming = sourceFormat === FORMATS.CLAUDE ? body.stream === true : body.stream !== false;
+  let stream = providerRequiresStreaming ? true : defaultStreaming;
 
   // Image generation models require non-streaming (Google v1internal:generateContent)
   const modelType = getModelType(alias, model);

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -21,8 +21,16 @@ const CODEX_SOURCE_TO_TARGET = {
 
 /**
  * Determine which SSE transform stream to use based on provider/format.
+ *
+ * Same-format requests normally take the raw passthrough stream (no
+ * translateResponse call at all). But when OAuth tool cloaking renamed the
+ * client's tools (toolNameMap present), every streamed tool_use block carries
+ * the suffixed name and MUST be decloaked before reaching the client — which
+ * happens in translateResponse's same-format branch. Route cloaked
+ * same-format streams through the translate stream so that branch actually
+ * runs; without a map, passthrough stays byte-exact as before.
  */
-function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, customToolNames, model, connectionId, body, onStreamComplete, apiKey, credentials }) {
+export function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, customToolNames, model, connectionId, body, onStreamComplete, apiKey, credentials }) {
   const isDroidCLI = userAgent?.toLowerCase().includes("droid") || userAgent?.toLowerCase().includes("codex-cli");
   // Responses-API providers (e.g. codex) emit Responses SSE → translate into client format
   const isResponsesProvider = PROVIDERS[provider]?.format === FORMATS.OPENAI_RESPONSES;
@@ -33,7 +41,7 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
     return createSSETransformStreamWithLogger(FORMATS.OPENAI_RESPONSES, codexTarget, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, customToolNames, credentials);
   }
 
-  if (needsTranslation(targetFormat, sourceFormat)) {
+  if (needsTranslation(targetFormat, sourceFormat) || toolNameMap?.size > 0) {
     return createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, customToolNames, credentials);
   }
 

--- a/tests/unit/claude-decloak-routing.test.js
+++ b/tests/unit/claude-decloak-routing.test.js
@@ -1,0 +1,109 @@
+// Regression tests for claude→claude OAuth tool-cloak decloak ROUTING.
+//
+// The original decloak fix put decloakStreamChunk() into translateResponse()'s
+// same-format branch, but the runtime never called it: buildTransformStream()
+// routed same-format streams to the raw passthrough stream (which forwards
+// bytes without ever consulting translateResponse), so OAuth-cloaked tool
+// names (*_ide) leaked to claude-format clients and every tool call was
+// rejected as unknown. These tests pin the routing itself:
+//   1. same-format + toolNameMap → translate stream → streamed tool_use names
+//      are restored, and claude framing (event: + data: pairs) is re-emitted
+//   2. same-format without a map → raw passthrough stays byte-exact (cloaked
+//      or foreign names pass through untouched — no cloak, nothing to restore)
+import { describe, it, expect } from "vitest";
+import { buildTransformStream } from "../../open-sse/handlers/chatCore/streamingHandler.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { CLAUDE_TOOL_SUFFIX } from "../../open-sse/config/appConstants.js";
+
+const CLOAKED = "get_weather" + CLAUDE_TOOL_SUFFIX; // "get_weather_ide"
+
+const claudeEvent = (obj) => `data: ${JSON.stringify(obj)}\n\n`;
+
+const toolUseStart = (name) => claudeEvent({
+  type: "content_block_start",
+  index: 1,
+  content_block: { type: "tool_use", id: "toolu_01XYZ", name, input: {} },
+});
+
+const messageStart = claudeEvent({ type: "message_start", message: { id: "msg_01X", usage: { input_tokens: 5, output_tokens: 0 } } });
+const messageStop = claudeEvent({ type: "message_stop" });
+
+/**
+ * Push `input` through the chosen transform stream and collect the decoded
+ * output WITHOUT closing the writer (close would run flush → usage-log side
+ * effects inappropriate for a unit test).
+ */
+async function pump(transform, input, expectedChunks) {
+  const writer = transform.writable.getWriter();
+  const reader = transform.readable.getReader();
+  const decoder = new TextDecoder();
+  const out = [];
+  const pumpDone = (async () => {
+    for (let i = 0; i < expectedChunks; i++) {
+      const { value } = await reader.read();
+      if (value) out.push(decoder.decode(value));
+    }
+  })();
+  await writer.write(new TextEncoder().encode(input));
+  await pumpDone;
+  writer.releaseLock();
+  reader.releaseLock();
+  return out;
+}
+
+describe("buildTransformStream claude→claude routing (OAuth tool cloak)", () => {
+  const baseArgs = {
+    provider: "claude",
+    sourceFormat: FORMATS.CLAUDE,
+    targetFormat: FORMATS.CLAUDE,
+    userAgent: "vitest",
+    reqLogger: null,
+    model: "claude-haiku-4-5-20251001",
+    connectionId: null,
+    body: null,
+    onStreamComplete: null,
+    apiKey: null,
+    customToolNames: null,
+  };
+
+  it("routes cloaked same-format streams through the translate stream and restores tool names", async () => {
+    const toolNameMap = new Map([[CLOAKED, "get_weather"]]);
+    const stream = buildTransformStream({ ...baseArgs, toolNameMap });
+    // 3 input events → translate mode re-emits 3 chunks (event: + data: framing)
+    const out = await pump(stream, messageStart + toolUseStart(CLOAKED) + messageStop, 3);
+    const text = out.join("");
+
+    // Tool name restored on the streamed tool_use content_block_start
+    expect(text).toContain('"name":"get_weather"');
+    expect(text).not.toContain(CLOAKED);
+
+    // Claude framing preserved (formatSSE re-emits event: lines from data.type)
+    expect(text).toContain("event: message_start");
+    expect(text).toContain("event: content_block_start");
+    expect(text).toContain("event: message_stop");
+  });
+
+  it("keeps the raw passthrough stream for same-format requests without a cloak map", async () => {
+    const stream = buildTransformStream({ ...baseArgs, toolNameMap: null });
+    // Passthrough forwards the data line (no decloak — nothing was cloaked)
+    const out = await pump(stream, toolUseStart(CLOAKED), 1);
+    const text = out.join("");
+    // Documents the routing boundary: without a map the name passes through
+    // untouched (providers that don't cloak never rename client tools).
+    expect(text).toContain(CLOAKED);
+  });
+
+  it("still uses the translate stream whenever formats differ (pre-existing behavior)", () => {
+    const stream = buildTransformStream({
+      ...baseArgs,
+      sourceFormat: FORMATS.OPENAI,
+      targetFormat: FORMATS.CLAUDE,
+      toolNameMap: null,
+    });
+    // Not asserting on chunk contents here (openai emission), only that a
+    // transform stream (readable/writable) is returned for cross-format.
+    expect(stream).toBeTruthy();
+    expect(stream.readable).toBeTruthy();
+    expect(stream.writable).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Problem

On OAuth Claude accounts (`cloakToolsOnOAuth`), every client tool is renamed with the `_ide` suffix before reaching Anthropic. `eb312bd4` added `decloakStreamChunk()` to `translateResponse()`'s same-format branch to restore the names — but the runtime never reaches that branch on either claude→claude path, so Claude-format clients (Claude Code, dsh, …) still receive `get_weather_ide` and reject every tool call as an unknown tool.

- **Streaming:** `buildTransformStream()` sends same-format requests through `createPassthroughStreamWithLogger()`, which forwards raw bytes and never calls `translateResponse`. The decloak branch is dead code on this path.
- **Non-streaming:** Claude-format requests that omit `stream` were treated as streaming (`body.stream !== false`), so the upstream's complete-message JSON came back through the passthrough stream with a spurious trailing `data: [DONE]` — also skipping decloak. Per the Anthropic Messages API, an omitted `stream` means non-streaming.

Reproducible on `master` with the included test: 3 of 3 routing tests fail before this change.

## Fix (2 lines of logic)

1. `streamingHandler.js` — route same-format streams through the translate stream **only when a `toolNameMap` is present**. Without a map, passthrough stays byte-exact as before, so non-OAuth and non-claude traffic is unaffected.
2. `chatCore.js` — for `sourceFormat === CLAUDE`, default `stream` to `false` when omitted (Messages API semantics). Those requests now hit `handleNonStreamingResponse`, which already decloaks via `decloakToolNames()` and returns clean JSON.

`handleForcedSSEToJson` needs no change: no `forceStream` provider has the `cloakToolsOnOAuth` quirk, so cloaked routes never reach it.

`buildTransformStream` is exported so the routing itself can be tested.

## Tests

- New `tests/unit/claude-decloak-routing.test.js` pins the routing: cloaked same-format → translate stream with names restored; no map → raw passthrough; differing formats → translate stream (pre-existing behavior).
- Full suite vs unmerged `master`: identical failure set (0 new failures).
