### PR TITLE
fix(claude): pass xhigh effort through on models with native support

### DIFF
--- a/open-sse/providers/thinkingLevels.js
+++ b/open-sse/providers/thinkingLevels.js
@@ -10,6 +10,7 @@ const L = {
   onOff: ["none", "thinking"],                                      // zai (binary), minimax (adaptive)
   openai: ["none", "minimal", "low", "medium", "high", "xhigh"],    // GPT-5.x / o-series (no "max")
   levelMax: ["none", "low", "medium", "high", "max"],               // claude-adaptive, kimi
+  claudeX: ["none", "low", "medium", "high", "xhigh", "max"],       // claude-adaptive w/ native xhigh
   budgetX: ["none", "low", "medium", "high", "xhigh", "max"],       // claude-budget
   gemini: ["minimal", "low", "medium", "high"],                     // gemini-3 thinkingLevel (no disable)
   hiMax: ["none", "high", "max"],                                   // deepseek (low/med→high, xhigh→max)
@@ -36,6 +37,16 @@ const CODEX_GPT_5_6_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh
 // Model-name pattern overrides (glob, first match wins) — more precise than format default.
 const PATTERN_THINKING = [
   { provider: "codex", pattern: "*gpt-6*", levels: CODEX_GPT_5_6_LEVELS },
+  // Claude adaptive models with native xhigh (verified against the upstream 400
+  // enum: "output_config.effort: Input should be 'low', 'medium', 'high', 'xhigh'
+  // or 'max'" on Opus 5; pi-ai catalog lists xhigh on Opus 4.7/4.8/5, Sonnet 5,
+  // Fable 5). Older adaptive models (4.6 era) top out at max and keep the
+  // xhigh→high clamp in thinkingUnified.
+  { provider: "claude", pattern: "claude-opus-5*", levels: L.claudeX },
+  { provider: "claude", pattern: "claude-opus-4-7*", levels: L.claudeX },
+  { provider: "claude", pattern: "claude-opus-4-8*", levels: L.claudeX },
+  { provider: "claude", pattern: "claude-sonnet-5*", levels: L.claudeX },
+  { provider: "claude", pattern: "claude-fable-5*", levels: L.claudeX },
   { provider: "codex", pattern: "*gpt-5.6-sol*", levels: [...CODEX_GPT_5_6_LEVELS, "ultra"] },
   { provider: "codex", pattern: "*gpt-5.6-terra*", levels: [...CODEX_GPT_5_6_LEVELS, "ultra"] },
   { provider: "codex", pattern: "*gpt-5.6-luna*", levels: CODEX_GPT_5_6_LEVELS },

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -246,7 +246,12 @@ function applyFormat(fmt, body, cfg, caps, supportedLevels) {
       if (canDisable) body.thinking = { type: "adaptive" };
       else delete body.thinking;
       const level = toLevel(eff);
-      body.output_config = { effort: level === "xhigh" || level === "auto" ? "high" : level };
+      // xhigh goes on the wire only where the model supports it natively
+      // (Opus 4.7/4.8/5, Sonnet 5, Fable 5 — per thinkingLevels overrides);
+      // older adaptive models (4.6 era) reject it, so keep clamping to high.
+      // "auto" is never a valid wire effort for claude-adaptive → always high.
+      const effort = level === "auto" || (level === "xhigh" && !supportedLevels?.includes("xhigh")) ? "high" : level;
+      body.output_config = { effort };
       break;
     }
     case "claude-budget": {

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -97,6 +97,20 @@ describe("applyThinking per provider format", () => {
     expect(out.output_config).toEqual({ effort: "high" });
     expect(out.thinking).toBeUndefined();
   });
+  it("claude 4.7+/5.x adaptive models pass xhigh through (native support)", () => {
+    // Upstream 400 enum on Opus 5: effort should be 'low', 'medium', 'high',
+    // 'xhigh' or 'max' — xhigh must not be degraded to high on these models.
+    for (const model of ["claude-opus-5", "claude-opus-4-7", "claude-opus-4-8", "claude-sonnet-5", "claude-fable-5-1"]) {
+      const out = apply("claude", model, { reasoning_effort: "xhigh" }, "claude");
+      expect(out.output_config).toEqual({ effort: "xhigh" });
+    }
+  });
+  it("older adaptive models (4.6 era) clamp xhigh to high", () => {
+    const out = apply("claude", "claude-opus-4-6", { reasoning_effort: "xhigh" }, "claude");
+    expect(out.output_config).toEqual({ effort: "high" });
+    const outSonnet = apply("claude", "claude-sonnet-4-6", { reasoning_effort: "xhigh" }, "claude");
+    expect(outSonnet.output_config).toEqual({ effort: "high" });
+  });
   it("claude haiku → enabled+budget", () => {
     const out = apply("claude", "claude-haiku-4.5", { reasoning_effort: "high" }, "claude");
     expect(out.thinking).toEqual({ type: "enabled", budget_tokens: 24576 });


### PR DESCRIPTION
## Problem

The `claude-adaptive` branch of `applyFormat()` clamps every `xhigh` effort to `high`. That clamp predates any Anthropic model accepting `xhigh`; the 5.x generation does — the upstream 400 enum on Opus 5 reads:

> `output_config.effort: Input should be 'low', 'medium', 'high', 'xhigh' or 'max'`

and the pi-ai catalog lists native `xhigh` on Opus 4.7 / 4.8 / 5, Sonnet 5 and Fable 5. So a user selecting `model(xhigh)` silently gets `high` — the highest reasoning level those models offer is unreachable through 9router.

Reproducible on `master` with the included test (`expected { effort: 'high' } to deeply equal { effort: 'xhigh' }`).

## Fix

Make the clamp capability-aware instead of unconditional:

- `thinkingLevels.js` — add a `claudeX` level set (`none/low/medium/high/xhigh/max`) and provider-scoped `PATTERN_THINKING` entries for the xhigh-capable models. This also fixes the dashboard level picker, which is driven by the same table.
- `thinkingUnified.js` — `applyFormat` already receives `supportedLevels`; consult it so `xhigh` reaches the wire only where the model takes it. The existing `auto → high` normalization (#3792) is preserved unchanged.

Older adaptive models (4.6 era) still match `L.levelMax` and keep the `xhigh → high` clamp — no behavior change for them.

## Tests

- `tests/translator/thinking-unified.test.js`: new case for 4.7+/5.x xhigh pass-through; existing "4.6 era clamps xhigh to high" case still passes.
- Full suite vs unmerged `master`: identical failure set (0 new failures).
