### PR TITLE
fix(providers): clear stale locks after successful validation

### DIFF
--- a/src/lib/db/repos/connectionsRepo.js
+++ b/src/lib/db/repos/connectionsRepo.js
@@ -10,6 +10,28 @@ const OPTIONAL_FIELDS = [
   "consecutiveUseCount", "idToken", "lastRefreshAt",
 ];
 
+const MODEL_LOCK_PREFIX = "modelLock_";
+
+function resetHealthStateOnActivation(existing, patch) {
+  if (patch?.testStatus !== "active") return patch;
+
+  const normalized = {
+    ...patch,
+    testStatus: "active",
+    lastError: Object.hasOwn(patch, "lastError") ? patch.lastError : null,
+    lastErrorAt: Object.hasOwn(patch, "lastErrorAt") ? patch.lastErrorAt : null,
+    errorCode: null,
+    rateLimitedUntil: null,
+    backoffLevel: 0,
+  };
+
+  for (const key of Object.keys(existing || {})) {
+    if (key.startsWith(MODEL_LOCK_PREFIX)) normalized[key] = null;
+  }
+
+  return normalized;
+}
+
 function rowToConn(row) {
   if (!row) return null;
   const extra = parseJson(row.data, {});
@@ -147,7 +169,8 @@ export async function createProviderConnection(data) {
     // access_token: never dedup — user manages duplicates manually
 
     if (existing) {
-      const merged = { ...existing, ...data, updatedAt: now };
+      const normalized = resetHealthStateOnActivation(existing, data);
+      const merged = { ...existing, ...normalized, updatedAt: now };
       upsert(db, merged);
       result = merged;
       return;
@@ -196,7 +219,8 @@ export async function updateProviderConnection(id, data) {
     const row = db.get(`SELECT * FROM providerConnections WHERE id = ?`, [id]);
     if (!row) { result = null; return; }
     const existing = rowToConn(row);
-    const merged = { ...existing, ...data, updatedAt: new Date().toISOString() };
+    const normalized = resetHealthStateOnActivation(existing, data);
+    const merged = { ...existing, ...normalized, updatedAt: new Date().toISOString() };
     upsert(db, merged);
     if (data.priority !== undefined) reorderInTx(db, existing.provider);
     result = merged;

--- a/tests/unit/db-sqlite-vs-lowdb.test.js
+++ b/tests/unit/db-sqlite-vs-lowdb.test.js
@@ -101,6 +101,104 @@ describe("DB SQLite layer — public API parity", () => {
     expect(back.providerSpecificData).toEqual({ foo: "bar" });
   });
 
+  it("providerConnections: successful validation clears stale routing locks", async () => {
+    const c = await sqliteDb.createProviderConnection({
+      provider: "health-reset-update",
+      authType: "oauth",
+      email: "update@example.com",
+      accessToken: "old-token",
+    });
+    await sqliteDb.updateProviderConnection(c.id, {
+      testStatus: "unavailable",
+      lastError: "Access denied",
+      lastErrorAt: "2026-09-05T00:00:00.000Z",
+      errorCode: 403,
+      backoffLevel: 3,
+      rateLimitedUntil: "2099-01-01T00:00:00.000Z",
+      modelLock_modelA: "2099-01-01T00:00:00.000Z",
+      modelLock_modelB: "2099-01-01T00:00:00.000Z",
+    });
+
+    await sqliteDb.updateProviderConnection(c.id, { testStatus: "active" });
+
+    const back = await sqliteDb.getProviderConnectionById(c.id);
+    expect(back).toMatchObject({
+      testStatus: "active",
+      lastError: null,
+      lastErrorAt: null,
+      errorCode: null,
+      backoffLevel: 0,
+      rateLimitedUntil: null,
+      modelLock_modelA: null,
+      modelLock_modelB: null,
+    });
+  });
+
+  it("providerConnections: re-saving valid OAuth credentials clears stale routing locks", async () => {
+    const existing = await sqliteDb.createProviderConnection({
+      provider: "health-reset-resave",
+      authType: "oauth",
+      email: "resave@example.com",
+      accessToken: "old-token",
+    });
+    await sqliteDb.updateProviderConnection(existing.id, {
+      testStatus: "unavailable",
+      lastError: "Access denied",
+      errorCode: 403,
+      backoffLevel: 2,
+      modelLock_modelA: "2099-01-01T00:00:00.000Z",
+    });
+
+    const resaved = await sqliteDb.createProviderConnection({
+      provider: "health-reset-resave",
+      authType: "oauth",
+      email: "resave@example.com",
+      accessToken: "new-token",
+      testStatus: "active",
+    });
+
+    expect(resaved.id).toBe(existing.id);
+    const back = await sqliteDb.getProviderConnectionById(existing.id);
+    expect(back).toMatchObject({
+      accessToken: "new-token",
+      testStatus: "active",
+      lastError: null,
+      errorCode: null,
+      backoffLevel: 0,
+      modelLock_modelA: null,
+    });
+  });
+
+  it("providerConnections: active soft warnings survive the health reset", async () => {
+    const c = await sqliteDb.createProviderConnection({
+      provider: "health-reset-warning",
+      authType: "oauth",
+      email: "warning@example.com",
+    });
+    await sqliteDb.updateProviderConnection(c.id, {
+      testStatus: "unavailable",
+      lastError: "Old failure",
+      modelLock_modelA: "2099-01-01T00:00:00.000Z",
+    });
+
+    const warningAt = "2026-09-06T00:00:00.000Z";
+    await sqliteDb.updateProviderConnection(c.id, {
+      testStatus: "active",
+      lastError: "Connected, but credits are exhausted",
+      lastErrorAt: warningAt,
+    });
+
+    const back = await sqliteDb.getProviderConnectionById(c.id);
+    expect(back).toMatchObject({
+      testStatus: "active",
+      lastError: "Connected, but credits are exhausted",
+      lastErrorAt: warningAt,
+      errorCode: null,
+      backoffLevel: 0,
+      modelLock_modelA: null,
+    });
+  });
+
   it("providerConnections: GitHub OAuth uses account identity as fallback name", async () => {
     const c = await sqliteDb.createProviderConnection({
       provider: "github",


### PR DESCRIPTION
## Summary

Clear stale connection health state whenever a connection is explicitly marked active after successful validation.

This fixes the split state reported in #3810, where the dashboard can show a revalidated connection as active while request routing still skips it because old model locks and backoff metadata remain persisted.

Closes #3810.

## Problem

Provider failures persist several fields on the connection record:

- `testStatus: "unavailable"`
- `lastError`, `lastErrorAt`, and `errorCode`
- `backoffLevel` and the legacy `rateLimitedUntil`
- dynamic per-model fields such as `modelLock_<model>`

A successful connection test later writes `testStatus: "active"`, while an OAuth re-login upserts fresh credentials with the same active status. Both paths use a shallow merge in `connectionsRepo`, so the old failure fields survive.

`getProviderCredentials()` reads the connection again and filters it through `isModelLockActive()`. The result is internally inconsistent:

1. the latest validation says the connection is active;
2. the old `modelLock_*` value still excludes it from live traffic;
3. requests continue to fail over until the stale lock expires or is otherwise cleared.

## Root cause

Connection activation was treated as a single-field status update instead of a health-state transition. The repository had no shared invariant tying `testStatus: "active"` to the routing metadata that controls eligibility.

This affected both repository write paths:

- `updateProviderConnection()`, used by connection tests;
- the existing-connection branch of `createProviderConnection()`, used by deduplicating OAuth credential re-saves.

## Fix

Add one repository-level normalization step for explicit activation updates:

- clear all existing `modelLock_*` fields;
- reset `backoffLevel`, `rateLimitedUntil`, and `errorCode`;
- clear historical error text and timestamps when the caller does not provide replacements;
- preserve an explicitly supplied active soft warning and timestamp, such as a valid credential with exhausted credits.

Keeping the invariant in the repository makes both activation paths consistent without provider-specific invalidation hooks.

## Behavior

### Before

```text
failed request -> modelLock_x set
successful test or OAuth re-login -> testStatus active
next request -> connection still skipped by modelLock_x
```

### After

```text
failed request -> modelLock_x set
successful test or OAuth re-login -> active status and stale routing state reset atomically
next request -> connection is eligible immediately
```

## Scope and safety

- The reset runs only when a write explicitly sets `testStatus` to `active`.
- Failed tests and unavailable transitions are unchanged.
- Credential values, provider selection strategies, and error classification rules are unchanged.
- Active soft warnings remain visible instead of being erased.

## Tests

Added regression coverage for:

1. successful validation clearing multiple model locks and historical error/backoff fields;
2. OAuth credential re-save clearing the same stale state on the deduplicating upsert path;
3. preservation of an explicitly supplied active soft warning.

Validation results:

- focused SQLite repository suite: 23/23 passed;
- deterministic related DB/auth suites: 35/35 passed;
- ESLint on changed files: passed;
- `git diff --check`: passed.

The broader concurrency run still has its three existing usage-aggregation failures. The same three failures reproduce on a clean `upstream/master` checkout, and this patch adds no new failure.
