### PR TITLE
fix(usage): record token usage for /v1/responses streams

### DIFF
--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -300,6 +300,16 @@ export function createSSEStream(options = {}) {
           totalContentLength += parsed.choices[0].delta.reasoning_content.length;
           accumulatedThinking += parsed.choices[0].delta.reasoning_content;
         }
+        // OpenAI Responses format - content/reasoning deltas
+        if (typeof parsed.delta === "string" && typeof parsed.type === "string") {
+          if (parsed.type === "response.output_text.delta") {
+            totalContentLength += parsed.delta.length;
+            accumulatedContent += parsed.delta;
+          } else if (parsed.type === "response.reasoning_summary_text.delta" || parsed.type === "response.reasoning_text.delta") {
+            totalContentLength += parsed.delta.length;
+            accumulatedThinking += parsed.delta;
+          }
+        }
         
         // Gemini format
         if (parsed.candidates?.[0]?.content?.parts) {

--- a/tests/unit/responses-stream-usage.test.js
+++ b/tests/unit/responses-stream-usage.test.js
@@ -1,0 +1,50 @@
+// Regression: Responses-format streams must accumulate text so usage estimation
+// fires when the upstream omits `usage` (see open-sse/utils/stream.js).
+import { describe, it, expect } from "vitest";
+import { initTranslators } from "open-sse/translator/index.js";
+import { createSSEStream } from "open-sse/utils/stream.js";
+
+async function runStream(events, opts) {
+  const sse = events.map(e => `event: ${e.type}\ndata: ${JSON.stringify(e)}\n\n`).join("");
+  let captured;
+  const ts = createSSEStream({
+    mode: "translate",
+    sourceFormat: "openai",
+    targetFormat: "openai-responses",
+    provider: "codex",
+    model: "m",
+    body: { messages: [{ role: "user", content: "hi ".repeat(200) }] },
+    onStreamComplete: (content, usage) => { captured = { content, usage }; },
+    ...opts
+  });
+  const rs = new ReadableStream({
+    start(c) { c.enqueue(new TextEncoder().encode(sse)); c.close(); }
+  });
+  await rs.pipeThrough(ts).pipeTo(new WritableStream({ write() {} }));
+  return captured;
+}
+
+describe("openai-responses stream usage", () => {
+  it("estimates usage when upstream omits it", async () => {
+    await initTranslators();
+    const out = await runStream([
+      { type: "response.created", response: { id: "r1" } },
+      { type: "response.output_item.added", output_index: 0, item: { id: "m1", type: "message", role: "assistant", content: [] } },
+      { type: "response.output_text.delta", item_id: "m1", output_index: 0, content_index: 0, delta: "x".repeat(400) },
+      { type: "response.completed", response: { id: "r1" } }
+    ]);
+    expect(out.content.content.length).toBe(400);
+    expect(out.usage?.completion_tokens).toBeGreaterThan(0);
+  });
+
+  it("prefers real usage from response.completed", async () => {
+    await initTranslators();
+    const out = await runStream([
+      { type: "response.created", response: { id: "r1" } },
+      { type: "response.output_text.delta", item_id: "m1", output_index: 0, content_index: 0, delta: "hello" },
+      { type: "response.completed", response: { id: "r1", usage: { input_tokens: 111, output_tokens: 22 } } }
+    ]);
+    expect(out.usage.prompt_tokens).toBe(111);
+    expect(out.usage.completion_tokens).toBe(22);
+  });
+});


### PR DESCRIPTION
Responses-format streams never produced Usage & Analytics rows. In the translate loop, content accumulation only covered Claude (`parsed.delta.text`), OpenAI chat (`choices[0].delta.content`) and Gemini shapes. OpenAI Responses events carry the text at `parsed.delta` as a plain string, so `totalContentLength` stayed 0.

When the upstream omitted `usage` in `response.completed`, extractUsage returned null and the estimate fallback had no content length to work from, so `saveUsageStats` hit its `in===0 && out===0` early return and wrote nothing. Prod confirms it: 1053 `FMT: openai → openai-responses` requests in 72h, 1070 `DONE ... IN 0 OUT 0` log lines, and zero usageHistory rows for the endpoint.

Accumulate `response.output_text.delta` into content and the reasoning-text deltas into thinking so estimation can fire.