### PR TITLE
feat(kiro): calibrate cache estimates from native credits

### DIFF
--- a/custom-server.js
+++ b/custom-server.js
@@ -3,6 +3,10 @@ const path = require("path");
 const fs = require("fs");
 const crypto = require("crypto");
 const { pathToFileURL } = require("url");
+const { AsyncLocalStorage } = require("node:async_hooks");
+
+// Shared with the bundled gateway without serializing internal state into headers.
+const responseDelivery = globalThis[Symbol.for("9router.responseDelivery")] ||= new AsyncLocalStorage();
 
 const origCreate = http.createServer.bind(http);
 
@@ -70,7 +74,17 @@ http.createServer = (...args) => {
     req.headers["x-9r-real-ip"] = ip;
     req.headers["x-9r-peer-token"] = PEER_TOKEN;
     if (viaProxy) req.headers["x-9r-via-proxy"] = "1";
-    return handler(req, res);
+    const delivery = { callbacks: new Set(), selected: null, finished: false };
+    const finishDelivery = success => {
+      if (delivery.finished) return;
+      delivery.finished = true;
+      for (const callback of delivery.callbacks) callback(success);
+      delivery.callbacks.clear();
+    };
+    res.once("finish", () => finishDelivery(res.statusCode >= 200 && res.statusCode < 300));
+    res.once("error", () => finishDelivery(false));
+    res.once("close", () => finishDelivery(false));
+    return responseDelivery.run(delivery, () => handler(req, res));
   };
   const server = origCreate(...rest, wrapped);
   server.once("listening", () => {

--- a/docs/KIRO_CREDIT_CACHE.md
+++ b/docs/KIRO_CREDIT_CACHE.md
@@ -1,0 +1,78 @@
+# Kiro native-credit cache estimates
+
+Design reference: `sub2api-kiro-enhanced` commit
+`68603603d603ae39f08d872b5db6699b75ce2d6c`, especially the README estimator
+scope/window policy, `backend/internal/service/kiro_dynamic_cache.go`,
+`kiro_cache_emulation*.go`, and the native translator/integrity paths.
+This is a JavaScript integration with 9router's existing pipeline, not an import
+of the source gateway, administration, deployment, or fixed-ratio simulation.
+
+## Feature mapping
+
+| Source feature | 9router implementation |
+| --- | --- |
+| Canonical prefix ladder | `open-sse/services/kiroCreditCache.js`: hash ordered outbound tools and messages; normalize current/history wrappers; retain continuation and model-visible configuration |
+| Native-credit calibration | Same module: compare cold/warm credits for a matching prefix, inference configuration and output count; require two pairs; use the lower envelope of the last eight pairs |
+| Account/endpoint/model scope | Hash connection identity (credential identity if absent), API key, principal/profile, endpoint, native model and inference configuration |
+| Model windows | `open-sse/config/kiroConstants.js`: Opus 5, five minutes; GPT-5.6 Terra, thirty minutes plus conversation ID |
+| Commit only successful observations | `kiroCacheDelivery.js`, `chatCore.js`, outer `src/sse/handlers/chat.js`, and `custom-server.js`: select the final response, then commit on successful HTTP finish; discard on errors/close |
+| Native stream integrity | Reuse KiroExecutor's CRC, framing, EOF, terminal and tool validation; exclude malformed/dropped events and truncation from learning without discarding otherwise usable output |
+| Fallback and side-generation isolation | Freeze before fetch; exclude HTTP/transport retries, token-refresh retries and integrity repair; only the response selected by the outer router can commit |
+| Protocol usage | Reuse existing usage names; nested OpenAI input is cache-inclusive, Anthropic input excludes cache. Preserve explicit native cache metrics (including zero) and existing public credit serialization |
+
+Auth-surface ordering/profile routing, stable session/continuation resolution,
+session-start replay, account selection and the Responses request/tool adapters
+were already present and remain in use. Account selection has its existing sticky
+round-robin policy, not a new conversation-to-account affinity map. Actual account
+identity scopes every observation, so rotation cannot reuse another account's state.
+The necessary response gaps fixed here are Kiro JSON conversion to Messages and
+Responses, and missing Kiro Responses SSE usage. JSON parser errors no longer embed
+raw payload excerpts. Existing typed/sized native integrity diagnostics remain.
+
+## Accounting and lifetime
+
+No cache savings are inferred without comparable successful observations. A credit
+reduction supplies a conservative savings fraction: appended uncached input and
+output cost remain in the warm bill. The 90% bound is a ceiling, not an assigned
+ratio. Two pairs are required before a later request uses the frozen estimate;
+adverse evidence affects subsequent requests. Cache creation is never invented
+from credits. Explicit native cache fields, including zero, override estimates.
+
+Sliding warmth is renewed only by successful observations and expires relative to
+request start, conservatively excluding very long generations. Calibration samples
+expire after thirty minutes. Overlapping requests can renew exact prefixes after
+successful delivery but cannot train cold/warm billing pairs. No asynchronous work
+occurs within tracker mutations. Each completion is idempotent.
+
+Limits: 1,024 scopes globally, 32 per account, 256 prefixes and 64 cold samples per
+scope, eight recent pairs. New scopes are rejected at capacity rather than evicting
+another account's warmth. Stored state contains hashes, counts, credits and expiry
+times, not prompts or credentials. Calibration/fingerprint/delivery metadata never
+enters response JSON, SSE, headers or usage logs. Existing `kiro_credits` and
+`kiro_credit_unit` behavior is retained.
+
+## Limits and verification
+
+- Only native `claude-opus-5` and `gpt-5.6-terra` are eligible, matching the pinned
+  reference; aliases resolving to them work. Sol, Luna and other models do not learn.
+- Estimates are process-local and reset on restart. They are not provider-reported
+  cache measurements, guaranteed retention, or a distributed cache tracker.
+- Prefix weights use 9router's existing approximate character/token convention.
+  Canonical strings, images, tool arguments and ordering remain significant.
+- Conversation ID alone does not isolate Opus. Changing continuation, time context,
+  tools, model-visible configuration or text can still make its prefix cold. Nothing
+  strips model-visible text to manufacture reuse across sessions.
+- Learning requires the `custom-server.js` HTTP delivery hook (`npm start` and the
+  standalone wrapper). Bare `next dev`, bare `next start`, or another host without
+  that hook retain normal usage but do not learn. HTTP finish confirms local writes,
+  not application-level acknowledgement by a remote client.
+- Discarded or synthesized response objects cannot commit; internal probes and
+  web-search/fusion generations cannot update the final response's observation.
+- No live Kiro/AWS requests were used for validation. Native EventStream fixtures
+  with valid CRCs exercise the real executor, translators and chatCore; local HTTP
+  socket tests verify successful finish, client disconnect, write error and HTTP error.
+
+Focused regression suites: `kiro-credit-cache.test.js`,
+`kiro-credit-delivery.test.js`, `kiro-credit-protocols.test.js`, and
+`kiro-credit-http.test.js`. Existing Kiro, cache accounting, Responses, base retry,
+session, custom-server and standalone tests provide compatibility coverage.

--- a/docs/KIRO_CREDIT_CACHE.md
+++ b/docs/KIRO_CREDIT_CACHE.md
@@ -14,7 +14,7 @@ of the source gateway, administration, deployment, or fixed-ratio simulation.
 | Canonical prefix ladder | `open-sse/services/kiroCreditCache.js`: hash ordered outbound tools and messages; normalize current/history wrappers; retain continuation and model-visible configuration |
 | Native-credit calibration | Same module: compare cold/warm credits for a matching prefix, inference configuration and output count; require two pairs; use the lower envelope of the last eight pairs |
 | Account/endpoint/model scope | Hash connection identity (credential identity if absent), API key, principal/profile, endpoint, native model and inference configuration |
-| Model windows | `open-sse/config/kiroConstants.js`: Opus 5, five minutes; GPT-5.6 Terra, thirty minutes plus conversation ID |
+| Family windows | `open-sse/config/kiroConstants.js`: Claude family, five minutes; GPT family, thirty minutes plus conversation ID |
 | Commit only successful observations | `kiroCacheDelivery.js`, `chatCore.js`, outer `src/sse/handlers/chat.js`, and `custom-server.js`: select the final response, then commit on successful HTTP finish; discard on errors/close |
 | Native stream integrity | Reuse KiroExecutor's CRC, framing, EOF, terminal and tool validation; exclude malformed/dropped events and truncation from learning without discarding otherwise usable output |
 | Fallback and side-generation isolation | Freeze before fetch; exclude HTTP/transport retries, token-refresh retries and integrity repair; only the response selected by the outer router can commit |
@@ -53,13 +53,26 @@ enters response JSON, SSE, headers or usage logs. Existing `kiro_credits` and
 
 ## Limits and verification
 
-- Only native `claude-opus-5` and `gpt-5.6-terra` are eligible, matching the pinned
-  reference; aliases resolving to them work. Sol, Luna and other models do not learn.
+- Family policies extend the pinned reference beyond its exact model allowlist.
+  Claude IDs (including Opus/Sonnet/Haiku forms) use a five-minute sliding window
+  and 4,096-token minimum prefix. GPT IDs and the registry's Sol/Terra/Luna
+  codenames use thirty minutes, a 1,024-token minimum, and require conversation ID;
+  a different conversation starts cold. Both retain the same credit calibration rules.
+- Classification accepts case/whitespace, dot/underscore/hyphen separators, optional
+  `kiro/` or `kr/`, and matching `anthropic`/`openai` namespaces. Future versions
+  with clear family names are eligible; unknown or conflicting families are disabled.
+  Thinking/agentic variants retain their family policy.
+- The registry maps full `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` IDs
+  (and synthetic thinking/agentic variants). It does not define bare codename
+  routing aliases to a particular version. Recognizing their family adds no routing
+  mapping. User-defined aliases are resolved before the estimator sees the native ID.
+  Policy normalization never rewrites that ID: distinct native model strings keep
+  separate scopes and calibration, even within one family.
 - Estimates are process-local and reset on restart. They are not provider-reported
   cache measurements, guaranteed retention, or a distributed cache tracker.
 - Prefix weights use 9router's existing approximate character/token convention.
   Canonical strings, images, tool arguments and ordering remain significant.
-- Conversation ID alone does not isolate Opus. Changing continuation, time context,
+- Conversation ID alone does not isolate Claude-family requests. Changing continuation, time context,
   tools, model-visible configuration or text can still make its prefix cold. Nothing
   strips model-visible text to manufacture reuse across sessions.
 - Learning requires the `custom-server.js` HTTP delivery hook (`npm start` and the

--- a/docs/KIRO_CREDIT_CACHE.md
+++ b/docs/KIRO_CREDIT_CACHE.md
@@ -1,91 +1,69 @@
 # Kiro native-credit cache estimates
 
-Design reference: `sub2api-kiro-enhanced` commit
-`68603603d603ae39f08d872b5db6699b75ce2d6c`, especially the README estimator
-scope/window policy, `backend/internal/service/kiro_dynamic_cache.go`,
-`kiro_cache_emulation*.go`, and the native translator/integrity paths.
-This is a JavaScript integration with 9router's existing pipeline, not an import
-of the source gateway, administration, deployment, or fixed-ratio simulation.
+Kiro cache simulation estimates cache reads from native-credit observations when
+Kiro does not report cache-token metrics. It does not assign a fixed cache ratio.
 
-## Feature mapping
+## Prefix reuse and calibration
 
-| Source feature | 9router implementation |
-| --- | --- |
-| Canonical prefix ladder | `open-sse/services/kiroCreditCache.js`: hash ordered outbound tools and messages; normalize current/history wrappers; retain continuation and model-visible configuration |
-| Native-credit calibration | Same module: compare cold/warm credits for a matching prefix, inference configuration and output count; require two pairs; use the lower envelope of the last eight pairs |
-| Account/endpoint/model scope | Hash connection identity (credential identity if absent), API key, principal/profile, endpoint, native model and inference configuration |
-| Family windows | `open-sse/config/kiroConstants.js`: Claude family, five minutes; GPT family, thirty minutes plus conversation ID |
-| Commit only successful observations | `kiroCacheDelivery.js`, `chatCore.js`, outer `src/sse/handlers/chat.js`, and `custom-server.js`: select the final response, then commit on successful HTTP finish; discard on errors/close |
-| Native stream integrity | Reuse KiroExecutor's CRC, framing, EOF, terminal and tool validation; exclude malformed/dropped events and truncation from learning without discarding otherwise usable output |
-| Fallback and side-generation isolation | Freeze before fetch; exclude HTTP/transport retries, token-refresh retries and integrity repair; only the response selected by the outer router can commit |
-| Protocol usage | Reuse existing usage names; nested OpenAI input is cache-inclusive, Anthropic input excludes cache. Preserve explicit native cache metrics (including zero) and existing public credit serialization |
+`open-sse/services/kiroCreditCache.js` canonicalizes the outbound request and hashes
+an ordered ladder of tools and message prefixes. Current and historical user
+wrappers share a canonical form, allowing append-only conversations to reuse an
+observed prefix. Text, images, tool arguments, ordering, continuation ID and other
+model-visible configuration remain significant; volatile text is not stripped to
+manufacture reuse. Prefix token weights approximate serialized characters / 4.
 
-Auth-surface ordering/profile routing, stable session/continuation resolution,
-session-start replay, account selection and the Responses request/tool adapters
-were already present and remain in use. Account selection has its existing sticky
-round-robin policy, not a new conversation-to-account affinity map. Actual account
-identity scopes every observation, so rotation cannot reuse another account's state.
-The necessary response gaps fixed here are Kiro JSON conversion to Messages and
-Responses, and missing Kiro Responses SSE usage. JSON parser errors no longer embed
-raw payload excerpts. Existing typed/sized native integrity diagnostics remain.
+A reuse index records successfully observed prefix fingerprints and their expiry.
+Calibration compares cold and warm native credits for matching prefixes, inference
+configuration and output-token counts. At least two comparable pairs are required.
+The estimate uses the lowest savings fraction among the last eight unexpired pairs,
+capped at 90%, weighted by the matched prefix's share of the request. Appended input
+and output costs remain in the warm bill, making this a conservative estimate.
+A zero-savings pair suppresses estimates until it expires or leaves that window.
 
-## Accounting and lifetime
+The estimate is frozen before the upstream request. A later successful observation
+can affect subsequent requests, but cannot change that request's frozen estimate.
+Positive estimates populate existing cache-read usage fields in Chat Completions,
+Responses and Messages, for JSON and SSE. Explicit native cache fields, including
+zero, take precedence. Cache creation is never invented from credits. OpenAI input
+counts include cached tokens; Messages input counts exclude them to avoid double
+counting. Existing public `kiro_credits` and `kiro_credit_unit` serialization is
+preserved; estimator and delivery metadata stay private.
 
-No cache savings are inferred without comparable successful observations. A credit
-reduction supplies a conservative savings fraction: appended uncached input and
-output cost remain in the warm bill. The 90% bound is a ceiling, not an assigned
-ratio. Two pairs are required before a later request uses the frozen estimate;
-adverse evidence affects subsequent requests. Cache creation is never invented
-from credits. Explicit native cache fields, including zero, override estimates.
+## Family policy and isolated state
 
-Sliding warmth is renewed only by successful observations and expires relative to
-request start, conservatively excluding very long generations. Calibration samples
-expire after thirty minutes. Overlapping requests can renew exact prefixes after
-successful delivery but cannot train cold/warm billing pairs. No asynchronous work
-occurs within tracker mutations. Each completion is idempotent.
+| Family | Sliding prefix window | Minimum prefix | Conversation isolation |
+| --- | --- | --- | --- |
+| Claude, including Opus/Sonnet/Haiku forms | 5 minutes | 4,096 tokens | No |
+| GPT, including Sol/Terra/Luna codenames | 30 minutes | 1,024 tokens | Required; a different conversation starts cold |
 
-Limits: 1,024 scopes globally, 32 per account, 256 prefixes and 64 cold samples per
-scope, eight recent pairs. New scopes are rejected at capacity rather than evicting
-another account's warmth. Stored state contains hashes, counts, credits and expiry
-times, not prompts or credentials. Calibration/fingerprint/delivery metadata never
-enters response JSON, SSE, headers or usage logs. Existing `kiro_credits` and
-`kiro_credit_unit` behavior is retained.
+`open-sse/config/kiroConstants.js` classifies clear family names across versions,
+case and supported separator/namespace forms. Unknown or conflicting families are
+disabled. Recognizing a codename's family does not create a model-routing alias.
 
-## Limits and verification
+Shared family policy does **not** mean shared calibration: state is isolated by the
+original native model ID, account or credential identity, API key, principal/profile,
+endpoint and inference configuration, with conversation ID added for GPT. Model ID
+normalization selects policy only; distinct native IDs retain separate state.
 
-- Family policies extend the pinned reference beyond its exact model allowlist.
-  Claude IDs (including Opus/Sonnet/Haiku forms) use a five-minute sliding window
-  and 4,096-token minimum prefix. GPT IDs and the registry's Sol/Terra/Luna
-  codenames use thirty minutes, a 1,024-token minimum, and require conversation ID;
-  a different conversation starts cold. Both retain the same credit calibration rules.
-- Classification accepts case/whitespace, dot/underscore/hyphen separators, optional
-  `kiro/` or `kr/`, and matching `anthropic`/`openai` namespaces. Future versions
-  with clear family names are eligible; unknown or conflicting families are disabled.
-  Thinking/agentic variants retain their family policy.
-- The registry maps full `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` IDs
-  (and synthetic thinking/agentic variants). It does not define bare codename
-  routing aliases to a particular version. Recognizing their family adds no routing
-  mapping. User-defined aliases are resolved before the estimator sees the native ID.
-  Policy normalization never rewrites that ID: distinct native model strings keep
-  separate scopes and calibration, even within one family.
-- Estimates are process-local and reset on restart. They are not provider-reported
-  cache measurements, guaranteed retention, or a distributed cache tracker.
-- Prefix weights use 9router's existing approximate character/token convention.
-  Canonical strings, images, tool arguments and ordering remain significant.
-- Conversation ID alone does not isolate Claude-family requests. Changing continuation, time context,
-  tools, model-visible configuration or text can still make its prefix cold. Nothing
-  strips model-visible text to manufacture reuse across sessions.
-- Learning requires the `custom-server.js` HTTP delivery hook (`npm start` and the
-  standalone wrapper). Bare `next dev`, bare `next start`, or another host without
-  that hook retain normal usage but do not learn. HTTP finish confirms local writes,
-  not application-level acknowledgement by a remote client.
-- Discarded or synthesized response objects cannot commit; internal probes and
-  web-search/fusion generations cannot update the final response's observation.
-- No live Kiro/AWS requests were used for validation. Native EventStream fixtures
-  with valid CRCs exercise the real executor, translators and chatCore; local HTTP
-  socket tests verify successful finish, client disconnect, write error and HTTP error.
+## Successful delivery and limits
 
-Focused regression suites: `kiro-credit-cache.test.js`,
-`kiro-credit-delivery.test.js`, `kiro-credit-protocols.test.js`, and
-`kiro-credit-http.test.js`. Existing Kiro, cache accounting, Responses, base retry,
-session, custom-server and standalone tests provide compatibility coverage.
+Learning requires a complete successful native event stream, valid positive metering
+and successful HTTP delivery of the selected response. Parse/CRC/terminal failures,
+truncation, aborted or failed writes, retries, fallbacks and internal side generations
+cannot train calibration. Overlapping requests may renew exact prefixes after
+successful delivery, but cannot train billing pairs. Completion is idempotent.
+
+Prefix warmth expires relative to request start and is renewed only on success.
+Calibration samples and pairs expire after 30 minutes. State is process-local, resets
+on restart, and is bounded to 1,024 scopes globally, 32 per account, 256 prefixes and
+64 cold samples per scope, and eight recent pairs. Stored state contains hashes and
+numeric observations, not prompts or credentials.
+
+Learning requires the `custom-server.js` HTTP delivery hook used by `npm start` and
+the standalone wrapper. Hosts without that hook retain normal usage but do not
+learn. HTTP finish confirms local writes, not remote application acknowledgement.
+Estimates are not provider-reported measurements, guaranteed retention or a
+distributed cache tracker.
+
+Regression coverage is in `kiro-credit-cache.test.js`, `kiro-credit-delivery.test.js`,
+`kiro-credit-protocols.test.js` and `kiro-credit-http.test.js` under `tests/unit/`.

--- a/docs/KIRO_CREDIT_CACHE.md
+++ b/docs/KIRO_CREDIT_CACHE.md
@@ -1,7 +1,8 @@
 # Kiro native-credit cache estimates
 
 Kiro cache simulation estimates cache reads from native-credit observations when
-Kiro does not report cache-token metrics. It does not assign a fixed cache ratio.
+Kiro does not report cache-token metrics. The existing 90% bound covers
+proven prefix reuse while dynamic calibration is still gathering observations.
 
 ## Prefix reuse and calibration
 
@@ -13,12 +14,22 @@ model-visible configuration remain significant; volatile text is not stripped to
 manufacture reuse. Prefix token weights approximate serialized characters / 4.
 
 A reuse index records successfully observed prefix fingerprints and their expiry.
-Calibration compares cold and warm native credits for matching prefixes, inference
-configuration and output-token counts. At least two comparable pairs are required.
-The estimate uses the lowest savings fraction among the last eight unexpired pairs,
-capped at 90%, weighted by the matched prefix's share of the request. Appended input
-and output costs remain in the warm bill, making this a conservative estimate.
-A zero-savings pair suppresses estimates until it expires or leaves that window.
+Calibration compares native credits per total token for matching prefixes and
+inference configuration, so cold and warm calls may have different output lengths.
+Each call uses its own valid total token count, with a validated input-plus-output
+fallback. Late input estimation refreshes the total before recording an observation.
+Missing or invalid normalization data cannot train billing pairs.
+
+With fewer than two valid pairs, the existing `LIMIT.maxSavings` ratio (0.9)
+applies only to
+canonically matched, unexpired prefixes. Cold requests and changed scopes receive
+no fallback. Once two valid pairs exist, dynamic calibration takes precedence,
+including a legitimate zero; it never falls back merely because savings are zero.
+The dynamic estimate uses the lowest savings fraction among the last eight
+unexpired pairs, capped at 90% and weighted by the matched prefix's share of input.
+The lowest observed cold density is retained. These conservative bounds reduce
+outlier influence, but total-token normalization does not establish separate
+input/output prices or guarantee an exact cache-hit rate.
 
 The estimate is frozen before the upstream request. A later successful observation
 can affect subsequent requests, but cannot change that request's frozen estimate.

--- a/docs/KIRO_CREDIT_CACHE.md
+++ b/docs/KIRO_CREDIT_CACHE.md
@@ -21,15 +21,23 @@ fallback. Late input estimation refreshes the total before recording an observat
 Missing or invalid normalization data cannot train billing pairs.
 
 With fewer than two valid pairs, the existing `LIMIT.maxSavings` ratio (0.9)
-applies only to
-canonically matched, unexpired prefixes. Cold requests and changed scopes receive
+applies only to canonically matched, unexpired prefixes. Cold requests and changed scopes receive
 no fallback. Once two valid pairs exist, dynamic calibration takes precedence,
 including a legitimate zero; it never falls back merely because savings are zero.
-The dynamic estimate uses the lowest savings fraction among the last eight
-unexpired pairs, capped at 90% and weighted by the matched prefix's share of input.
-The lowest observed cold density is retained. These conservative bounds reduce
-outlier influence, but total-token normalization does not establish separate
-input/output prices or guarantee an exact cache-hit rate.
+The lowest observed cold density is retained. The dynamic estimate selects the
+lowest credit-savings fraction among the last eight unexpired pairs, capped at 90%.
+Cached input still incurs credits, so credit savings are converted to inferred
+reuse with `reuse = clamp(credit_savings / (1 - d), 0, 1)`: GPT uses `d = 0.523`,
+and Claude uses `d = 0.525`. This conversion applies only after two valid pairs;
+it does not alter startup fallback or turn zero savings into positive reuse.
+
+Inferred reuse is weighted by the canonical matched prefix's share of input. Thus
+calibrated reads can exceed 90% but never exceed that structural bound. Policies
+without a discount retain their raw-savings behavior; unknown models remain
+estimator-disabled. The family constants are fixed modeling assumptions, not
+provider-reported cache measurements. Total-token normalization and differing
+input/output costs can bias the inference; model/traffic variation is not modeled,
+and an exact cache-hit rate is not guaranteed.
 
 The estimate is frozen before the upstream request. A later successful observation
 can affect subsequent requests, but cannot change that request's frozen estimate.

--- a/open-sse/config/kiroConstants.js
+++ b/open-sse/config/kiroConstants.js
@@ -28,10 +28,32 @@ export const KIRO_CODEWHISPERER_TARGET =
 export const KIRO_ENDPOINT_FALLBACK_STATUSES = new Set([401, 403, 404]);
 
 // Estimator policy, not a guarantee of provider cache retention or pricing.
-export const KIRO_CACHE_MODELS = Object.freeze({
-  "claude-opus-5": { ttlMs: 5 * 60_000, minTokens: 4096 },
-  "gpt-5.6-terra": { ttlMs: 30 * 60_000, minTokens: 1024, conversationScoped: true }
+export const KIRO_CACHE_FAMILIES = Object.freeze({
+  claude: Object.freeze({ ttlMs: 5 * 60_000, minTokens: 4096 }),
+  gpt: Object.freeze({ ttlMs: 30 * 60_000, minTokens: 1024, conversationScoped: true })
 });
+
+/** Classify policy only; never rewrite the outbound model or its cache scope. */
+export function resolveKiroCachePolicy(model) {
+  if (typeof model !== "string") return null;
+  let id = model.trim().toLowerCase().replace(/^(?:kiro|kr)\//, "");
+  const namespace = id.match(/^(anthropic|openai)[/.]/)?.[1];
+  if (namespace) id = id.slice(namespace.length + 1);
+  id = id.replace(/[._\s]+/g, "-");
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id)) return null;
+  const claude = /^(?:claude|opus|sonnet|haiku)(?:-|$)/.test(id);
+  // The Kiro registry identifies Sol, Terra and Luna as GPT variants. Bare
+  // codenames establish family, not a canonical version/routing alias.
+  const gpt = /^gpt(?:-|$)/.test(id) ||
+    /^(?:sol|terra|luna)(?:-thinking)?(?:-agentic)?$/.test(id);
+  if (claude && namespace !== "openai" && !/(?:^|-)(?:gpt|sol|terra|luna)(?:-|$)/.test(id)) {
+    return KIRO_CACHE_FAMILIES.claude;
+  }
+  if (gpt && namespace !== "anthropic" && !/(?:^|-)(?:claude|opus|sonnet|haiku)(?:-|$)/.test(id)) {
+    return KIRO_CACHE_FAMILIES.gpt;
+  }
+  return null;
+}
 export const KIRO_CACHE_LIMITS = Object.freeze({
   scopes: 1024, accountScopes: 32, prefixes: 256, samples: 64, pairs: 8,
   minPairs: 2, maxSavings: 0.9, calibrationTtlMs: 30 * 60_000

--- a/open-sse/config/kiroConstants.js
+++ b/open-sse/config/kiroConstants.js
@@ -27,6 +27,16 @@ export const KIRO_CODEWHISPERER_TARGET =
   "AmazonCodeWhispererStreamingService.GenerateAssistantResponse";
 export const KIRO_ENDPOINT_FALLBACK_STATUSES = new Set([401, 403, 404]);
 
+// Estimator policy, not a guarantee of provider cache retention or pricing.
+export const KIRO_CACHE_MODELS = Object.freeze({
+  "claude-opus-5": { ttlMs: 5 * 60_000, minTokens: 4096 },
+  "gpt-5.6-terra": { ttlMs: 30 * 60_000, minTokens: 1024, conversationScoped: true }
+});
+export const KIRO_CACHE_LIMITS = Object.freeze({
+  scopes: 1024, accountScopes: 32, prefixes: 256, samples: 64, pairs: 8,
+  minPairs: 2, maxSavings: 0.9, calibrationTtlMs: 30 * 60_000
+});
+
 // Public default CodeWhisperer profile ARNs (us-east-1), keyed by auth method.
 // Used when an account cannot resolve its own profileArn. Builder ID and social
 // (Google/GitHub) sign-ins map to different shared profiles.

--- a/open-sse/config/kiroConstants.js
+++ b/open-sse/config/kiroConstants.js
@@ -29,8 +29,8 @@ export const KIRO_ENDPOINT_FALLBACK_STATUSES = new Set([401, 403, 404]);
 
 // Estimator policy, not a guarantee of provider cache retention or pricing.
 export const KIRO_CACHE_FAMILIES = Object.freeze({
-  claude: Object.freeze({ ttlMs: 5 * 60_000, minTokens: 4096 }),
-  gpt: Object.freeze({ ttlMs: 30 * 60_000, minTokens: 1024, conversationScoped: true })
+  claude: Object.freeze({ ttlMs: 5 * 60_000, minTokens: 4096, cachedCreditRatio: 0.525 }),
+  gpt: Object.freeze({ ttlMs: 30 * 60_000, minTokens: 1024, conversationScoped: true, cachedCreditRatio: 0.523 })
 });
 
 /** Classify policy only; never rewrite the outbound model or its cache scope. */

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -102,6 +102,7 @@ export class BaseExecutor {
     let lastError = null;
     let lastStatus = 0;
     const retryAttemptsByUrl = {};
+    let attemptCount = 0;
 
     // Merge default retry config with provider-specific config
     const retryConfig = { ...DEFAULT_RETRY_CONFIG, ...this.config.retry };
@@ -141,6 +142,7 @@ export class BaseExecutor {
         const bodyStr = JSON.stringify(transformedBody);
         const fetchT0 = Date.now();
         dbg("FETCH", `${this.provider.toUpperCase()} → ${url} | body=${bodyStr.length}B | connectTimeout=${timeoutMs}ms`);
+        attemptCount++;
         const response = await proxyAwareFetch(url, {
           method: "POST",
           headers,
@@ -160,7 +162,7 @@ export class BaseExecutor {
           continue;
         }
 
-        return { response, url, headers, transformedBody };
+        return { response, url, headers, transformedBody, attemptCount };
       } catch (error) {
         clearTimeout(connectTimer);
         lastError = error;

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -10,6 +10,7 @@ import { refreshKiroToken } from "../services/tokenRefresh.js";
 import { SSE_DONE, SSE_HEADERS } from "../utils/sseConstants.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { STREAM_FIRST_CHUNK_TIMEOUT_MS } from "../config/runtimeConfig.js";
+import { prepareKiroCacheDelivery, bindKiroCacheDelivery } from "../services/kiroCacheDelivery.js";
 
 const KIRO_REPAIR_BUFFER_MAX_BYTES = 8 * 1024 * 1024;
 const KIRO_REPAIR_HEARTBEAT_MS = 10_000;
@@ -342,12 +343,25 @@ export class KiroExecutor extends BaseExecutor {
    * classify the status, and trigger account fallback/cooldown.
    */
   async execute(args) {
-    const result = await super.execute(args);
-    if (result?.response?.ok) this.attachIntegrityGate(result, args);
-    return result;
+    // Freeze warmth before sending, not after headers: another request may finish
+    // while this fetch is in flight. Each fallback/retry is excluded from learning.
+    const endpoint = this.buildUrl(args.model, args.stream, 0, args.credentials);
+    const transaction = args.observeCache === false ? null : prepareKiroCacheDelivery({
+      body: args.body, endpoint, credentials: args.credentials, signal: args.signal
+    });
+    try {
+      const result = await super.execute(args);
+      const eligible = result.attemptCount === 1 && result.url === endpoint;
+      if (!eligible || !result?.response?.ok) transaction?.complete(false);
+      if (result?.response?.ok) this.attachIntegrityGate(result, args, eligible ? transaction : null);
+      return result;
+    } catch (error) {
+      transaction?.complete(false);
+      throw error;
+    }
   }
 
-  attachIntegrityGate(result, args) {
+  attachIntegrityGate(result, args, transaction = null) {
     const abortController = new AbortController();
     const maxBytes = envPositiveInt("KIRO_TOOL_CALL_REPAIR_BUFFER_MAX_BYTES", KIRO_REPAIR_BUFFER_MAX_BYTES);
     const legacyTimeout = envPositiveInt("KIRO_TOOL_CALL_REPAIR_TIMEOUT_MS", STREAM_FIRST_CHUNK_TIMEOUT_MS);
@@ -379,12 +393,14 @@ export class KiroExecutor extends BaseExecutor {
             maxBytes,
             ttftTimeoutMs,
             stallTimeoutMs,
-            repairEnabled
+            repairEnabled,
+            transaction
           });
           if (abortController.signal.aborted) throw makeAbortError(abortController.signal.reason);
           controller.enqueue(bytes);
           controller.close();
         } catch (error) {
+          transaction?.complete(false);
           if (open && error.name === "AbortError") {
             controller.error(error);
           } else if (open && error.name !== "AbortError") {
@@ -401,6 +417,7 @@ export class KiroExecutor extends BaseExecutor {
         }
       },
       cancel(reason) {
+        transaction?.complete(false);
         open = false;
         clearInterval(heartbeatTimer);
         abortController.abort(reason || "client cancelled");
@@ -412,6 +429,7 @@ export class KiroExecutor extends BaseExecutor {
       statusText: result.response.statusText,
       headers: { ...SSE_HEADERS }
     });
+    bindKiroCacheDelivery(result.response, transaction);
   }
 
   async runIntegrityRecovery(rawResponse, args, options) {
@@ -421,7 +439,12 @@ export class KiroExecutor extends BaseExecutor {
       options,
       "initial"
     );
-    if (first.kind === "complete") return first.bytes;
+    if (first.kind === "complete") {
+      if (options.transaction) options.transaction.observation = first.observation;
+      return first.bytes;
+    }
+    // A repaired/fallback generation must not calibrate the original request.
+    options.transaction?.complete(false);
     if (first.kind === "terminal_stop" || first.kind === "upstream_error") {
       return this.integrityFailureSSE(first);
     }
@@ -522,11 +545,14 @@ export class KiroExecutor extends BaseExecutor {
 
   async readIntegrityAttempt(rawResponse, model, options, attempt) {
     let diagnostics;
+    let observation;
     const transformed = this.transformEventStreamToSSE(rawResponse, model, {
       maxToolBytes: Math.max(1, Math.floor(options.maxBytes / 2)),
       onTerminalState: (value) => {
         diagnostics = value;
-      }
+      },
+      cachePlan: attempt === "initial" ? options.transaction?.plan : null,
+      onCacheObservation: value => { observation = value; }
     });
     const reader = transformed.body.getReader();
     const chunks = [];
@@ -603,7 +629,7 @@ export class KiroExecutor extends BaseExecutor {
         return { kind: "short_final", diagnostics: safeDiagnostics };
       }
     }
-    return { kind: "complete", bytes: concatChunks(chunks, totalBytes), diagnostics: safeDiagnostics };
+    return { kind: "complete", bytes: concatChunks(chunks, totalBytes), diagnostics: safeDiagnostics, observation };
   }
 
   transformEventStreamToSSE(response, model, options = {}) {
@@ -631,6 +657,8 @@ export class KiroExecutor extends BaseExecutor {
       contextUsagePercentage: 0,
       hasContextUsage: false,
       hasMetering: false,
+      credits: 0,
+      observationInvalid: false,
       usage: null,
       inThinking: false,
       toolValidationError: null,
@@ -712,7 +740,7 @@ export class KiroExecutor extends BaseExecutor {
         if (!input || typeof input !== "object" || Array.isArray(input)) throw new Error("not an object");
         return input;
       } catch (error) {
-        throw new Error(`Kiro tool input must be valid object JSON (${error.message})`);
+        throw new Error("Kiro tool input must be valid object JSON");
       }
     };
     const emitTools = (controller) => {
@@ -783,6 +811,13 @@ export class KiroExecutor extends BaseExecutor {
       }
 
       const eventType = event.headers[":event-type"] || "";
+      if (!event.payload || typeof event.payload !== "object" ||
+          (Array.isArray(event.payload) && eventType !== "toolUseEvent") || /error|exception/i.test(eventType)) {
+        state.observationInvalid = true;
+      }
+      if (["assistantResponseEvent", "codeEvent"].includes(eventType) && typeof event.payload?.content !== "string") {
+        state.observationInvalid = true;
+      }
       const eventCountKey = KIRO_EVENT_TYPES.has(eventType) ? eventType : "other";
       eventCounts[eventCountKey] = (eventCounts[eventCountKey] || 0) + 1;
       if (eventType === "assistantResponseEvent" && typeof event.payload?.content === "string") {
@@ -814,6 +849,7 @@ export class KiroExecutor extends BaseExecutor {
       } else if (eventType === "reasoningContentEvent") {
         const value = event.payload?.reasoningContentEvent || event.payload || {};
         const content = typeof value === "string" ? value : value.text || value.content || "";
+        if (typeof content !== "string") state.observationInvalid = true;
         if (content) {
           state.hasReasoning = true;
           state.totalContentLength += content.length;
@@ -868,36 +904,49 @@ export class KiroExecutor extends BaseExecutor {
         }
       } else if (eventType === "contextUsageEvent") {
         const percentage = Number(event.payload?.contextUsagePercentage);
-        if (Number.isFinite(percentage)) {
+        if (event.payload?.contextUsagePercentage != null && Number.isFinite(percentage) && percentage >= 0 && percentage <= 100) {
           state.contextUsagePercentage = percentage;
           state.hasContextUsage = true;
-        }
+        } else state.observationInvalid = true;
       } else if (eventType === "meteringEvent") {
         state.hasMetering = true;
         const metering = event.payload?.meteringEvent || event.payload || {};
-        const credits = Number(metering.usage);
-        if (Number.isFinite(credits)) {
-          state.usage = {
-            ...(state.usage || {}),
-            kiro_credits: credits,
-            kiro_credit_unit: typeof metering.unit === "string" ? metering.unit : "credit"
-          };
+        const credits = typeof metering.usage === "number" ? metering.usage
+          : typeof metering.usage === "string" && metering.usage.trim() ? Number(metering.usage) : NaN;
+        // Preserve the established public credit fields. Calibration uses a
+        // separate validated accumulator and never serializes its private state.
+        const publicCredits = Number(metering.usage);
+        if (Number.isFinite(publicCredits)) {
+          state.usage = { ...(state.usage || {}), kiro_credits: publicCredits,
+            kiro_credit_unit: typeof metering.unit === "string" ? metering.unit : "credit" };
         }
+        if (Number.isFinite(credits) && credits > 0 && (!metering.unit || metering.unit === "credit")) {
+          state.credits += credits;
+        } else state.observationInvalid = true;
       } else if (eventType === "metricsEvent") {
         const metrics = event.payload?.metricsEvent || event.payload || {};
+        const cacheReadValue = metrics.cacheReadInputTokens ?? metrics.cache_read_input_tokens;
+        const cacheCreateValue = metrics.cacheCreationInputTokens ?? metrics.cache_creation_input_tokens;
+        const hasCache = metrics.cacheReadInputTokens !== undefined || metrics.cache_read_input_tokens !== undefined ||
+          metrics.cacheCreationInputTokens !== undefined || metrics.cache_creation_input_tokens !== undefined;
+        const values = [metrics.inputTokens, metrics.outputTokens, cacheReadValue, cacheCreateValue];
+        if (values.some(value => value !== undefined &&
+            (value === null || !Number.isSafeInteger(Number(value)) || Number(value) < 0))) state.observationInvalid = true;
         const prompt = Number(metrics.inputTokens) || 0;
         const completion = Number(metrics.outputTokens) || 0;
-        if (prompt || completion) {
+        if (prompt || completion || hasCache) {
+          const cacheRead = Math.max(0, Number(cacheReadValue) || 0);
+          const cacheCreate = Math.max(0, Number(cacheCreateValue) || 0);
+          const input = prompt + cacheRead + cacheCreate;
           state.usage = {
             ...(state.usage || {}),
-            prompt_tokens: prompt,
+            prompt_tokens: input,
             completion_tokens: completion,
-            total_tokens: prompt + completion
+            total_tokens: input + completion
           };
-          const cacheRead = Number(metrics.cacheReadInputTokens || metrics.cache_read_input_tokens) || 0;
-          const cacheCreate = Number(metrics.cacheCreationInputTokens || metrics.cache_creation_input_tokens) || 0;
-          if (cacheRead) state.usage.cache_read_input_tokens = cacheRead;
-          if (cacheCreate) state.usage.cache_creation_input_tokens = cacheCreate;
+          if (hasCache) {
+            state.usage.prompt_tokens_details = { cached_tokens: cacheRead, cache_creation_tokens: cacheCreate };
+          }
         }
       }
       return true;
@@ -1091,6 +1140,15 @@ export class KiroExecutor extends BaseExecutor {
           total_tokens: prompt + completion
         };
       }
+      const observation = {
+        credits: state.credits,
+        outputTokens: state.usage?.completion_tokens,
+        complete: hasOutput && state.hasMetering && Number.isFinite(state.credits) && state.credits > 0 &&
+          !state.observationInvalid && !state.toolValidationError &&
+          !state.droppedTools && ["complete", "tool_use"].includes(disposition) && !truncatedAfterOutput
+      };
+      options.onCacheObservation?.(observation);
+      if (observation.complete && state.credits > 0) state.usage = options.cachePlan?.apply(state.usage) || state.usage;
       const finishReason = truncatedAfterOutput
         ? "length"
         : state.hasToolCalls
@@ -1270,12 +1328,13 @@ function parseEventFrame(data) {
 
   const payloadBytes = data.subarray(headerEnd, totalLength - 4);
   if (payloadBytes.byteLength === 0) return { headers, payload: null };
-  const payloadText = decoder.decode(payloadBytes);
-  if (!payloadText.trim()) return { headers, payload: null };
   try {
+    const payloadText = new TextDecoder("utf-8", { fatal: true }).decode(payloadBytes);
+    if (!payloadText.trim()) return { headers, payload: null };
     return { headers, payload: JSON.parse(payloadText) };
-  } catch (error) {
-    throw new Error(`AWS EventStream payload is not valid JSON (${error.message})`);
+  } catch {
+    // Parser errors may contain a raw prompt/tool/reasoning excerpt.
+    throw new Error("AWS EventStream payload is not valid UTF-8 JSON");
   }
 }
 

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -932,6 +932,7 @@ export class KiroExecutor extends BaseExecutor {
         const values = [metrics.inputTokens, metrics.outputTokens, cacheReadValue, cacheCreateValue];
         if (values.some(value => value !== undefined &&
             (value === null || !Number.isSafeInteger(Number(value)) || Number(value) < 0))) state.observationInvalid = true;
+        if (metrics.inputTokens !== undefined || hasCache) state.hasInputMetrics = true;
         const prompt = Number(metrics.inputTokens) || 0;
         const completion = Number(metrics.outputTokens) || 0;
         if (prompt || completion || hasCache) {
@@ -1128,10 +1129,10 @@ export class KiroExecutor extends BaseExecutor {
         return;
       }
 
-      if (state.hasMetering && state.hasContextUsage && !state.usage?.total_tokens) {
-        const completion = state.totalContentLength
+      if (state.hasMetering && state.hasContextUsage && !state.hasInputMetrics) {
+        const completion = state.usage?.completion_tokens ?? (state.totalContentLength
           ? Math.max(1, Math.floor(state.totalContentLength / 4))
-          : 0;
+          : 0);
         const prompt = Math.floor(state.contextUsagePercentage * contextWindow / 100);
         state.usage = {
           ...(state.usage || {}),
@@ -1143,6 +1144,8 @@ export class KiroExecutor extends BaseExecutor {
       const observation = {
         credits: state.credits,
         outputTokens: state.usage?.completion_tokens,
+        inputTokens: state.hasInputMetrics || state.hasContextUsage ? state.usage?.prompt_tokens : undefined,
+        totalTokens: state.hasInputMetrics || state.hasContextUsage ? state.usage?.total_tokens : undefined,
         complete: hasOutput && state.hasMetering && Number.isFinite(state.credits) && state.credits > 0 &&
           !state.observationInvalid && !state.toolValidationError &&
           !state.droppedTools && ["complete", "tool_use"].includes(disposition) && !truncatedAfterOutput

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -30,6 +30,7 @@ import { stripUnsupportedModalities } from "../translator/concerns/modality.js";
 import { prefetchRemoteImages } from "../translator/concerns/prefetch.js";
 import { defaultClaudeToolType } from "../translator/concerns/toolCall.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
+import { forwardKiroCacheDelivery, cancelKiroCacheDelivery } from "../services/kiroCacheDelivery.js";
 
 /**
  * Core chat handler - shared between SSE and Worker
@@ -310,10 +311,14 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   const streamController = createStreamController({
     onDisconnect: (reason) => {
+      if (provider === "kiro") cancelKiroCacheDelivery(providerResponse);
       trackPendingRequest(model, provider, connectionId, false);
       if (onDisconnect) onDisconnect(reason);
     },
-    onError: () => trackPendingRequest(model, provider, connectionId, false),
+    onError: () => {
+      if (provider === "kiro") cancelKiroCacheDelivery(providerResponse);
+      trackPendingRequest(model, provider, connectionId, false);
+    },
     log, provider, model, reqTag
   });
 
@@ -430,6 +435,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
             signal: streamController.signal,
             log,
             proxyOptions,
+            observeCache: false,
           });
           if (retryResult.response.ok) {
             providerResponse = retryResult.response;
@@ -473,23 +479,27 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary, reqTag, log };
   const appendLog = (extra) => appendRequestLog({ model, provider, connectionId, ...extra }).catch(() => { });
   const trackDone = () => trackPendingRequest(model, provider, connectionId, false);
+  const withDelivery = result => {
+    if (provider === "kiro" && result?.success) forwardKiroCacheDelivery(providerResponse, result.response);
+    return result;
+  };
 
   // Provider forced streaming but client wants JSON
   if (!clientRequestedStreaming && providerRequiresStreaming) {
     const result = await handleForcedSSEToJson({ ...sharedCtx, providerResponse, sourceFormat, targetFormat: providerResponseFormat, customToolNames, trackDone, appendLog });
-    if (result) { streamController.handleComplete(); return result; }
+    if (result) { streamController.handleComplete(); return withDelivery(result); }
   }
 
   // True non-streaming response
   if (!stream) {
     const result = await handleNonStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat: providerResponseFormat, reqLogger, toolNameMap, customToolNames, trackDone, appendLog });
     streamController.handleComplete();
-    return result;
+    return withDelivery(result);
   }
 
   // Streaming response
   const { onStreamComplete, streamDetailId } = buildOnStreamComplete({ ...sharedCtx });
-  return handleStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat: providerResponseFormat, userAgent, reqLogger, toolNameMap, customToolNames, streamController, onStreamComplete, streamDetailId, credentials });
+  return withDelivery(await handleStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat: providerResponseFormat, userAgent, reqLogger, toolNameMap, customToolNames, streamController, onStreamComplete, streamDetailId, credentials }));
 }
 
 export function isTokenExpiringSoon(expiresAt, bufferMs = 5 * 60 * 1000) {

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -10,6 +10,8 @@ import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, sav
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
 import { ROLE, RESPONSES_ITEM } from "../../translator/schema/index.js";
+import { kiroToClaudeNonStreaming } from "../../translator/response/kiro-to-claude.js";
+import { kiroToResponsesUsage } from "../../translator/concerns/kiroUsage.js";
 
 function parseToolArguments(value) {
   if (!value) return {};
@@ -143,6 +145,15 @@ function openAICompletionToResponses(responseBody, customToolNames = null) {
  */
 export function translateNonStreamingResponse(responseBody, targetFormat, sourceFormat, customToolNames = null) {
   if (targetFormat === sourceFormat) return responseBody;
+  if (targetFormat === FORMATS.KIRO) {
+    if (sourceFormat === FORMATS.CLAUDE) return kiroToClaudeNonStreaming(responseBody);
+    if (sourceFormat === FORMATS.OPENAI_RESPONSES) {
+      const response = openAICompletionToResponses(responseBody, customToolNames);
+      response.usage = kiroToResponsesUsage(responseBody.usage);
+      return response;
+    }
+    return responseBody;
+  }
   // Provider responded in OpenAI Chat Completions shape but the client speaks
   // Responses API — convert so tool_calls/text surface as Responses `output`.
   if (targetFormat === FORMATS.OPENAI && sourceFormat === FORMATS.OPENAI_RESPONSES) {
@@ -289,7 +300,7 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
   if (contentType.includes("text/event-stream")) {
     const sseText = await providerResponse.text();
     const parsed = parseSSEToOpenAIResponse(sseText, model);
-    if (!parsed) {
+    if (!parsed || parsed.error) {
       appendLog({ status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}` });
       return createErrorResult(HTTP_STATUS.BAD_GATEWAY, "Invalid SSE response for non-streaming request");
     }

--- a/open-sse/services/kiroCacheDelivery.js
+++ b/open-sse/services/kiroCacheDelivery.js
@@ -1,0 +1,43 @@
+import { kiroCreditCache } from "./kiroCreditCache.js";
+
+const responses = new WeakMap();
+
+// custom-server owns this AsyncLocalStorage. No request header or wire field can
+// create a delivery receipt. Bare next dev/start has no receipt and cannot learn.
+export function prepareKiroCacheDelivery(request, cache = kiroCreditCache) {
+  const delivery = globalThis[Symbol.for("9router.responseDelivery")]?.getStore();
+  if (!delivery || delivery.finished) return null;
+  const plan = cache.prepare(request);
+  if (!plan) return null;
+  const transaction = {
+    plan, observation: null,
+    complete(success) {
+      plan.complete(transaction.observation, success && !request.signal?.aborted);
+      delivery.callbacks.delete(finish);
+    }
+  };
+  const finish = success => transaction.complete(success && delivery.selected === transaction);
+  delivery.callbacks.add(finish);
+  return transaction;
+}
+
+export function bindKiroCacheDelivery(response, transaction) {
+  if (response && transaction) responses.set(response, transaction);
+}
+
+export function forwardKiroCacheDelivery(upstream, downstream) {
+  bindKiroCacheDelivery(downstream, responses.get(upstream));
+  return downstream;
+}
+
+export function cancelKiroCacheDelivery(response) {
+  responses.get(response)?.complete(false);
+}
+
+// Called only for the response selected by the outer request router. Internal
+// fallback probes, fusion/search generations and discarded Responses never win.
+export function selectKiroCacheResponse(response) {
+  const delivery = globalThis[Symbol.for("9router.responseDelivery")]?.getStore();
+  if (delivery && !delivery.finished) delivery.selected = responses.get(response);
+  return response;
+}

--- a/open-sse/services/kiroCreditCache.js
+++ b/open-sse/services/kiroCreditCache.js
@@ -1,0 +1,155 @@
+import { createHash } from "node:crypto";
+import { KIRO_CACHE_MODELS, KIRO_CACHE_LIMITS as LIMIT } from "../config/kiroConstants.js";
+
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.keys(value).sort().map(key => [key, canonical(value[key])]));
+  }
+  return value;
+}
+const hash = value => createHash("sha256").update(JSON.stringify(canonical(value))).digest("hex");
+
+// Hash the translated, outbound semantics, not inbound metadata or byte prefixes.
+// Current and historical users share a wrapper. Only transport identity is omitted;
+// text (including time context), tools, images and tool results stay ordered and exact.
+function profile(body, policy) {
+  const state = body.conversationState;
+  const current = state.currentMessage.userInputMessage;
+  const { conversationState: _state, profileArn: _profile, inferenceConfig: _inference, ...prelude } = body;
+  const { history, currentMessage: _current, conversationId: _id, ...shape } = state;
+  let fingerprint = hash([prelude, shape]);
+  let tokens = 0;
+  const blocks = [];
+  const add = value => {
+    const json = JSON.stringify(canonical(value));
+    tokens += Math.ceil(json.length / 4);
+    fingerprint = hash([fingerprint, hash(value)]);
+    if (tokens >= policy.minTokens) blocks.push({ fingerprint, tokens });
+  };
+  for (const tool of current.userInputMessageContext?.tools || []) add({ tool });
+  for (const message of [...(history || []), { userInputMessage: current }]) {
+    if (!message.userInputMessage) { add(message); continue; }
+    const user = { ...message.userInputMessage };
+    // Historical turns may omit the current turn's transport defaults.
+    user.origin ??= current.origin;
+    user.modelId ??= current.modelId;
+    if (user.userInputMessageContext) {
+      user.userInputMessageContext = { ...user.userInputMessageContext };
+      delete user.userInputMessageContext.tools;
+      if (!Object.keys(user.userInputMessageContext).length) delete user.userInputMessageContext;
+    }
+    add({ userInputMessage: user });
+  }
+  return blocks.length ? { blocks, tokens } : null;
+}
+
+/** Bounded, process-local conservative calibration from comparable native credits. */
+export class KiroCreditCache {
+  constructor({ now = Date.now } = {}) {
+    this.now = now;
+    this.scopes = new Map();
+  }
+
+  prepare({ body, credentials, endpoint }) {
+    const state = body?.conversationState;
+    const model = state?.currentMessage?.userInputMessage?.modelId;
+    const policy = KIRO_CACHE_MODELS[model];
+    if (!policy || !endpoint || (policy.conversationScoped && !state.conversationId)) return null;
+    const data = credentials?.providerSpecificData || {};
+    const apiKey = data.authMethod === "api_key" ? (credentials.apiKey || credentials.accessToken) : null;
+    const account = credentials?.connectionId || credentials?.apiKey || credentials?.accessToken;
+    if (!account || (data.authMethod === "api_key" && !apiKey)) return null;
+    const p = profile(body, policy);
+    if (!p) return null;
+    const owner = hash(account);
+    const shape = hash(body.inferenceConfig || {});
+    const key = hash([owner, apiKey || "", data.userId, data.principalId,
+      data.authMethod, body.profileArn, endpoint, model, shape, policy.conversationScoped ? state.conversationId : ""]);
+    const started = this.now();
+    this.prune(started);
+    let scope = this.scopes.get(key);
+    if (!scope) {
+      if (this.scopes.size >= LIMIT.scopes ||
+          [...this.scopes.values()].filter(s => s.owner === owner).length >= LIMIT.accountScopes) return null;
+      scope = { owner, expires: started + LIMIT.calibrationTtlMs, active: 0, epoch: 0,
+        prefixes: new Map(), samples: new Map(), pairs: [] };
+      this.scopes.set(key, scope);
+    }
+    let matched = 0;
+    for (const b of p.blocks) {
+      if (scope.prefixes.get(b.fingerprint) > started) matched = b.tokens;
+    }
+    const exclusive = scope.active === 0;
+    const epoch = ++scope.epoch;
+    scope.active++;
+    const ratio = scope.pairs.length >= LIMIT.minPairs
+      ? Math.min(LIMIT.maxSavings, ...scope.pairs.map(pair => pair.ratio)) : 0;
+    const fraction = ratio * matched / p.tokens;
+    let done = false;
+    return {
+      apply(usage) {
+        // OpenAI prompt_tokens is inclusive. Native cache metrics take precedence,
+        // including explicit zero; cache creation is never invented from credits.
+        if (!usage || usage.prompt_tokens_details || usage.cache_read_input_tokens !== undefined ||
+            usage.cache_creation_input_tokens !== undefined) return usage;
+        const read = Math.floor(usage.prompt_tokens * fraction);
+        return read > 0 ? { ...usage, prompt_tokens_details: { cached_tokens: read } } : usage;
+      },
+      complete: (observation, success) => {
+        if (done) return;
+        done = true;
+        scope.active--;
+        const now = this.now();
+        const expires = started + policy.ttlMs;
+        if (!success || !observation?.complete || !Number.isFinite(observation.credits) ||
+            observation.credits <= 0 || !Number.isSafeInteger(observation.outputTokens) ||
+            observation.outputTokens < 0 || expires <= now || this.scopes.get(key) !== scope) return;
+        // Overlapping native generations can combine unrelated billing/cache effects.
+        // They may renew exact prefixes, but cannot contribute calibration pairs.
+        if (exclusive && epoch === scope.epoch) {
+          const sampleKey = fingerprint => hash([shape, observation.outputTokens, fingerprint]);
+          if (!matched) {
+            const k = sampleKey(p.blocks.at(-1).fingerprint);
+            const old = scope.samples.get(k);
+            if (!old || old.expires <= now || observation.credits < old.cold) {
+              if (old || scope.samples.size < LIMIT.samples) scope.samples.set(k, {
+                cold: observation.credits, expires: now + LIMIT.calibrationTtlMs
+              });
+            }
+          } else {
+            for (const b of [...p.blocks].reverse()) {
+              if (b.tokens > matched) continue;
+              const cold = scope.samples.get(sampleKey(b.fingerprint));
+              if (!cold || cold.expires <= now) continue;
+              // Appended input raises warm cost: ignoring that cost underestimates
+              // savings. No input/output price slope or fixed cache ratio is assumed.
+              scope.pairs.push({ ratio: Math.max(0, Math.min(LIMIT.maxSavings,
+                (cold.cold - observation.credits) / cold.cold)), expires: now + LIMIT.calibrationTtlMs });
+              scope.pairs = scope.pairs.slice(-LIMIT.pairs);
+              break;
+            }
+          }
+        }
+        scope.expires = now + LIMIT.calibrationTtlMs;
+        for (const b of p.blocks) {
+          const old = scope.prefixes.get(b.fingerprint);
+          if (old || scope.prefixes.size < LIMIT.prefixes) {
+            scope.prefixes.set(b.fingerprint, Math.max(old || 0, expires));
+          }
+        }
+      }
+    };
+  }
+
+  prune(now) {
+    for (const [key, scope] of this.scopes) {
+      if (scope.expires <= now && scope.active === 0) { this.scopes.delete(key); continue; }
+      for (const [fp, expires] of scope.prefixes) if (expires <= now) scope.prefixes.delete(fp);
+      for (const [key, sample] of scope.samples) if (sample.expires <= now) scope.samples.delete(key);
+      scope.pairs = scope.pairs.filter(pair => pair.expires > now);
+    }
+  }
+}
+
+export const kiroCreditCache = new KiroCreditCache();

--- a/open-sse/services/kiroCreditCache.js
+++ b/open-sse/services/kiroCreditCache.js
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { KIRO_CACHE_MODELS, KIRO_CACHE_LIMITS as LIMIT } from "../config/kiroConstants.js";
+import { resolveKiroCachePolicy, KIRO_CACHE_LIMITS as LIMIT } from "../config/kiroConstants.js";
 
 function canonical(value) {
   if (Array.isArray(value)) return value.map(canonical);
@@ -54,7 +54,7 @@ export class KiroCreditCache {
   prepare({ body, credentials, endpoint }) {
     const state = body?.conversationState;
     const model = state?.currentMessage?.userInputMessage?.modelId;
-    const policy = KIRO_CACHE_MODELS[model];
+    const policy = resolveKiroCachePolicy(model);
     if (!policy || !endpoint || (policy.conversationScoped && !state.conversationId)) return null;
     const data = credentials?.providerSpecificData || {};
     const apiKey = data.authMethod === "api_key" ? (credentials.apiKey || credentials.accessToken) : null;

--- a/open-sse/services/kiroCreditCache.js
+++ b/open-sse/services/kiroCreditCache.js
@@ -44,10 +44,22 @@ function profile(body, policy) {
   return blocks.length ? { blocks, tokens } : null;
 }
 
+function creditDensity(observation) {
+  let total = observation.totalTokens;
+  if (!Number.isSafeInteger(total) || total <= 0) {
+    if (!Number.isSafeInteger(observation.inputTokens) || observation.inputTokens < 0) return null;
+    total = observation.inputTokens + observation.outputTokens;
+  }
+  if (!Number.isSafeInteger(total) || total <= 0) return null;
+  const density = observation.credits / total;
+  return Number.isFinite(density) && density > 0 ? density : null;
+}
+
 /** Bounded, process-local conservative calibration from comparable native credits. */
 export class KiroCreditCache {
-  constructor({ now = Date.now } = {}) {
+  constructor({ now = Date.now, staticReadRatio = LIMIT.maxSavings } = {}) {
     this.now = now;
+    this.staticReadRatio = Number.isFinite(staticReadRatio) ? Math.max(0, Math.min(1, staticReadRatio)) : 0;
     this.scopes = new Map();
   }
 
@@ -83,8 +95,9 @@ export class KiroCreditCache {
     const exclusive = scope.active === 0;
     const epoch = ++scope.epoch;
     scope.active++;
+    // An available dynamic zero is authoritative; fallback is only for startup.
     const ratio = scope.pairs.length >= LIMIT.minPairs
-      ? Math.min(LIMIT.maxSavings, ...scope.pairs.map(pair => pair.ratio)) : 0;
+      ? Math.min(LIMIT.maxSavings, ...scope.pairs.map(pair => pair.ratio)) : this.staticReadRatio;
     const fraction = ratio * matched / p.tokens;
     let done = false;
     return {
@@ -107,14 +120,15 @@ export class KiroCreditCache {
             observation.outputTokens < 0 || expires <= now || this.scopes.get(key) !== scope) return;
         // Overlapping native generations can combine unrelated billing/cache effects.
         // They may renew exact prefixes, but cannot contribute calibration pairs.
-        if (exclusive && epoch === scope.epoch) {
-          const sampleKey = fingerprint => hash([shape, observation.outputTokens, fingerprint]);
+        const density = creditDensity(observation);
+        if (exclusive && epoch === scope.epoch && density !== null) {
+          const sampleKey = fingerprint => hash([shape, fingerprint]);
           if (!matched) {
             const k = sampleKey(p.blocks.at(-1).fingerprint);
             const old = scope.samples.get(k);
-            if (!old || old.expires <= now || observation.credits < old.cold) {
+            if (!old || old.expires <= now || density < old.coldDensity) {
               if (old || scope.samples.size < LIMIT.samples) scope.samples.set(k, {
-                cold: observation.credits, expires: now + LIMIT.calibrationTtlMs
+                coldDensity: density, expires: now + LIMIT.calibrationTtlMs
               });
             }
           } else {
@@ -122,10 +136,11 @@ export class KiroCreditCache {
               if (b.tokens > matched) continue;
               const cold = scope.samples.get(sampleKey(b.fingerprint));
               if (!cold || cold.expires <= now) continue;
-              // Appended input raises warm cost: ignoring that cost underestimates
-              // savings. No input/output price slope or fixed cache ratio is assumed.
+              // Compare credits per total token so varying output lengths can pair.
+              // Keep the lowest cold density and rolling savings lower envelope;
+              // no input/output price split or exact cache rate is inferred.
               scope.pairs.push({ ratio: Math.max(0, Math.min(LIMIT.maxSavings,
-                (cold.cold - observation.credits) / cold.cold)), expires: now + LIMIT.calibrationTtlMs });
+                (cold.coldDensity - density) / cold.coldDensity)), expires: now + LIMIT.calibrationTtlMs });
               scope.pairs = scope.pairs.slice(-LIMIT.pairs);
               break;
             }

--- a/open-sse/services/kiroCreditCache.js
+++ b/open-sse/services/kiroCreditCache.js
@@ -55,6 +55,13 @@ function creditDensity(observation) {
   return Number.isFinite(density) && density > 0 ? density : null;
 }
 
+// Cached input still incurs credits. Convert savings to reuse only when the
+// family has a discount model; an uncalibrated policy keeps its legacy savings.
+export function inferKiroCacheReuse(creditSavings, policy) {
+  if (policy?.cachedCreditRatio === undefined) return creditSavings;
+  return Math.max(0, Math.min(1, creditSavings / (1 - policy.cachedCreditRatio)));
+}
+
 /** Bounded, process-local conservative calibration from comparable native credits. */
 export class KiroCreditCache {
   constructor({ now = Date.now, staticReadRatio = LIMIT.maxSavings } = {}) {
@@ -96,9 +103,10 @@ export class KiroCreditCache {
     const epoch = ++scope.epoch;
     scope.active++;
     // An available dynamic zero is authoritative; fallback is only for startup.
-    const ratio = scope.pairs.length >= LIMIT.minPairs
-      ? Math.min(LIMIT.maxSavings, ...scope.pairs.map(pair => pair.ratio)) : this.staticReadRatio;
-    const fraction = ratio * matched / p.tokens;
+    const reuse = scope.pairs.length >= LIMIT.minPairs
+      ? inferKiroCacheReuse(Math.min(LIMIT.maxSavings, ...scope.pairs.map(pair => pair.creditSavings)), policy)
+      : this.staticReadRatio;
+    const fraction = reuse * matched / p.tokens;
     let done = false;
     return {
       apply(usage) {
@@ -139,7 +147,7 @@ export class KiroCreditCache {
               // Compare credits per total token so varying output lengths can pair.
               // Keep the lowest cold density and rolling savings lower envelope;
               // no input/output price split or exact cache rate is inferred.
-              scope.pairs.push({ ratio: Math.max(0, Math.min(LIMIT.maxSavings,
+              scope.pairs.push({ creditSavings: Math.max(0, Math.min(LIMIT.maxSavings,
                 (cold.coldDensity - density) / cold.coldDensity)), expires: now + LIMIT.calibrationTtlMs });
               scope.pairs = scope.pairs.slice(-LIMIT.pairs);
               break;

--- a/open-sse/translator/concerns/kiroUsage.js
+++ b/open-sse/translator/concerns/kiroUsage.js
@@ -1,0 +1,23 @@
+// The executor's nested Chat usage is cache-inclusive. Legacy flat Kiro usage
+// is cache-exclusive; retain that accepted input shape for existing callers.
+export function kiroToClaudeUsage(usage = {}) {
+  const read = usage.cache_read_input_tokens ?? usage.prompt_tokens_details?.cached_tokens;
+  const creation = usage.cache_creation_input_tokens ?? usage.prompt_tokens_details?.cache_creation_tokens;
+  const nested = usage.cache_read_input_tokens === undefined && usage.cache_creation_input_tokens === undefined;
+  return {
+    input_tokens: Math.max(0, (usage.prompt_tokens ?? 0) - (nested ? (read || 0) + (creation || 0) : 0)),
+    output_tokens: usage.completion_tokens ?? 0,
+    ...(typeof read === "number" ? { cache_read_input_tokens: read } : {}),
+    ...(typeof creation === "number" ? { cache_creation_input_tokens: creation } : {})
+  };
+}
+
+export function kiroToResponsesUsage(usage = {}) {
+  const input = usage.prompt_tokens ?? 0;
+  const output = usage.completion_tokens ?? 0;
+  const cached = usage.prompt_tokens_details?.cached_tokens;
+  return {
+    input_tokens: input, output_tokens: output, total_tokens: input + output,
+    ...(typeof cached === "number" ? { input_tokens_details: { cached_tokens: cached } } : {})
+  };
+}

--- a/open-sse/translator/response/kiro-to-claude.js
+++ b/open-sse/translator/response/kiro-to-claude.js
@@ -14,6 +14,7 @@
  * format is Claude and target is Kiro.
  */
 import { register } from "../index.js";
+import { kiroToClaudeUsage } from "../concerns/kiroUsage.js";
 import { FORMATS } from "../formats.js";
 
 function stopThinkingBlock(state, results) {
@@ -68,22 +69,7 @@ export function kiroToClaudeResponse(chunk, state) {
 
   // Track usage if present on the chunk.
   if (data.usage && typeof data.usage === "object") {
-    const promptTokens =
-      typeof data.usage.prompt_tokens === "number" ? data.usage.prompt_tokens : 0;
-    const outputTokens =
-      typeof data.usage.completion_tokens === "number"
-        ? data.usage.completion_tokens
-        : 0;
-    state.usage = { input_tokens: promptTokens, output_tokens: outputTokens };
-    // Claude clients read cache_read/cache_creation to price a turn and to size
-    // their prompt cache. Both spellings are accepted because the Kiro executor
-    // emits the Chat shape and passthrough responses use the nested details form.
-    const cacheRead = data.usage.cache_read_input_tokens
-      ?? data.usage.prompt_tokens_details?.cached_tokens;
-    const cacheCreation = data.usage.cache_creation_input_tokens
-      ?? data.usage.prompt_tokens_details?.cache_creation_tokens;
-    if (typeof cacheRead === "number") state.usage.cache_read_input_tokens = cacheRead;
-    if (typeof cacheCreation === "number") state.usage.cache_creation_input_tokens = cacheCreation;
+    state.usage = kiroToClaudeUsage(data.usage);
   }
 
   // First chunk → emit message_start.
@@ -260,17 +246,7 @@ export function kiroToClaudeNonStreaming(data) {
     content,
     model: data?.model || "kiro",
     stop_reason: convertFinishReason(choice?.finish_reason || "stop"),
-    usage: {
-      input_tokens: usage.prompt_tokens || 0,
-      output_tokens: usage.completion_tokens || 0,
-      // Same cache preservation as the streaming path above.
-      ...(typeof (usage.cache_read_input_tokens ?? usage.prompt_tokens_details?.cached_tokens) === "number"
-        ? { cache_read_input_tokens: usage.cache_read_input_tokens ?? usage.prompt_tokens_details.cached_tokens }
-        : {}),
-      ...(typeof (usage.cache_creation_input_tokens ?? usage.prompt_tokens_details?.cache_creation_tokens) === "number"
-        ? { cache_creation_input_tokens: usage.cache_creation_input_tokens ?? usage.prompt_tokens_details.cache_creation_tokens }
-        : {}),
-    },
+    usage: kiroToClaudeUsage(usage),
   };
 }
 

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -6,6 +6,7 @@ import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
 import { buildChunk } from "../concerns/chunk.js";
 import { buildUsage } from "../concerns/usage.js";
+import { kiroToResponsesUsage } from "../concerns/kiroUsage.js";
 import { fallbackToolCallId } from "../concerns/toolCall.js";
 import { reasoningDelta, extractReasoningText } from "../concerns/reasoning.js";
 import { ROLE, OPENAI_BLOCK, RESPONSES_ITEM, OPENAI_FINISH, MODEL_FALLBACK } from "../schema/index.js";
@@ -376,7 +377,8 @@ function sendCompleted(state, emit) {
         created_at: state.created,
         status: "completed",
         background: false,
-        error: null
+        error: null,
+        ...(state.provider === "kiro" && state.usage ? { usage: kiroToResponsesUsage(state.usage) } : {})
       }
     });
   }

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -24,6 +24,7 @@ import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
 import { getProjectIdForConnection } from "open-sse/services/projectId.js";
 import { stripModelContextMarker } from "open-sse/utils/modelMarkers.js";
+import { selectKiroCacheResponse } from "open-sse/services/kiroCacheDelivery.js";
 
 /**
  * Handle chat completion request
@@ -31,6 +32,10 @@ import { stripModelContextMarker } from "open-sse/utils/modelMarkers.js";
  * Format detection and translation handled by translator
  */
 export async function handleChat(request, clientRawRequest = null) {
+  return selectKiroCacheResponse(await handleChatRequest(request, clientRawRequest));
+}
+
+async function handleChatRequest(request, clientRawRequest) {
   let body;
   try {
     body = await request.json();

--- a/tests/helpers/kiroNative.js
+++ b/tests/helpers/kiroNative.js
@@ -1,0 +1,42 @@
+const encoder = new TextEncoder();
+function crc32(bytes) {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let i = 0; i < 8; i++) crc = (crc >>> 1) ^ ((crc & 1) ? 0xedb88320 : 0);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+export function kiroFrame(type, payload, raw = false) {
+  const name = encoder.encode(":event-type");
+  const value = encoder.encode(type);
+  const header = new Uint8Array(1 + name.length + 3 + value.length);
+  header[0] = name.length;
+  header.set(name, 1);
+  header[1 + name.length] = 7;
+  new DataView(header.buffer).setUint16(2 + name.length, value.length);
+  header.set(value, 4 + name.length);
+  const body = encoder.encode(raw ? payload : JSON.stringify(payload));
+  const bytes = new Uint8Array(16 + header.length + body.length);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(0, bytes.length);
+  view.setUint32(4, header.length);
+  bytes.set(header, 12);
+  bytes.set(body, 12 + header.length);
+  view.setUint32(8, crc32(bytes.subarray(0, 8)));
+  view.setUint32(bytes.length - 4, crc32(bytes.subarray(0, -4)));
+  return bytes;
+}
+export function nativeResponse({ credits = 10, metrics, stop = "end_turn", extra = [] } = {}) {
+  const frames = [kiroFrame("assistantResponseEvent", { content: "A complete answer." }),
+    kiroFrame("metricsEvent", metrics || { inputTokens: 10000, outputTokens: 20 }),
+    ...(credits === undefined ? [] : [kiroFrame("meteringEvent", { usage: credits, unit: "credit" })]),
+    kiroFrame("messageStopEvent", { stopReason: stop }), ...extra];
+  return new Response(new ReadableStream({ start(c) {
+    frames.forEach(f => c.enqueue(f)); c.close();
+  } }));
+}
+export function sseEvents(text) {
+  return text.split("\n").filter(l => l.startsWith("data: ") && l !== "data: [DONE]")
+    .map(l => JSON.parse(l.slice(6)));
+}

--- a/tests/unit/kiro-credit-cache.test.js
+++ b/tests/unit/kiro-credit-cache.test.js
@@ -77,7 +77,8 @@ describe("native-credit cache calibration", () => {
     expect(cached(cache.prepare(keyReq))).toBe(0);
   });
 
-  it.each([["claude-opus-5", 5], ["gpt-5.6-terra", 30]])("uses %s sliding TTL (%i minutes)", (model, minutes) => {
+  it.each([["claude-opus-5", 5], ["claude-sonnet-6", 5], ["haiku-5", 5],
+    ["gpt-5.6-terra", 30], ["gpt-5.6-luna", 30], ["sol", 30]])("uses %s sliding TTL (%i minutes)", (model, minutes) => {
     let now = 0;
     const cache = new KiroCreditCache({ now: () => now });
     const req = request(model);
@@ -147,10 +148,11 @@ describe("native-credit cache calibration", () => {
     const req = request(); train(cache, req);
     const native = { ...usage, prompt_tokens_details: { cached_tokens: 10000 } };
     expect(cache.prepare(req).apply(native)).toEqual(native);
-    expect(cache.prepare(request("claude-sonnet-4.6"))).toBeNull();
+    expect(cache.prepare(request("unknown-model"))).toBeNull();
   });
 
-  it.each([["claude-opus-5", 5], ["gpt-5.6-terra", 30]])("failed %s observations do not slide TTL", (model, minutes) => {
+  it.each([["claude-opus-5", 5], ["claude-sonnet-6", 5], ["haiku-5", 5],
+    ["gpt-5.6-terra", 30], ["gpt-5.6-luna", 30], ["sol", 30]])("failed %s observations do not slide TTL", (model, minutes) => {
     let now = 0;
     const cache = new KiroCreditCache({ now: () => now });
     const req = request(model); train(cache, req);
@@ -190,4 +192,68 @@ describe("native-credit cache calibration", () => {
     expect(cache.prepare(r)).toBeNull();
     expect(cached(cache.prepare(request()))).toBe(8000);
   });
+});
+
+const familyModels = [
+  ...["claude-opus-5", "claude-sonnet-4.6", "claude-haiku-4.5", "claude-3-5-sonnet",
+    "claude-opus-9.2", "claude-future", "opus-5", "sonnet", "haiku-7",
+    " CLAUDE_OPUS_5 ", "Claude.Sonnet.6", "kiro/claude-haiku-5", "kr/opus-5",
+    "anthropic.claude-sonnet-4-6", "claude-sonnet-5-thinking-agentic"
+  ].map(model => [model, 5, false]),
+  ...["gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.6-sol", "gpt-7.2", "gpt-next",
+    "terra", "luna", "sol", " TERRA ", "GPT_5_6_LUNA", "GPT.7.2",
+    "kr/gpt-6", "kiro/luna", "openai/gpt-7", "gpt-5.6-sol-thinking-agentic",
+    "luna-thinking-agentic"
+  ].map(model => [model, 30, true]),
+];
+
+describe("Kiro cache family policies", () => {
+  it.each(familyModels)("%s calibrates with a %i minute window (conversation scoped: %s)", (model, minutes, scoped) => {
+    let now = 0;
+    const cache = new KiroCreditCache({ now: () => now });
+    const req = request(model);
+    const eligible = cache.prepare(req);
+    expect(eligible).not.toBeNull();
+    eligible.complete(null, false);
+    const short = request(model);
+    short.body.conversationState.currentMessage.userInputMessage.content = "x".repeat(5000);
+    const shortPlan = cache.prepare(short);
+    expect(shortPlan !== null).toBe(scoped); // GPT minimum 1,024; Claude minimum 4,096.
+    shortPlan?.complete(null, false);
+    const tracker = new KiroCreditCache({ now: () => now });
+    train(tracker, req);
+    const probe = r => {
+      const p = tracker.prepare(r);
+      const read = cached(p);
+      p?.complete(null, false);
+      return read;
+    };
+    const warm = probe(req);
+    // Existing conservative floor can lose one token through floating-point arithmetic.
+    expect(warm).toBeGreaterThanOrEqual(7999);
+    expect(warm).toBeLessThanOrEqual(8000);
+    expect(probe(request(model, "other"))).toBe(scoped ? 0 : warm);
+    const missing = request(model); delete missing.body.conversationState.conversationId;
+    expect(probe(missing)).toBe(scoped ? 0 : warm);
+    now = minutes * MINUTE - 1;
+    expect(probe(req)).toBe(warm);
+    now++;
+    expect(probe(req)).toBe(0);
+  });
+
+  it.each([undefined, null, 5, {}, "", "auto", "unknown-model", "not-claude-opus-5",
+    "claudette", "gptish", "my-gpt-5", "lunar", "terra-unknown", "claude-gpt-5",
+    "gpt-claude-5", "openai/claude-opus-5", "anthropic/gpt-5", "unknown/claude-5"])(
+    "disables unknown or ambiguous model %s without allocating state", model => {
+      const cache = new KiroCreditCache();
+      const req = request(); req.body.conversationState.currentMessage.userInputMessage.modelId = model;
+      expect(cache.prepare(req)).toBeNull();
+      expect(cache.scopes.size).toBe(0);
+    });
+
+  it.each([["claude-sonnet-5", "claude-haiku-5"], ["gpt-5.6-luna", "gpt-5.6-sol"]])(
+    "keeps %s calibration isolated from another model in its family (%s)", (model, other) => {
+      const cache = new KiroCreditCache(); train(cache, request(model));
+      expect(cached(cache.prepare(request(other)))).toBe(0);
+    });
 });

--- a/tests/unit/kiro-credit-cache.test.js
+++ b/tests/unit/kiro-credit-cache.test.js
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import { KiroCreditCache } from "../../open-sse/services/kiroCreditCache.js";
+
+const MINUTE = 60_000;
+const user = (content = "cacheable input ".repeat(1400)) => ({ userInputMessage: {
+  content, modelId: "claude-opus-5", origin: "AI_EDITOR"
+} });
+function request(model = "claude-opus-5", session = "session-a") {
+  const currentMessage = user();
+  currentMessage.userInputMessage.modelId = model;
+  return {
+    endpoint: "https://q.example/generate",
+    credentials: { connectionId: "account-a", accessToken: "fixture-oauth" },
+    body: { conversationState: { conversationId: session, agentContinuationId: "continuation",
+      currentMessage, history: [], chatTriggerType: "MANUAL" }, inferenceConfig: { maxTokens: 100 } }
+  };
+}
+const usage = { prompt_tokens: 10000, completion_tokens: 20, total_tokens: 10020 };
+const observation = (credits, outputTokens = 20) => ({ credits, outputTokens, complete: true });
+function finish(cache, req, credits, success = true) {
+  const p = cache.prepare(req);
+  const result = p.apply(usage);
+  p.complete(observation(credits), success);
+  return result;
+}
+function train(cache, req) {
+  for (const credits of [10, 2, 2]) finish(cache, req, credits);
+}
+const cached = (plan) => plan?.apply(usage).prompt_tokens_details?.cached_tokens || 0;
+
+describe("native-credit cache calibration", () => {
+  it("has no fixed savings; requires two comparable successful cold/warm pairs", () => {
+    const cache = new KiroCreditCache();
+    const req = request();
+    for (const credits of [10, 2, 2]) expect(finish(cache, req, credits)).toEqual(usage);
+    const p = cache.prepare(req);
+    expect(cached(p)).toBe(8000);
+    expect(p.apply(usage).prompt_tokens).toBe(10000);
+    p.complete(observation(8), true);
+    expect(cached(p)).toBe(8000); // frozen plan, even after late metering
+    expect(cached(cache.prepare(req))).toBe(2000); // adverse evidence applies immediately
+  });
+
+  it("matches an append-only ladder with current/history wrappers normalized", () => {
+    const cache = new KiroCreditCache();
+    const req = request();
+    finish(cache, req, 10);
+    for (const credits of [3, 4]) {
+      req.body.conversationState.history.push(req.body.conversationState.currentMessage,
+        { assistantResponseMessage: { content: "answer" } });
+      req.body.conversationState.currentMessage = user("next question");
+      finish(cache, req, credits);
+    }
+    expect(cached(cache.prepare(req))).toBeGreaterThan(5000);
+  });
+
+  it("shares Opus calibration across sessions and OAuth rotation, but isolates accounts, endpoints, profiles, models and API keys", () => {
+    const cache = new KiroCreditCache();
+    train(cache, request());
+    const next = request("claude-opus-5", "session-b");
+    next.credentials.accessToken = "rotated-fixture-oauth";
+    expect(cached(cache.prepare(next))).toBe(8000);
+    for (const change of [
+      r => { r.credentials.connectionId = "account-b"; },
+      r => { r.endpoint += "/other"; },
+      r => { r.body.profileArn = "fixture-profile"; },
+      r => { r.body.conversationState.agentContinuationId = "different-continuation"; },
+      r => { r.body.conversationState.currentMessage.userInputMessage.modelId = "gpt-5.6-terra"; },
+    ]) {
+      const r = request(); change(r);
+      expect(cached(cache.prepare(r))).toBe(0);
+    }
+    const keyReq = request();
+    keyReq.credentials.providerSpecificData = { authMethod: "api_key" };
+    train(cache, keyReq);
+    keyReq.credentials.accessToken = "different-fixture-key";
+    expect(cached(cache.prepare(keyReq))).toBe(0);
+  });
+
+  it.each([["claude-opus-5", 5], ["gpt-5.6-terra", 30]])("uses %s sliding TTL (%i minutes)", (model, minutes) => {
+    let now = 0;
+    const cache = new KiroCreditCache({ now: () => now });
+    const req = request(model);
+    train(cache, req);
+    now += (minutes - 1) * MINUTE;
+    const probe = cache.prepare(req);
+    expect(cached(probe)).toBeGreaterThan(0);
+    probe.complete(null, false);
+    finish(cache, req, 2);
+    finish(cache, req, 2);
+    now += 2 * MINUTE;
+    expect(cached(cache.prepare(req))).toBeGreaterThan(0);
+    now += minutes * MINUTE;
+    expect(cached(cache.prepare(req))).toBe(0);
+  });
+
+  it("makes a different GPT conversation cold", () => {
+    const cache = new KiroCreditCache();
+    train(cache, request("gpt-5.6-terra"));
+    expect(cached(cache.prepare(request("gpt-5.6-terra", "other")))).toBe(0);
+    const req = request("gpt-5.6-terra");
+    delete req.body.conversationState.conversationId;
+    expect(cache.prepare(req)).toBeNull();
+  });
+
+  it.each([0, -1, NaN, Infinity, undefined, null, "2"])("rejects invalid credits %s without renewing warmth", credits => {
+    const cache = new KiroCreditCache();
+    const req = request();
+    finish(cache, req, credits);
+    train(cache, req);
+    expect(cached(cache.prepare(req))).toBe(8000);
+  });
+
+  it("failed, incomplete, slow and overlapping requests cannot calibrate", () => {
+    let now = 0;
+    const cache = new KiroCreditCache({ now: () => now });
+    const req = request();
+    finish(cache, req, 10, false);
+    const p = cache.prepare(req);
+    p.complete({ ...observation(10), complete: false }, true);
+    const slow = cache.prepare(req);
+    now += 6 * MINUTE;
+    slow.complete(observation(10), true);
+    train(cache, req);
+    expect(cached(cache.prepare(req))).toBe(8000);
+    const overlap = new KiroCreditCache();
+    const plans = Array.from({ length: 10 }, () => overlap.prepare(req));
+    for (const plan of plans.reverse()) {
+      plan.complete(observation(2), true);
+      plan.complete(observation(10), true);
+    }
+    expect(cached(overlap.prepare(req))).toBe(0);
+  });
+
+  it("does not pair differing output counts or inference configurations", () => {
+    const cache = new KiroCreditCache();
+    const req = request();
+    finish(cache, req, 10);
+    for (let i = 0; i < 3; i++) cache.prepare(req).complete(observation(2, 30), true);
+    req.body.inferenceConfig.maxTokens++;
+    for (let i = 0; i < 3; i++) finish(cache, req, 2);
+    expect(cached(cache.prepare(req))).toBe(0);
+  });
+
+  it("keeps fully cached native input authoritative without double counting", () => {
+    const cache = new KiroCreditCache();
+    const req = request(); train(cache, req);
+    const native = { ...usage, prompt_tokens_details: { cached_tokens: 10000 } };
+    expect(cache.prepare(req).apply(native)).toEqual(native);
+    expect(cache.prepare(request("claude-sonnet-4.6"))).toBeNull();
+  });
+
+  it.each([["claude-opus-5", 5], ["gpt-5.6-terra", 30]])("failed %s observations do not slide TTL", (model, minutes) => {
+    let now = 0;
+    const cache = new KiroCreditCache({ now: () => now });
+    const req = request(model); train(cache, req);
+    now = minutes * MINUTE - 1;
+    finish(cache, req, 2, false);
+    now += 2;
+    expect(cached(cache.prepare(req))).toBe(0);
+  });
+
+  it("retains semantic order and tool/image/continuation differences, but ignores object key order", () => {
+    const req = request();
+    req.body.conversationState.currentMessage.userInputMessage.userInputMessageContext = {
+      tools: [{ name: "one", schema: { type: "object" } }, { name: "two" }]
+    };
+    const cache = new KiroCreditCache(); train(cache, req);
+    const reordered = structuredClone(req);
+    reordered.body.inferenceConfig = Object.fromEntries(Object.entries(req.body.inferenceConfig).reverse());
+    expect(cached(cache.prepare(reordered))).toBeGreaterThan(0);
+    for (const change of [
+      r => r.body.conversationState.currentMessage.userInputMessage.userInputMessageContext.tools.reverse(),
+      r => { r.body.conversationState.currentMessage.userInputMessage.images = [{ source: { bytes: "fixture-image" } }]; },
+      r => { r.body.conversationState.agentContinuationId = "new-continuation"; },
+    ]) {
+      const r = structuredClone(req); change(r);
+      expect(cached(cache.prepare(r))).toBe(0);
+    }
+  });
+
+  it("bounds per-account scopes without evicting another account's calibration", () => {
+    const cache = new KiroCreditCache(); train(cache, request());
+    for (let i = 0; i < 32; i++) {
+      const r = request("gpt-5.6-terra", `session-${i}`);
+      r.credentials.connectionId = "other-account";
+      cache.prepare(r).complete(null, false);
+    }
+    const r = request("gpt-5.6-terra", "overflow"); r.credentials.connectionId = "other-account";
+    expect(cache.prepare(r)).toBeNull();
+    expect(cached(cache.prepare(request()))).toBe(8000);
+  });
+});

--- a/tests/unit/kiro-credit-cache.test.js
+++ b/tests/unit/kiro-credit-cache.test.js
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { KiroCreditCache } from "../../open-sse/services/kiroCreditCache.js";
+import { KiroCreditCache, inferKiroCacheReuse } from "../../open-sse/services/kiroCreditCache.js";
+
+import { resolveKiroCachePolicy } from "../../open-sse/config/kiroConstants.js";
 
 const MINUTE = 60_000;
 const user = (content = "cacheable input ".repeat(1400)) => ({ userInputMessage: {
@@ -37,11 +39,11 @@ describe("native-credit cache calibration", () => {
       expect(finish(cache, req, credits).prompt_tokens_details.cached_tokens).toBe(9000);
     }
     const p = cache.prepare(req);
-    expect(cached(p)).toBe(8000);
+    expect(cached(p)).toBe(10000);
     expect(p.apply(usage).prompt_tokens).toBe(10000);
     p.complete(observation(8), true);
-    expect(cached(p)).toBe(8000); // frozen plan, even after late metering
-    expect(cached(cache.prepare(req))).toBeCloseTo(2000, -1); // adverse evidence applies immediately
+    expect(cached(p)).toBe(10000); // frozen plan, even after late metering
+    expect(cached(cache.prepare(req))).toBeCloseTo(10000 * 0.2 / 0.475, -1); // adverse evidence applies immediately
   });
 
   it("matches an append-only ladder with current/history wrappers normalized", () => {
@@ -62,7 +64,7 @@ describe("native-credit cache calibration", () => {
     train(cache, request());
     const next = request("claude-opus-5", "session-b");
     next.credentials.accessToken = "rotated-fixture-oauth";
-    expect(cached(cache.prepare(next))).toBe(8000);
+    expect(cached(cache.prepare(next))).toBe(10000);
     for (const change of [
       r => { r.credentials.connectionId = "account-b"; },
       r => { r.endpoint += "/other"; },
@@ -112,7 +114,7 @@ describe("native-credit cache calibration", () => {
     const req = request();
     finish(cache, req, credits);
     train(cache, req);
-    expect(cached(cache.prepare(req))).toBe(8000);
+    expect(cached(cache.prepare(req))).toBe(10000);
   });
 
   it("failed, incomplete, slow and overlapping requests cannot calibrate", () => {
@@ -126,7 +128,7 @@ describe("native-credit cache calibration", () => {
     now += 6 * MINUTE;
     slow.complete(observation(10), true);
     train(cache, req);
-    expect(cached(cache.prepare(req))).toBe(8000);
+    expect(cached(cache.prepare(req))).toBe(10000);
     const overlap = new KiroCreditCache();
     const plans = Array.from({ length: 10 }, () => overlap.prepare(req));
     for (const plan of plans.reverse()) {
@@ -194,7 +196,7 @@ describe("native-credit cache calibration", () => {
     }
     const r = request("gpt-5.6-terra", "overflow"); r.credentials.connectionId = "other-account";
     expect(cache.prepare(r)).toBeNull();
-    expect(cached(cache.prepare(request()))).toBe(8000);
+    expect(cached(cache.prepare(request()))).toBe(10000);
   });
 });
 
@@ -234,8 +236,8 @@ describe("Kiro cache family policies", () => {
     };
     const warm = probe(req);
     // Existing conservative floor can lose one token through floating-point arithmetic.
-    expect(warm).toBeGreaterThanOrEqual(7999);
-    expect(warm).toBeLessThanOrEqual(8000);
+    expect(warm).toBeGreaterThanOrEqual(9999);
+    expect(warm).toBeLessThanOrEqual(10000);
     expect(probe(request(model, "other"))).toBe(scoped ? 0 : warm);
     const missing = request(model); delete missing.body.conversationState.conversationId;
     expect(probe(missing)).toBe(scoped ? 0 : warm);
@@ -272,11 +274,11 @@ describe("real-traffic credit calibration", () => {
     const cold = cache.prepare(req); expect(cached(cold)).toBe(0);
     cold.complete(observed(10, 9000, 1000), true);
     const warm1 = cache.prepare(req); expect(cached(warm1)).toBe(4000);
-    warm1.complete(observed(2, 9000, 3000), true);
+    warm1.complete(observed(9, 9000, 3000), true);
     const warm2 = cache.prepare(req); expect(cached(warm2)).toBe(4000);
-    warm2.complete(observed(4, 9000, 1000), true);
+    warm2.complete(observed(8, 9000, 1000), true);
     const dynamic = cache.prepare(req);
-    expect(cached(dynamic)).toBe(6000); // lower envelope: min(5/6, 0.6)
+    expect(cached(dynamic)).toBeCloseTo(10000 * 0.2 / 0.475, -1); // min savings = 0.2
     expect(cached(warm2)).toBe(4000); // prepared estimate stays frozen
   });
   it("dynamic zero overrides static fallback even with unequal outputs", () => {
@@ -291,16 +293,16 @@ describe("real-traffic credit calibration", () => {
     const cache = new KiroCreditCache(); const req = request();
     const cold = observed(10, 9000, 1000); cold.totalTokens = total;
     cache.prepare(req).complete(cold, true);
-    cache.prepare(req).complete(observed(4, 9000, 1000), true);
-    cache.prepare(req).complete(observed(5, 9000, 11000), true);
-    expect(cached(cache.prepare(req))).toBe(6000);
+    cache.prepare(req).complete(observed(8, 9000, 1000), true);
+    cache.prepare(req).complete(observed(15, 9000, 11000), true);
+    expect(cached(cache.prepare(req))).toBeCloseTo(10000 * 0.2 / 0.475, -1);
   });
   it("prefers an actual total, and skips invalid normalization instead of training", () => {
     const cache = new KiroCreditCache(); const req = request();
     cache.prepare(req).complete(observed(10, 9000, 1000, 20000), true);
-    cache.prepare(req).complete(observed(4, 9000, 1000, 20000), true);
-    cache.prepare(req).complete(observed(4, 9000, 2000, 20000), true);
-    expect(cached(cache.prepare(req))).toBe(6000);
+    cache.prepare(req).complete(observed(8, 9000, 1000, 20000), true);
+    cache.prepare(req).complete(observed(9, 9000, 2000, 24000), true);
+    expect(cached(cache.prepare(req))).toBeCloseTo(10000 * 0.2 / 0.475, -1);
     const invalid = new KiroCreditCache();
     invalid.prepare(req).complete({ credits:10, outputTokens:20, complete:true }, true);
     expect([...invalid.scopes.values()][0].samples.size).toBe(0);
@@ -351,8 +353,8 @@ describe("density bounds and recovery", () => {
     const observe = credits => cache.prepare(req).complete(observation(credits), true);
     observe(10);
     now = 6 * MINUTE; observe(4);
-    observe(2); observe(2);
-    expect(cached(cache.prepare(req))).toBe(5000);
+    observe(3.5); observe(3.5);
+    expect(cached(cache.prepare(req))).toBeCloseTo(10000 * 0.125 / 0.475, -1);
   });
   it("retains authoritative zero until its pair leaves the eight-pair window", () => {
     const cache = new KiroCreditCache({ staticReadRatio: 0.4 }); const req = request();
@@ -364,11 +366,64 @@ describe("density bounds and recovery", () => {
       if (i > 0) expect(cached(p)).toBe(0);
       p.complete({ ...observation(2 * totalTokens / 10020, outputTokens), totalTokens }, true);
     }
-    expect(cached(cache.prepare(req))).toBeGreaterThanOrEqual(7999);
+    expect(cached(cache.prepare(req))).toBeGreaterThanOrEqual(9999);
   });
   it.each([-1, NaN, Infinity, Number.MAX_SAFE_INTEGER, undefined])("invalid fallback input %s cannot train density", inputTokens => {
     const cache = new KiroCreditCache(); const req = request();
     cache.prepare(req).complete({ credits:10, inputTokens, outputTokens:20, complete:true }, true);
     expect([...cache.scopes.values()][0].samples.size).toBe(0);
+  });
+});
+
+
+describe("family credit discounts", () => {
+  it.each([["gpt-5.6-sol", 0.523], ["luna", 0.523], ["claude-opus-5", 0.525],
+    ["Claude.Sonnet.6", 0.525]])("%s converts savings only after calibration", (model, d) => {
+    const cache = new KiroCreditCache(); const req = request(model);
+    expect(finish(cache, req, 10).prompt_tokens_details).toBeUndefined();
+    expect(finish(cache, req, 8).prompt_tokens_details.cached_tokens).toBe(9000);
+    expect(finish(cache, req, 8).prompt_tokens_details.cached_tokens).toBe(9000);
+    const plan = cache.prepare(req);
+    expect(cached(plan)).toBeCloseTo(Math.floor(10000 * 0.2 / (1 - d)), -1);
+    plan.complete(observation(10), true);
+    expect(cached(cache.prepare(req))).toBe(0); // calibrated zero, no fallback
+  });
+  it.each(["claude-opus-5", "gpt-5.6-luna"])("%s clamps inferred reuse to its structural prefix", model => {
+    const cache = new KiroCreditCache(); const req = request(model); train(cache, req);
+    const full = cache.prepare(req); expect(cached(full)).toBe(10000); full.complete(null, false);
+    const structural = new KiroCreditCache({ staticReadRatio: 1 });
+    finish(structural, req, 10);
+    req.body.conversationState.history.push(req.body.conversationState.currentMessage);
+    const current = user("uncached new input ".repeat(3000)); current.userInputMessage.modelId = model;
+    req.body.conversationState.currentMessage = current;
+    const bound = cached(structural.prepare(req));
+    expect(bound).toBeGreaterThan(0); expect(bound).toBeLessThan(10000);
+    expect(cached(cache.prepare(req))).toBe(bound);
+  });
+  it("does not share discount calibration across exact model IDs", () => {
+    const cache = new KiroCreditCache(); train(cache, request("gpt-5.6-luna"));
+    expect(cached(cache.prepare(request("gpt-5.6-luna")))).toBe(10000);
+    expect(cached(cache.prepare(request("gpt-5.6-sol")))).toBe(0);
+    expect(cache.prepare(request("unknown-model"))).toBeNull();
+  });
+});
+
+
+describe("credit savings conversion bounds", () => {
+  it.each([["gpt-5.6-sol", 0.523], ["claude-sonnet-5", 0.525]])("%s uses its family discount", (model, d) => {
+    const policy = resolveKiroCachePolicy(model);
+    expect(policy.cachedCreditRatio).toBe(d);
+    expect(inferKiroCacheReuse(0.2, policy)).toBeCloseTo(0.2 / (1 - d), 12);
+    expect(inferKiroCacheReuse(0, policy)).toBe(0);
+    expect(inferKiroCacheReuse(-0.2, policy)).toBe(0);
+    expect(inferKiroCacheReuse(1, policy)).toBe(1);
+  });
+  it("leaves savings unchanged for unknown or uncalibrated policies", () => {
+    const unknown = resolveKiroCachePolicy("unknown-model"); expect(unknown).toBeNull();
+    for (const policy of [unknown, {}]) {
+      expect(inferKiroCacheReuse(0.2, policy)).toBe(0.2);
+      expect(inferKiroCacheReuse(0, policy)).toBe(0);
+      expect(inferKiroCacheReuse(0.9, policy)).toBe(0.9);
+    }
   });
 });

--- a/tests/unit/kiro-credit-cache.test.js
+++ b/tests/unit/kiro-credit-cache.test.js
@@ -16,7 +16,7 @@ function request(model = "claude-opus-5", session = "session-a") {
   };
 }
 const usage = { prompt_tokens: 10000, completion_tokens: 20, total_tokens: 10020 };
-const observation = (credits, outputTokens = 20) => ({ credits, outputTokens, complete: true });
+const observation = (credits, outputTokens = 20) => ({ credits, outputTokens, inputTokens: 10000, totalTokens: 10000 + outputTokens, complete: true });
 function finish(cache, req, credits, success = true) {
   const p = cache.prepare(req);
   const result = p.apply(usage);
@@ -29,16 +29,19 @@ function train(cache, req) {
 const cached = (plan) => plan?.apply(usage).prompt_tokens_details?.cached_tokens || 0;
 
 describe("native-credit cache calibration", () => {
-  it("has no fixed savings; requires two comparable successful cold/warm pairs", () => {
+  it("uses the existing 90% bound on early warm calls, then two comparable pairs take over", () => {
     const cache = new KiroCreditCache();
     const req = request();
-    for (const credits of [10, 2, 2]) expect(finish(cache, req, credits)).toEqual(usage);
+    expect(finish(cache, req, 10)).toEqual(usage);
+    for (const credits of [2, 2]) {
+      expect(finish(cache, req, credits).prompt_tokens_details.cached_tokens).toBe(9000);
+    }
     const p = cache.prepare(req);
     expect(cached(p)).toBe(8000);
     expect(p.apply(usage).prompt_tokens).toBe(10000);
     p.complete(observation(8), true);
     expect(cached(p)).toBe(8000); // frozen plan, even after late metering
-    expect(cached(cache.prepare(req))).toBe(2000); // adverse evidence applies immediately
+    expect(cached(cache.prepare(req))).toBeCloseTo(2000, -1); // adverse evidence applies immediately
   });
 
   it("matches an append-only ladder with current/history wrappers normalized", () => {
@@ -130,10 +133,11 @@ describe("native-credit cache calibration", () => {
       plan.complete(observation(2), true);
       plan.complete(observation(10), true);
     }
-    expect(cached(overlap.prepare(req))).toBe(0);
+    expect([...overlap.scopes.values()][0].pairs).toHaveLength(0);
+    expect(cached(overlap.prepare(req))).toBe(9000); // only static fallback, no learned ratio
   });
 
-  it("does not pair differing output counts or inference configurations", () => {
+  it("does not pair differing inference configurations", () => {
     const cache = new KiroCreditCache();
     const req = request();
     finish(cache, req, 10);
@@ -256,4 +260,115 @@ describe("Kiro cache family policies", () => {
       const cache = new KiroCreditCache(); train(cache, request(model));
       expect(cached(cache.prepare(request(other)))).toBe(0);
     });
+});
+
+
+describe("real-traffic credit calibration", () => {
+  const observed = (credits, inputTokens, outputTokens, totalTokens = inputTokens + outputTokens) =>
+    ({ credits, inputTokens, outputTokens, totalTokens, complete: true });
+  it("uses configured fallback only on proven warmth, then normalized dynamic savings", () => {
+    const cache = new KiroCreditCache({ staticReadRatio: 0.4 });
+    const req = request();
+    const cold = cache.prepare(req); expect(cached(cold)).toBe(0);
+    cold.complete(observed(10, 9000, 1000), true);
+    const warm1 = cache.prepare(req); expect(cached(warm1)).toBe(4000);
+    warm1.complete(observed(2, 9000, 3000), true);
+    const warm2 = cache.prepare(req); expect(cached(warm2)).toBe(4000);
+    warm2.complete(observed(4, 9000, 1000), true);
+    const dynamic = cache.prepare(req);
+    expect(cached(dynamic)).toBe(6000); // lower envelope: min(5/6, 0.6)
+    expect(cached(warm2)).toBe(4000); // prepared estimate stays frozen
+  });
+  it("dynamic zero overrides static fallback even with unequal outputs", () => {
+    const cache = new KiroCreditCache({ staticReadRatio: 0.8 });
+    const req = request();
+    cache.prepare(req).complete(observed(10, 9000, 1000), true);
+    cache.prepare(req).complete(observed(12, 9000, 3000), true); // equal density => zero
+    cache.prepare(req).complete(observed(2, 9000, 500), true);
+    expect(cached(cache.prepare(req))).toBe(0);
+  });
+  it.each([undefined, 0, -1, NaN, Infinity])("uses safe input + output when total is %s", total => {
+    const cache = new KiroCreditCache(); const req = request();
+    const cold = observed(10, 9000, 1000); cold.totalTokens = total;
+    cache.prepare(req).complete(cold, true);
+    cache.prepare(req).complete(observed(4, 9000, 1000), true);
+    cache.prepare(req).complete(observed(5, 9000, 11000), true);
+    expect(cached(cache.prepare(req))).toBe(6000);
+  });
+  it("prefers an actual total, and skips invalid normalization instead of training", () => {
+    const cache = new KiroCreditCache(); const req = request();
+    cache.prepare(req).complete(observed(10, 9000, 1000, 20000), true);
+    cache.prepare(req).complete(observed(4, 9000, 1000, 20000), true);
+    cache.prepare(req).complete(observed(4, 9000, 2000, 20000), true);
+    expect(cached(cache.prepare(req))).toBe(6000);
+    const invalid = new KiroCreditCache();
+    invalid.prepare(req).complete({ credits:10, outputTokens:20, complete:true }, true);
+    expect([...invalid.scopes.values()][0].samples.size).toBe(0);
+  });
+  it("bounds startup estimates to the matched prefix and preserves explicit native zero", () => {
+    const cache = new KiroCreditCache({ staticReadRatio: 0.4 }); const req = request();
+    cache.prepare(req).complete(observed(10, 9000, 1000), true);
+    req.body.conversationState.history.push(req.body.conversationState.currentMessage,
+      { assistantResponseMessage: { content: "answer" } });
+    req.body.conversationState.currentMessage = user("new uncached content ".repeat(2000));
+    const p = cache.prepare(req);
+    expect(cached(p)).toBeGreaterThan(0); expect(cached(p)).toBeLessThan(4000);
+    const native = { ...usage, prompt_tokens_details: { cached_tokens: 0 } };
+    expect(p.apply(native)).toBe(native);
+  });
+});
+
+
+describe("startup fallback isolation", () => {
+  it.each([["claude-sonnet-5", 5, false], ["gpt-5.6-luna", 30, true]])("%s keeps model/account/endpoint/TTL isolation", (model, minutes, scoped) => {
+    let now = 0;
+    const cache = new KiroCreditCache({ now: () => now, staticReadRatio: 0.4 });
+    const req = request(model);
+    cache.prepare(req).complete(observation(10), true);
+    const probe = r => { const p = cache.prepare(r); const read = cached(p); p?.complete(null, false); return read; };
+    expect(probe(request(model, "other-session"))).toBe(scoped ? 0 : 4000);
+    for (const change of [
+      r => { r.credentials.connectionId = "other-account"; },
+      r => { r.endpoint += "/other"; },
+      r => { r.body.conversationState.currentMessage.userInputMessage.modelId = model + "-future"; },
+      r => { r.body.conversationState.agentContinuationId = "other-continuation"; },
+    ]) { const r = request(model); change(r); expect(probe(r)).toBe(0); }
+    expect(probe(req)).toBe(4000);
+    now = minutes * MINUTE;
+    expect(probe(req)).toBe(0);
+  });
+  it.each([0, -1, NaN, Infinity])("invalid/disabled static ratio %s cannot create an estimate", staticReadRatio => {
+    const cache = new KiroCreditCache({ staticReadRatio }); const req = request();
+    cache.prepare(req).complete(observation(10), true);
+    expect(cached(cache.prepare(req))).toBe(0);
+  });
+});
+
+
+describe("density bounds and recovery", () => {
+  it("keeps the lowest cold density when a prefix turns cold again", () => {
+    let now = 0; const cache = new KiroCreditCache({ now: () => now }); const req = request();
+    const observe = credits => cache.prepare(req).complete(observation(credits), true);
+    observe(10);
+    now = 6 * MINUTE; observe(4);
+    observe(2); observe(2);
+    expect(cached(cache.prepare(req))).toBe(5000);
+  });
+  it("retains authoritative zero until its pair leaves the eight-pair window", () => {
+    const cache = new KiroCreditCache({ staticReadRatio: 0.4 }); const req = request();
+    cache.prepare(req).complete(observation(10), true);
+    cache.prepare(req).complete(observation(12), true);
+    for (let i = 0; i < 8; i++) {
+      const outputTokens = 100 + i * 71, totalTokens = 10000 + outputTokens;
+      const p = cache.prepare(req);
+      if (i > 0) expect(cached(p)).toBe(0);
+      p.complete({ ...observation(2 * totalTokens / 10020, outputTokens), totalTokens }, true);
+    }
+    expect(cached(cache.prepare(req))).toBeGreaterThanOrEqual(7999);
+  });
+  it.each([-1, NaN, Infinity, Number.MAX_SAFE_INTEGER, undefined])("invalid fallback input %s cannot train density", inputTokens => {
+    const cache = new KiroCreditCache(); const req = request();
+    cache.prepare(req).complete({ credits:10, inputTokens, outputTokens:20, complete:true }, true);
+    expect([...cache.scopes.values()][0].samples.size).toBe(0);
+  });
 });

--- a/tests/unit/kiro-credit-delivery.test.js
+++ b/tests/unit/kiro-credit-delivery.test.js
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { nativeResponse, kiroFrame, sseEvents } from "../helpers/kiroNative.js";
+
+const { fetchMock } = vi.hoisted(() => ({ fetchMock: vi.fn() }));
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({ proxyAwareFetch: fetchMock }));
+const { KiroExecutor } = await import("../../open-sse/executors/kiro.js");
+const { kiroCreditCache } = await import("../../open-sse/services/kiroCreditCache.js");
+const { selectKiroCacheResponse } = await import("../../open-sse/services/kiroCacheDelivery.js");
+const symbol = Symbol.for("9router.responseDelivery");
+let oldStorage;
+let storage;
+let executor;
+const args = () => ({ model: "claude-opus-5", stream: true,
+  credentials: { connectionId: "account", accessToken: "fixture" },
+  body: { conversationState: { conversationId: "session", agentContinuationId: "continuation",
+    currentMessage: { userInputMessage: { modelId: "claude-opus-5", content: "cacheable words ".repeat(1500) } }, history: [] } }
+});
+const settle = (receipt, success) => {
+  receipt.finished = true;
+  for (const cb of receipt.callbacks) cb(success);
+};
+async function run(response = nativeResponse(), { selected = true, written = true } = {}) {
+  const receipt = { callbacks: new Set(), selected: null, finished: false };
+  return storage.run(receipt, async () => {
+    fetchMock.mockResolvedValueOnce(response);
+    const result = await executor.execute(args());
+    if (selected) selectKiroCacheResponse(result.response);
+    const text = await result.response.text();
+    settle(receipt, written);
+    return text;
+  });
+}
+function counts() {
+  return [...kiroCreditCache.scopes.values()].map(s => ({ active: s.active,
+    prefixes: s.prefixes.size, samples: s.samples.size, pairs: s.pairs.length }));
+}
+beforeEach(() => {
+  oldStorage = globalThis[symbol];
+  storage = new AsyncLocalStorage(); globalThis[symbol] = storage;
+  kiroCreditCache.scopes.clear();
+  fetchMock.mockReset().mockImplementation(async () => nativeResponse({ credits: 2 }));
+  executor = new KiroExecutor();
+});
+afterEach(() => { globalThis[symbol] = oldStorage; });
+
+describe("native EOF plus selected successful client delivery", () => {
+  it("does not learn at native EOF or JSON/SSE consumption; commits once on delivery", async () => {
+    const receipt = { callbacks: new Set(), selected: null, finished: false };
+    await storage.run(receipt, async () => {
+      fetchMock.mockResolvedValueOnce(nativeResponse());
+      const result = await executor.execute(args());
+      selectKiroCacheResponse(result.response);
+      await result.response.text();
+      expect(counts()).toEqual([{ active: 1, prefixes: 0, samples: 0, pairs: 0 }]);
+      settle(receipt, true); settle(receipt, true);
+      expect(counts()).toEqual([{ active: 0, prefixes: 1, samples: 1, pairs: 0 }]);
+    });
+  });
+
+  it.each(["failed client write", "discarded fallback", "web-search side generation"])("excludes %s", async reason => {
+    await run(nativeResponse(), { selected: reason === "failed client write", written: reason !== "failed client write" });
+    expect(counts()).toEqual([{ active: 0, prefixes: 0, samples: 0, pairs: 0 }]);
+  });
+
+  it("a successful side generation cannot win the final response selection", async () => {
+    const receipt = { callbacks: new Set(), selected: null, finished: false };
+    await storage.run(receipt, async () => {
+      const result = await executor.execute(args());
+      await result.response.text();
+      selectKiroCacheResponse(new Response("synthetic web search result"));
+      settle(receipt, true);
+    });
+    expect(counts()).toEqual([{ active: 0, prefixes: 0, samples: 0, pairs: 0 }]);
+  });
+
+  it("does not learn without an authoritative delivery hook", async () => {
+    globalThis[symbol] = undefined;
+    const result = await executor.execute(args());
+    await result.response.text();
+    expect(counts()).toEqual([]);
+  });
+
+  it.each([401, 502])("excludes endpoint fallback or same-endpoint retry after HTTP %s", async status => {
+    executor.config = { ...executor.config, retry: { 502: { attempts: 1, delayMs: 0 } } };
+    await run(new Response("fixture failure", { status }));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(counts()).toEqual([{ active: 0, prefixes: 0, samples: 0, pairs: 0 }]);
+  });
+
+  it("freezes the cold/warm plan before headers, including overlapping slow fetches", async () => {
+    let release;
+    fetchMock.mockImplementationOnce(() => new Promise(resolve => { release = resolve; }));
+    const receipt = { callbacks: new Set(), selected: null, finished: false };
+    const first = storage.run(receipt, () => executor.execute(args()));
+    expect(counts()[0].active).toBe(1);
+    await run(nativeResponse({ credits: 2 }));
+    release(nativeResponse({ credits: 10 }));
+    const result = await first;
+    await storage.run(receipt, async () => {
+      selectKiroCacheResponse(result.response);
+      const text = await result.response.text();
+      expect(sseEvents(text).at(-1).usage.prompt_tokens_details).toBeUndefined();
+      settle(receipt, true);
+    });
+    expect(counts()).toEqual([{ active: 0, prefixes: 1, samples: 0, pairs: 0 }]);
+  });
+
+  it.each([null, false, "", "NaN", 0, -1])("rejects invalid native metering %s", async credits => {
+    await run(nativeResponse({ credits }));
+    expect(counts()).toEqual([{ active: 0, prefixes: 0, samples: 0, pairs: 0 }]);
+  });
+
+  it.each(["max_tokens", "model_context_window_exceeded", "cancelled", "refusal", "unknown_reason"])("does not observe terminal %s", async stop => {
+    await run(nativeResponse({ stop }));
+    expect(counts()).toEqual([{ active: 0, prefixes: 0, samples: 0, pairs: 0 }]);
+  });
+
+  it.each(["CRC", "truncated", "JSON", "malformed event", "bad tool"])("excludes %s even if an integrity retry returns usable output", async kind => {
+    let bad;
+    if (kind === "CRC") { bad = kiroFrame("metadataEvent", {}); bad[bad.length - 1] ^= 1; }
+    if (kind === "truncated") bad = kiroFrame("metadataEvent", {}).subarray(0, 13);
+    if (kind === "JSON") bad = kiroFrame("metadataEvent", "invalid PRIVATE_PROMPT_SENTINEL", true);
+    if (kind === "malformed event") bad = kiroFrame("assistantResponseEvent", { content: 123 });
+    if (kind === "bad tool") bad = kiroFrame("toolUseEvent", { toolUseId: "bad", name: "tool_call", input: {} });
+    const text = await run(nativeResponse({ extra: [bad] }));
+    expect(text).not.toContain("PRIVATE_PROMPT_SENTINEL");
+    expect(counts()).toEqual([{ active: 0, prefixes: 0, samples: 0, pairs: 0 }]);
+  });
+
+  it("missing metering and transport read errors cannot warm prefixes", async () => {
+    const response = new Response(new ReadableStream({ start(c) {
+      c.enqueue(kiroFrame("assistantResponseEvent", { content: "answer" }));
+      c.enqueue(kiroFrame("metricsEvent", { inputTokens: 10000, outputTokens: 20 }));
+      c.close();
+    } }));
+    await run(response);
+    expect(counts()[0].prefixes).toBe(0);
+    await run(new Response(new ReadableStream({ start(c) { c.error(new Error("transport failed")); } })));
+    expect(counts()[0].prefixes).toBe(0);
+  });
+
+  it("explicit zero native cache fields override learned savings", async () => {
+    for (const credits of [10, 2, 2]) await run(nativeResponse({ credits }));
+    const text = await run(nativeResponse({ metrics: { inputTokens: 10000, outputTokens: 20,
+      cacheReadInputTokens: 0, cacheCreationInputTokens: 0 } }));
+    expect(sseEvents(text).at(-1).usage.prompt_tokens_details).toEqual({ cached_tokens: 0, cache_creation_tokens: 0 });
+  });
+
+  it("sums native credit events privately while retaining public last-event serialization", async () => {
+    const text = await run(nativeResponse({ credits: 2, extra: [kiroFrame("meteringEvent", { usage: 3, unit: "credit" })] }));
+    expect(sseEvents(text).at(-1).usage).toMatchObject({ kiro_credits: 3, kiro_credit_unit: "credit" });
+    const scope = [...kiroCreditCache.scopes.values()][0];
+    expect([...scope.samples.values()][0].cold).toBe(5);
+  });
+
+  it("rejects a late abort even after native EOF, before a purported delivery success", async () => {
+    const controller = new AbortController();
+    const receipt = { callbacks: new Set(), selected: null, finished: false };
+    await storage.run(receipt, async () => {
+      const result = await executor.execute({ ...args(), signal: controller.signal });
+      selectKiroCacheResponse(result.response);
+      await result.response.text();
+      controller.abort();
+      settle(receipt, true);
+    });
+    expect(counts()).toEqual([{ active: 0, prefixes: 0, samples: 0, pairs: 0 }]);
+  });
+
+  it("out-of-order concurrent native requests never train billing pairs", async () => {
+    const receipts = [];
+    await Promise.all(Array.from({ length: 12 }, async () => {
+      const receipt = { callbacks: new Set(), selected: null, finished: false }; receipts.push(receipt);
+      await storage.run(receipt, async () => {
+        const result = await executor.execute(args()); selectKiroCacheResponse(result.response);
+        await result.response.text();
+      });
+    }));
+    receipts.reverse().forEach(receipt => settle(receipt, true));
+    expect(counts()).toEqual([{ active: 0, prefixes: 1, samples: 0, pairs: 0 }]);
+  });
+});

--- a/tests/unit/kiro-credit-delivery.test.js
+++ b/tests/unit/kiro-credit-delivery.test.js
@@ -151,7 +151,7 @@ describe("native EOF plus selected successful client delivery", () => {
     const text = await run(nativeResponse({ credits: 2, extra: [kiroFrame("meteringEvent", { usage: 3, unit: "credit" })] }));
     expect(sseEvents(text).at(-1).usage).toMatchObject({ kiro_credits: 3, kiro_credit_unit: "credit" });
     const scope = [...kiroCreditCache.scopes.values()][0];
-    expect([...scope.samples.values()][0].cold).toBe(5);
+    expect([...scope.samples.values()][0].coldDensity).toBe(5 / 10020);
   });
 
   it("rejects a late abort even after native EOF, before a purported delivery success", async () => {
@@ -178,5 +178,44 @@ describe("native EOF plus selected successful client delivery", () => {
     }));
     receipts.reverse().forEach(receipt => settle(receipt, true));
     expect(counts()).toEqual([{ active: 0, prefixes: 1, samples: 0, pairs: 0 }]);
+  });
+});
+
+
+describe("late Kiro input estimation", () => {
+  it("fills missing input after output metrics and refreshes total before calibration", async () => {
+    const text = await run(nativeResponse({ metrics: { outputTokens: 37 }, extra: [
+      kiroFrame("contextUsageEvent", { contextUsagePercentage: 10 })
+    ] }));
+    const usage = sseEvents(text).findLast(e => e.usage)?.usage;
+    expect(usage.prompt_tokens).toBeGreaterThan(0);
+    expect(usage.completion_tokens).toBe(37);
+    expect(usage.total_tokens).toBe(usage.prompt_tokens + 37);
+    expect([...kiroCreditCache.scopes.values()][0].samples.values().next().value.coldDensity)
+      .toBe(10 / usage.total_tokens);
+  });
+  it("does not refill fully cached native input from context percentage", async () => {
+    const text = await run(nativeResponse({ metrics: { inputTokens: 0, outputTokens: 37, cacheReadInputTokens: 10000 },
+      extra: [kiroFrame("contextUsageEvent", { contextUsagePercentage: 50 })] }));
+    const usage = sseEvents(text).findLast(e => e.usage)?.usage;
+    expect(usage.prompt_tokens).toBe(10000);
+    expect(usage.total_tokens).toBe(10037);
+  });
+});
+
+
+describe("startup fallback delivery boundaries", () => {
+  it("does not apply or train a warmed fallback on a retried attempt", async () => {
+    const previous = kiroCreditCache.staticReadRatio;
+    kiroCreditCache.staticReadRatio = 0.4;
+    try {
+      await run(nativeResponse({ credits: 10 }));
+      const retry = await run(new Response("fixture failure", { status: 401 }));
+      expect(sseEvents(retry).at(-1).usage.prompt_tokens_details).toBeUndefined();
+      expect(counts()[0].pairs).toBe(0);
+      const next = await run(nativeResponse({ credits: 2 }), { written: false });
+      expect(sseEvents(next).at(-1).usage.prompt_tokens_details.cached_tokens).toBe(4000);
+      expect(counts()[0].pairs).toBe(0); // failed delivery cannot train the warm pair
+    } finally { kiroCreditCache.staticReadRatio = previous; }
   });
 });

--- a/tests/unit/kiro-credit-http.test.js
+++ b/tests/unit/kiro-credit-http.test.js
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { EventEmitter } from "node:events";
+import { runInNewContext } from "node:vm";
+import http from "node:http";
+
+const require = createRequire(import.meta.url);
+const symbol = Symbol.for("9router.responseDelivery");
+const originalStorage = globalThis[symbol];
+afterEach(() => { globalThis[symbol] = originalStorage; });
+
+function wrappedHttp() {
+  // Exercise the real HTTP wrapper with real sockets while excluding its unrelated
+  // background OAuth refresh bootstrap (no credentials or provider network calls).
+  const facade = { createServer(...args) {
+    const server = http.createServer(...args);
+    server.once = function (event, callback) {
+      return event === "listening" ? this : EventEmitter.prototype.once.call(this, event, callback);
+    };
+    return server;
+  } };
+  const moduleContext = {};
+  runInNewContext(readFileSync(new URL("../../custom-server.js", import.meta.url), "utf8"), {
+    require: name => name === "http" ? facade : require(name), module: moduleContext,
+    __dirname: "/tmp/kiro-http-test", globalThis, process: { env: {} }, console
+  });
+  return facade;
+}
+
+describe("HTTP delivery receipts", () => {
+  it.each(["finish", "client disconnect", "write error", "HTTP failure"])("settles once on %s", async mode => {
+    const receipts = [];
+    let resolveReceipt;
+    const observed = new Promise(resolve => { resolveReceipt = resolve; });
+    const server = wrappedHttp().createServer((req, res) => {
+      const delivery = globalThis[symbol].getStore();
+      delivery.callbacks.add(success => { receipts.push(success); resolveReceipt(); });
+      if (mode === "HTTP failure") res.statusCode = 502;
+      if (mode === "write error") res.destroy(new Error("fixture write failure"));
+      else if (mode === "client disconnect") res.write("partial");
+      else res.end("complete");
+    });
+    server.once = EventEmitter.prototype.once;
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    try {
+      await new Promise(resolve => {
+        const request = http.get(`http://127.0.0.1:${server.address().port}`, response => {
+          response.on("data", () => { if (mode === "client disconnect") request.destroy(); });
+          response.on("end", resolve);
+          response.on("close", resolve);
+        });
+        request.on("error", resolve);
+      });
+      await observed;
+      expect(receipts).toEqual([mode === "finish"]);
+    } finally {
+      server.closeAllConnections();
+      await new Promise(resolve => server.close(resolve));
+    }
+  });
+});

--- a/tests/unit/kiro-credit-protocols.test.js
+++ b/tests/unit/kiro-credit-protocols.test.js
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { nativeResponse, sseEvents } from "../helpers/kiroNative.js";
+
+const { fetchMock } = vi.hoisted(() => ({ fetchMock: vi.fn() }));
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({ proxyAwareFetch: fetchMock }));
+vi.mock("@/lib/usageDb.js", () => ({
+  trackPendingRequest: vi.fn(), appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}), saveRequestUsage: vi.fn(async () => {})
+}));
+vi.mock("../../open-sse/utils/requestLogger.js", () => ({ createRequestLogger: async () => ({
+  logClientRawRequest() {}, logRawRequest() {}, logTargetRequest() {}, logError() {},
+  logProviderResponse() {}, logConvertedResponse() {},
+  appendUpstreamChunk() {}, appendConvertedChunk() {}, appendOpenAIChunk() {}
+}) }));
+
+const { handleChatCore } = await import("../../open-sse/handlers/chatCore.js");
+const { KiroExecutor } = await import("../../open-sse/executors/kiro.js");
+const { FORMATS } = await import("../../open-sse/translator/formats.js");
+const { kiroCreditCache } = await import("../../open-sse/services/kiroCreditCache.js");
+const { selectKiroCacheResponse } = await import("../../open-sse/services/kiroCacheDelivery.js");
+const { clearKiroSessionReplayStore } = await import("../../open-sse/utils/kiroSessionReplay.js");
+beforeEach(() => {
+  kiroCreditCache.scopes.clear();
+  clearKiroSessionReplayStore();
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("Kiro public usage boundaries", () => {
+  it("preserves existing public credit fields without exposing estimator metadata", async () => {
+    fetchMock.mockResolvedValueOnce(nativeResponse());
+    const result = await new KiroExecutor().execute({ model: "claude-opus-5", body: {},
+      stream: true, credentials: { accessToken: "fixture" } });
+    const text = await result.response.text();
+    expect(sseEvents(text).at(-1).usage).toMatchObject({ kiro_credits: 10, kiro_credit_unit: "credit" });
+    expect(text).not.toMatch(/calibration|fingerprint|observation|responseDelivery/);
+  });
+
+  for (const sourceFormat of [FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, FORMATS.CLAUDE]) {
+    it.each([true, false])(`${sourceFormat} preserves fully cached native usage, stream=%s`, async stream => {
+      fetchMock.mockResolvedValueOnce(nativeResponse({ metrics: {
+        inputTokens: 0, outputTokens: 20, cacheReadInputTokens: 10000
+      } }));
+      const body = { model: "kiro/claude-opus-5", stream, max_tokens: 100,
+        ...(sourceFormat === FORMATS.OPENAI_RESPONSES
+          ? { input: [{ role: "user", content: "hello" }] }
+          : { messages: [{ role: "user", content: "hello" }] }) };
+      const result = await handleChatCore({ body,
+        modelInfo: { provider: "kiro", model: "claude-opus-5" },
+        credentials: { connectionId: "fixture", accessToken: "fixture", providerSpecificData: {} },
+        connectionId: "fixture", sourceFormatOverride: sourceFormat });
+      const text = await result.response.text();
+      expect(text).not.toMatch(/calibration|fingerprint|observation|responseDelivery/);
+      const events = stream ? sseEvents(text) : [JSON.parse(text)];
+      const usage = events.map(e => e.response?.usage || e.usage).filter(Boolean).at(-1);
+      expect(usage).toBeDefined();
+      if (sourceFormat === FORMATS.CLAUDE) {
+        expect(usage.cache_read_input_tokens).toBe(10000);
+        expect(usage.input_tokens).toBeLessThanOrEqual(2000); // existing stream safety buffer
+      } else {
+        expect((usage.prompt_tokens_details || usage.input_tokens_details)?.cached_tokens).toBe(10000);
+        expect(usage.prompt_tokens ?? usage.input_tokens).toBeGreaterThanOrEqual(10000);
+        expect(usage.prompt_tokens ?? usage.input_tokens).toBeLessThanOrEqual(12000);
+      }
+    });
+  }
+});
+
+describe("calibration through real request/response translators and chatCore", () => {
+  for (const sourceFormat of [FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, FORMATS.CLAUDE]) {
+    it.each([true, false])(`${sourceFormat} append-only cold/warm accounting, stream=%s`, async stream => {
+      const storage = new AsyncLocalStorage();
+      const symbol = Symbol.for("9router.responseDelivery");
+      const old = globalThis[symbol];
+      globalThis[symbol] = storage;
+      const messages = [{ role: "user", content: "canonical prefix ".repeat(1600) }];
+      const usages = [];
+      try {
+        for (const credits of [10, 2, 2, 2]) {
+          const delivery = { callbacks: new Set(), finished: false, selected: null };
+          await storage.run(delivery, async () => {
+            fetchMock.mockResolvedValueOnce(nativeResponse({ credits }));
+            const body = { stream, max_tokens: 100, session_id: "fixture-session",
+              ...(sourceFormat === FORMATS.OPENAI_RESPONSES ? { input: structuredClone(messages) } : { messages: structuredClone(messages) }) };
+            const result = await handleChatCore({ body,
+              modelInfo: { provider: "kiro", model: "claude-opus-5" },
+              credentials: { accessToken: "fixture", connectionId: "account-calibration" },
+              connectionId: "account-calibration", sourceFormatOverride: sourceFormat,
+              clientRawRequest: { headers: { "x-session-id": "fixture-session" } } });
+            selectKiroCacheResponse(result.response);
+            const text = await result.response.text();
+            expect(text).not.toMatch(/calibration|fingerprint|observation|responseDelivery/);
+            const events = stream ? sseEvents(text) : [JSON.parse(text)];
+            const usage = events.map(e => e.response?.usage || e.usage).filter(Boolean).at(-1);
+            usages.push(usage);
+            // Merely draining the response (including JSON conversion) is not a
+            // successful client write. The transport receipt is still pending.
+            expect([...kiroCreditCache.scopes.values()].some(s => s.active === 1)).toBe(true);
+            delivery.finished = true;
+            for (const callback of delivery.callbacks) callback(true);
+          });
+          messages.push({ role: "assistant", content: "A complete answer." }, { role: "user", content: "continue" });
+        }
+        const read = u => u.cache_read_input_tokens ?? u.prompt_tokens_details?.cached_tokens ?? u.input_tokens_details?.cached_tokens ?? 0;
+        expect(usages.slice(0, 3).map(read)).toEqual([0, 0, 0]);
+        expect(read(usages[3])).toBeGreaterThan(5000);
+        if (sourceFormat === FORMATS.CLAUDE) {
+          expect(usages[3].input_tokens + read(usages[3])).toBe(usages[0].input_tokens);
+        } else {
+          expect(usages[3].prompt_tokens ?? usages[3].input_tokens).toBe(usages[0].prompt_tokens ?? usages[0].input_tokens);
+        }
+        // No new public names except the existing protocol's cache usage fields.
+        const cacheKeys = new Set(["cache_read_input_tokens", "cache_creation_input_tokens", "prompt_tokens_details", "input_tokens_details"]);
+        expect(Object.keys(usages[3]).filter(k => !cacheKeys.has(k)).sort())
+          .toEqual(Object.keys(usages[0]).filter(k => !cacheKeys.has(k)).sort());
+      } finally { globalThis[symbol] = old; }
+    });
+  }
+});

--- a/tests/unit/kiro-credit-protocols.test.js
+++ b/tests/unit/kiro-credit-protocols.test.js
@@ -20,11 +20,13 @@ const { FORMATS } = await import("../../open-sse/translator/formats.js");
 const { kiroCreditCache } = await import("../../open-sse/services/kiroCreditCache.js");
 const { selectKiroCacheResponse } = await import("../../open-sse/services/kiroCacheDelivery.js");
 const { clearKiroSessionReplayStore } = await import("../../open-sse/utils/kiroSessionReplay.js");
+const originalStaticRatio = kiroCreditCache.staticReadRatio;
 beforeEach(() => {
+  kiroCreditCache.staticReadRatio = 0.4;
   kiroCreditCache.scopes.clear();
   clearKiroSessionReplayStore();
 });
-afterEach(() => vi.clearAllMocks());
+afterEach(() => { kiroCreditCache.staticReadRatio = originalStaticRatio; vi.clearAllMocks(); });
 
 describe("Kiro public usage boundaries", () => {
   it("preserves existing public credit fields without exposing estimator metadata", async () => {
@@ -33,7 +35,7 @@ describe("Kiro public usage boundaries", () => {
       stream: true, credentials: { accessToken: "fixture" } });
     const text = await result.response.text();
     expect(sseEvents(text).at(-1).usage).toMatchObject({ kiro_credits: 10, kiro_credit_unit: "credit" });
-    expect(text).not.toMatch(/calibration|fingerprint|observation|responseDelivery/);
+    expect(text).not.toMatch(/calibration|fingerprint|observation|responseDelivery|coldDensity|staticReadRatio|totalTokens/);
   });
 
   for (const sourceFormat of [FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, FORMATS.CLAUDE]) {
@@ -50,7 +52,7 @@ describe("Kiro public usage boundaries", () => {
         credentials: { connectionId: "fixture", accessToken: "fixture", providerSpecificData: {} },
         connectionId: "fixture", sourceFormatOverride: sourceFormat });
       const text = await result.response.text();
-      expect(text).not.toMatch(/calibration|fingerprint|observation|responseDelivery/);
+      expect(text).not.toMatch(/calibration|fingerprint|observation|responseDelivery|coldDensity|staticReadRatio|totalTokens/);
       const events = stream ? sseEvents(text) : [JSON.parse(text)];
       const usage = events.map(e => e.response?.usage || e.usage).filter(Boolean).at(-1);
       expect(usage).toBeDefined();
@@ -76,10 +78,10 @@ describe("calibration through real request/response translators and chatCore", (
       const messages = [{ role: "user", content: "canonical prefix ".repeat(1600) }];
       const usages = [];
       try {
-        for (const credits of [10, 2, 2, 2]) {
+        for (const [credits, outputTokens] of [[10, 20], [2, 1300], [2, 300], [2, 70]]) {
           const delivery = { callbacks: new Set(), finished: false, selected: null };
           await storage.run(delivery, async () => {
-            fetchMock.mockResolvedValueOnce(nativeResponse({ credits }));
+            fetchMock.mockResolvedValueOnce(nativeResponse({ credits, metrics: { inputTokens: 10000, outputTokens } }));
             const body = { stream, max_tokens: 100, session_id: "fixture-session",
               ...(sourceFormat === FORMATS.OPENAI_RESPONSES ? { input: structuredClone(messages) } : { messages: structuredClone(messages) }) };
             const result = await handleChatCore({ body,
@@ -89,7 +91,7 @@ describe("calibration through real request/response translators and chatCore", (
               clientRawRequest: { headers: { "x-session-id": "fixture-session" } } });
             selectKiroCacheResponse(result.response);
             const text = await result.response.text();
-            expect(text).not.toMatch(/calibration|fingerprint|observation|responseDelivery/);
+            expect(text).not.toMatch(/calibration|fingerprint|observation|responseDelivery|coldDensity|staticReadRatio|totalTokens/);
             const events = stream ? sseEvents(text) : [JSON.parse(text)];
             const usage = events.map(e => e.response?.usage || e.usage).filter(Boolean).at(-1);
             usages.push(usage);
@@ -102,7 +104,9 @@ describe("calibration through real request/response translators and chatCore", (
           messages.push({ role: "assistant", content: "A complete answer." }, { role: "user", content: "continue" });
         }
         const read = u => u.cache_read_input_tokens ?? u.prompt_tokens_details?.cached_tokens ?? u.input_tokens_details?.cached_tokens ?? 0;
-        expect(usages.slice(0, 3).map(read)).toEqual([0, 0, 0]);
+        expect(read(usages[0])).toBe(0);
+        expect(read(usages[1])).toBeGreaterThan(0);
+        expect(read(usages[2])).toBeGreaterThan(0);
         expect(read(usages[3])).toBeGreaterThan(5000);
         if (sourceFormat === FORMATS.CLAUDE) {
           expect(usages[3].input_tokens + read(usages[3])).toBe(usages[0].input_tokens);

--- a/tests/unit/kiro-credit-protocols.test.js
+++ b/tests/unit/kiro-credit-protocols.test.js
@@ -35,7 +35,7 @@ describe("Kiro public usage boundaries", () => {
       stream: true, credentials: { accessToken: "fixture" } });
     const text = await result.response.text();
     expect(sseEvents(text).at(-1).usage).toMatchObject({ kiro_credits: 10, kiro_credit_unit: "credit" });
-    expect(text).not.toMatch(/calibration|fingerprint|observation|responseDelivery|coldDensity|staticReadRatio|totalTokens/);
+    expect(text).not.toMatch(/calibration|fingerprint|observation|responseDelivery|coldDensity|staticReadRatio|totalTokens|cachedCreditRatio|creditSavings/);
   });
 
   for (const sourceFormat of [FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, FORMATS.CLAUDE]) {
@@ -52,7 +52,7 @@ describe("Kiro public usage boundaries", () => {
         credentials: { connectionId: "fixture", accessToken: "fixture", providerSpecificData: {} },
         connectionId: "fixture", sourceFormatOverride: sourceFormat });
       const text = await result.response.text();
-      expect(text).not.toMatch(/calibration|fingerprint|observation|responseDelivery|coldDensity|staticReadRatio|totalTokens/);
+      expect(text).not.toMatch(/calibration|fingerprint|observation|responseDelivery|coldDensity|staticReadRatio|totalTokens|cachedCreditRatio|creditSavings/);
       const events = stream ? sseEvents(text) : [JSON.parse(text)];
       const usage = events.map(e => e.response?.usage || e.usage).filter(Boolean).at(-1);
       expect(usage).toBeDefined();
@@ -91,7 +91,7 @@ describe("calibration through real request/response translators and chatCore", (
               clientRawRequest: { headers: { "x-session-id": "fixture-session" } } });
             selectKiroCacheResponse(result.response);
             const text = await result.response.text();
-            expect(text).not.toMatch(/calibration|fingerprint|observation|responseDelivery|coldDensity|staticReadRatio|totalTokens/);
+            expect(text).not.toMatch(/calibration|fingerprint|observation|responseDelivery|coldDensity|staticReadRatio|totalTokens|cachedCreditRatio|creditSavings/);
             const events = stream ? sseEvents(text) : [JSON.parse(text)];
             const usage = events.map(e => e.response?.usage || e.usage).filter(Boolean).at(-1);
             usages.push(usage);

--- a/tests/unit/kiro-usage-and-tool-integrity.test.js
+++ b/tests/unit/kiro-usage-and-tool-integrity.test.js
@@ -307,7 +307,7 @@ describe("D: cache tokens survive the kiro -> claude translation", () => {
       completion_tokens: 20,
       prompt_tokens_details: { cached_tokens: 480, cache_creation_tokens: 20 }
     })).toEqual({
-      input_tokens: 500,
+      input_tokens: 0,
       output_tokens: 20,
       cache_read_input_tokens: 480,
       cache_creation_input_tokens: 20


### PR DESCRIPTION
## Summary

Estimate Kiro cache reads from canonicalized outbound prefix fingerprints and native-credit observations. Cold requests report no estimate. Proven warm prefixes use the existing 0.9 bound while fewer than two valid billing pairs exist; after that, dynamic calibration is authoritative, including a zero estimate. Calibrated credit savings are converted to reuse as `clamp(credit_savings / (1 - d), 0, 1)`, with GPT `d = 0.523` and Claude `d = 0.525`, then bounded by the canonical matched prefix.

Cold/warm comparisons use each call's credits per actual total token, with a validated input-plus-output fallback. This allows different output lengths to calibrate without assuming separate input/output prices. The reuse index tracks successfully delivered prefixes; calibration retains the lowest cold density and the credit-savings lower envelope of the last eight unexpired pairs before conversion. Cached input still incurs credits; the family constants model that cost. They are fixed assumptions, and model/traffic variation or differing input/output costs can bias the inferred reuse. Missing input estimated from context usage refreshes the total before an observation is recorded.

## Behavior and safeguards

- Claude-family policy uses a 5-minute sliding prefix window and a 4,096-token minimum. GPT-family policy uses 30 minutes, a 1,024-token minimum, and conversation isolation. Unknown or conflicting families remain disabled.
- Family policy is shared; calibration is isolated by exact outbound model ID, account/credential, profile, endpoint and inference configuration. Policy classification creates no routing aliases.
- Startup fallback applies only to canonically matched, unexpired prefixes. Both startup and dynamic estimates are weighted by the matched share of input and frozen before the request. Discount conversion never changes startup timing; calibrated reads may exceed 90% but cannot exceed the structural matched-prefix bound. Policies without a discount keep raw savings; unknown models remain estimator-disabled.
- Learning requires a complete valid native stream, positive metering and successful delivery of the selected HTTP response. Failures, retries, fallbacks, malformed/truncated streams, aborted writes and side generations cannot train calibration. Overlapping requests cannot train billing pairs.
- Explicit native cache metrics, including zero, override estimates. Existing public credit serialization and JSON/SSE schemas stay unchanged. Calibration/delivery metadata stays private; cache creation is not inferred, and input/cache accounting avoids double counting across Chat Completions, Responses and Messages.
- State is bounded and process-local, resets on restart, and requires the custom-server delivery hook. Calibration expires after 30 minutes. These estimates do not guarantee provider cache retention or an exact cache-hit rate. No new public setting is introduced.

## Validation

- `cd tests && npx vitest run unit/kiro-credit-cache.test.js unit/kiro-credit-delivery.test.js unit/kiro-credit-protocols.test.js unit/kiro-credit-http.test.js unit/kiro-usage-and-tool-integrity.test.js --silent`: **5 suites, 174 tests passed**.
- Fail-first family-discount run: all 7 new regressions failed before implementation. Coverage includes both family constants and aliases, clamp/structural bounds, calibrated zero, startup timing, unknown-policy passthrough, model isolation, and existing delivery/protocol safeguards.
- Changed-file ESLint, production build/postbuild and `git diff --check` passed; autoreview/secret scan clean.
- A previously recorded wider terminal-integrity run hit two 5-second timeouts (`surfaces retry HTTP failures as SSE after heartbeat commits headers`, `bounds the retry HTTP error body`). Both reproduced on the unchanged baseline during that earlier run; this suite was not rerun for the discount-only change.
- No new live provider calls were made for this update. The earlier canary evidence below validates the HTTP integration before the startup/density and family-discount changes.

### Earlier live Kiro E2E (before the startup-calibration update)

An isolated canary built from this PR was exercised through the real `POST /v1/chat/completions` HTTP path to Kiro. Every response completed with HTTP 200, native metering, one upstream attempt, and a committed delivery receipt. Kiro supplied no native cache-token fields, so the positive outward `usage.prompt_tokens_details.cached_tokens` values below came from this estimator.

| Native model ID | Calls | Final prompt tokens | Final cached tokens |
|---|---:|---:|---:|
| `claude-opus-5` | 4 | 35,199 | 15,125 |
| `claude-opus-4.8` | 4 | 34,882 | 14,975 |
| `claude-opus-4.6` | 12 | 25,125 | 10,217 |
| `gpt-5.6-sol` | 4 | 21,589 | 8,783 |
| `gpt-5.6-luna` | 4 | 21,720 | 9,067 |

`claude-opus-4.6` needed a longer run because an early warm request was billed near the cold baseline; the conservative rolling lower envelope suppressed estimates until that sample left the window. Its 12 calls comprised two fixed-conversation cohorts of six calls, retaining the same canary/account/model calibration scope without a reset. The original-conversation continuation condition was not exercised. Native warm credits were lower than the cold baseline; this does not establish an exact cache rate.
