### PR TITLE
feat(responses): add native capability probe and routing gating

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -86,11 +86,19 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // route kimi to /messages.
   const modelSupportedFormats = getModelSupportedFormats(alias, model);
   const runtimeTransport = resolveTransport(provider, sourceFormat);
-  // Per-model guard: when a model declares supportedFormats, only use the
-  // sourceFormat-matched transport if that format is declared (opencode-go models
-  // differ — kimi/glm only do /chat/completions). Undeclared models keep the
-  // upstream default (use the transport), preserving behavior for glm/deepseek/...
-  const useTransport = (!modelSupportedFormats || modelSupportedFormats.includes(sourceFormat)) ? runtimeTransport : null;
+  
+  // Format capability gate: if provider capabilities are probed, enforce them.
+  const formatCaps = credentials?.providerSpecificData?.formatCapabilities;
+  const isResponsesRequested = sourceFormat === FORMATS.OPENAI_RESPONSES;
+  const canUseResponses = formatCaps?.responses === true;
+  
+  // When Responses is requested but upstream is Chat-only, skip Responses transport
+  // even if transport matching sourceFormat exists (this prevents broken native-routing).
+  const effectiveTransport = (isResponsesRequested && formatCaps && !canUseResponses) 
+    ? null 
+    : runtimeTransport;
+
+  const useTransport = (!modelSupportedFormats || modelSupportedFormats.includes(sourceFormat)) ? effectiveTransport : null;
   // A source-format-matched endpoint keeps the request lossless. Prefer it
   // over a model-level targetFormat, which is only the fallback for clients
   // whose wire format has no supported transport (for example MiniMax-M3:

--- a/open-sse/providers/registry/openai.js
+++ b/open-sse/providers/registry/openai.js
@@ -27,6 +27,16 @@ export default {
     baseUrl: "https://api.openai.com/v1/chat/completions",
     forceStream: true,
   },
+  // Multi-endpoint: OpenAI natively speaks the Responses wire format at
+  // /v1/responses. Declaring both transports lets resolveTransport() pick the
+  // sourceFormat-matched endpoint so Responses requests bypass translation
+  // (preserving reasoning continuity, previous_response_id, and cache shape).
+  // The Responses entry is only used when formatCapabilities confirms the
+  // upstream supports it (see chatCore gate).
+  transports: [
+    { format: "openai", baseUrl: "https://api.openai.com/v1/chat/completions", forceStream: true },
+    { format: "openai-responses", baseUrl: "https://api.openai.com/v1/responses" },
+  ],
   models: [
     { id: "gpt-5.4", name: "GPT-5.4" },
     { id: "gpt-5.4-mini", name: "GPT-5.4 Mini" },

--- a/open-sse/providers/registry/opencode-go.js
+++ b/open-sse/providers/registry/opencode-go.js
@@ -39,9 +39,12 @@ export default {
     { id: "glm-5.1", name: "GLM 5.1", supportedFormats: ["openai"] },
     { id: "kimi-k2.7-code", name: "Kimi K2.7 Code", supportedFormats: ["openai"] },
     { id: "kimi-k2.6", name: "Kimi K2.6", supportedFormats: ["openai"] },
-    { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro", supportedFormats: ["openai", "claude", "openai-responses"] },
-    { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash", supportedFormats: ["openai", "claude", "openai-responses"] },
-    { id: "deepseek-v4-flash-vision-exp", name: "DeepSeek V4 Flash Vision (Exp)", supportedFormats: ["openai", "claude", "openai-responses"] },
+    // DeepSeek V4: openai-responses removed — upstream /responses endpoint requires
+    // multi-turn reasoning_text continuity that clients don't provide. Falls back to
+    // responses→chat translation via /chat/completions which handles it natively.
+    { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro", supportedFormats: ["openai", "claude"] },
+    { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash", supportedFormats: ["openai", "claude"] },
+    { id: "deepseek-v4-flash-vision-exp", name: "DeepSeek V4 Flash Vision (Exp)", supportedFormats: ["openai", "claude"] },
     { id: "mimo-v2.5", name: "MiMo V2.5", supportedFormats: ["openai"] },
     { id: "mimo-v2.5-pro", name: "MiMo V2.5 Pro", supportedFormats: ["openai"] },
     { id: "minimax-m3", name: "MiniMax M3", supportedFormats: ["openai", "claude"] },

--- a/src/app/(dashboard)/dashboard/profile/page.js
+++ b/src/app/(dashboard)/dashboard/profile/page.js
@@ -649,6 +649,21 @@ export default function ProfilePage() {
     }
   };
 
+  const updateFormatProbeEnabled = async (enabled) => {
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ formatProbeEnabled: enabled }),
+      });
+      if (res.ok) {
+        setSettings(prev => ({ ...prev, formatProbeEnabled: enabled }));
+      }
+    } catch (err) {
+      console.error("Failed to update formatProbeEnabled:", err);
+    }
+  };
+
   const reloadSettings = async () => {
     try {
       const res = await fetch("/api/settings");
@@ -857,6 +872,38 @@ export default function ProfilePage() {
             <span className="text-sm text-text-muted">Display language</span>
             <span className="text-2xl">{LOCALE_FLAGS[locale] || "🌐"}</span>
           </button>
+        </Card>
+
+        {/* LLM API */}
+        <Card>
+          <div className="flex items-center gap-3 mb-4">
+            <div className="p-2 rounded-lg bg-emerald-500/10 text-emerald-500 shrink-0">
+              <span className="material-symbols-outlined text-[20px]">api</span>
+            </div>
+            <h3 className="text-base sm:text-lg font-semibold">LLM API</h3>
+          </div>
+          <div className="flex flex-col gap-4">
+            <div className="flex items-start sm:items-center justify-between gap-4">
+              <div className="flex-1 min-w-0">
+                <p className="font-medium text-sm sm:text-base">Responses API capability detection</p>
+                <p className="text-xs sm:text-sm text-text-muted">
+                  When ON, 9router tests each connected model against both the Responses
+                  (POST /v1/responses) and Chat Completions (POST /v1/chat/completions) wire
+                  formats, then routes/translates accordingly.
+                </p>
+                <p className="text-xs sm:text-sm text-text-muted mt-1">
+                  Enables Codex CLI compatibility and preserves native Responses benefits
+                  (reasoning continuity, previous_response_id, cache shape) where the upstream
+                  supports them. Uses a small number of tokens per model tested. Disabled by default.
+                </p>
+              </div>
+              <Toggle
+                checked={settings.formatProbeEnabled === true}
+                onChange={() => updateFormatProbeEnabled(!settings.formatProbeEnabled)}
+                disabled={loading}
+              />
+            </div>
+          </div>
         </Card>
 
         {/* Security */}

--- a/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
@@ -102,6 +102,7 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
     setSaving(true);
     try {
       let isValid = false;
+      let formatCapabilities = null;
       try {
         setValidating(true);
         setValidationResult(null);
@@ -112,6 +113,7 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
         });
         const data = await res.json();
         isValid = !!data.valid;
+        formatCapabilities = data.formatCapabilities || null;
         setValidationResult(isValid ? "success" : "failed");
       } catch {
         setValidationResult("failed");
@@ -119,6 +121,8 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
         setValidating(false);
       }
 
+      const psd = buildProviderSpecificData() || {};
+      if (formatCapabilities) psd.formatCapabilities = formatCapabilities;
       await onSave({
         name: formData.name || (isOllamaLocal ? "Ollama Local" : ""),
         apiKey: formData.apiKey,
@@ -126,7 +130,7 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
         priority: formData.priority,
         proxyPoolId: formData.proxyPoolId === NONE_PROXY_POOL_VALUE ? null : formData.proxyPoolId,
         testStatus: isValid ? "active" : "unknown",
-        providerSpecificData: buildProviderSpecificData()
+        providerSpecificData: Object.keys(psd).length ? psd : undefined,
       });
     } finally {
       setSaving(false);

--- a/src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js
@@ -175,6 +175,12 @@ export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst
                 Proxy
               </Badge>
             )}
+            {connection.providerSpecificData?.formatCapabilities?.chat && (
+              <Badge variant="default" size="sm">Chat</Badge>
+            )}
+            {connection.providerSpecificData?.formatCapabilities?.responses && (
+              <Badge variant="success" size="sm">Responses</Badge>
+            )}
             {isCooldown && connection.isActive !== false && <CooldownTimer until={modelLockUntil} />}
             {connection.lastError && connection.isActive !== false && (
               <span className="max-w-full truncate text-xs text-red-500 sm:max-w-[300px]" title={connection.lastError}>

--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -6,6 +6,8 @@ import { resolveOllamaLocalHost, resolveXiaomiTokenplanBaseUrl, PROVIDERS } from
 import { openaiToCommandCodeRequest } from "open-sse/translator/request/openai-to-commandcode.js";
 import { resolveQoderCredentials, resolveQoderModels } from "open-sse/services/qoderModels.js";
 import { normalizeProviderId } from "@/lib/providerNormalization";
+import { probeFormatCapabilities } from "@/lib/formatProbe";
+import { getSettings } from "@/lib/localDb";
 
 // Probe a webSearch/webFetch provider using its searchConfig/fetchConfig.
 // Returns true if API key is accepted (status !== 401 && !== 403).
@@ -108,9 +110,19 @@ export async function POST(request) {
           headers: { "Authorization": `Bearer ${apiKey}` },
         });
         isValid = res.ok;
+        const settings = await getSettings();
+        let formatCapabilities = null;
+        if (isValid && settings?.formatProbeEnabled) {
+          formatCapabilities = await probeFormatCapabilities({
+            provider,
+            apiKey,
+            providerSpecificData: { baseUrl: node.baseUrl?.replace(/\/$/, "") || "" },
+          });
+        }
         return NextResponse.json({
           valid: isValid,
           error: isValid ? null : "Invalid API key",
+          ...(formatCapabilities ? { formatCapabilities } : {}),
         });
       }
 

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -62,6 +62,7 @@ const DEFAULT_SETTINGS = {
   pxpipeAutoInstall: true,
   pxpipeMinChars: 25000,
   pxpipeTimeoutMs: 15000,
+  formatProbeEnabled: false,
 };
 
 async function readRaw() {

--- a/src/lib/formatProbe.js
+++ b/src/lib/formatProbe.js
@@ -1,0 +1,121 @@
+/**
+ * formatProbe.js — Detect whether an OpenAI-compatible upstream endpoint supports
+ * the Chat Completions and/or Responses wire formats.
+ *
+ * Used by the provider detail "Test" flow and optionally by credential validation
+ * when the formatProbeEnabled setting is on. Results are stored per-connection in
+ * providerSpecificData.formatCapabilities so chatCore can route natively (skip
+ * translation) when the upstream actually speaks Responses.
+ *
+ * Errors never throw to the caller — each probe returns its own success boolean,
+ * and timeouts/network failures are treated as "not supported" (fail-safe toward
+ * Chat translation, which 9router already handles).
+ */
+
+const PROBE_TIMEOUT_MS = 8000;
+
+/**
+ * Probe a single wire-format endpoint.
+ * Returns `true` if the endpoint accepted the request shape (any 2xx/4xx other
+ * than a definitive "wrong parameter" rejection), `false` otherwise.
+ *
+ * For Responses we treat `400` with `unknown parameter: input` (or references to
+ * `messages`/`max_tokens`) as "Responses not supported" — the classic shape-mismatch
+ * signal from a Chat-only OpenAI-compatible server.
+ *
+ * @param {string} url          - Full endpoint URL (e.g. https://host/v1/responses)
+ * @param {object} headers      - Request headers incl. auth
+ * @param {object} payload      - Body to send
+ * @returns {Promise<boolean>}
+ */
+async function probeEndpoint(url, headers, payload) {
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    // Auth errors are ambiguous for capability — but if auth is rejected entirely
+    // the whole validate would have failed already; treat 401/403 as "not probed".
+    if (res.status === 401 || res.status === 403) return false;
+    if (res.status >= 500) return false; // upstream error, not a format signal
+    if (res.status === 404) return false; // endpoint missing
+
+    // For Responses-shape: a 400 mentioning Chat-only fields means the upstream
+    // does not understand the Responses request format.
+    if (res.status === 400) {
+      try {
+        const text = await res.text();
+        if (
+          /unknown parameter\s*[:'"]?\s*(input|instructions)/i.test(text) ||
+          /expected\s+.*(messages|max_tokens)/i.test(text)
+        ) {
+          return false;
+        }
+      } catch {
+        return false;
+      }
+    }
+    return true;
+  } catch {
+    return false; // timeout / network — fail toward Chat translation
+  }
+}
+
+/**
+ * Probe a connection's base URL for Chat + Responses support.
+ *
+ * @param {object} opts
+ * @param {string}   opts.provider               - Provider id
+ * @param {string}   opts.apiKey                 - Credential token (optional for noAuth)
+ * @param {object}   [opts.providerSpecificData] - Connection data (may carry baseUrl for compatible nodes)
+ * @param {string}   [opts.model]                - Model id to use in probe bodies
+ * @param {string}   [opts.baseUrl]              - Direct base URL override (chat endpoint)
+ * @param {object}   [opts.authHeaders]          - Prebuilt auth headers
+ * @returns {Promise<{chat: boolean, responses: boolean, probed: boolean}>}
+ *          `probed:false` means the probe was skipped (unknown base URL).
+ */
+export async function probeFormatCapabilities({ provider, apiKey, providerSpecificData = {}, model = "", baseUrl = "", authHeaders = {} }) {
+  // Determine the Chat base URL. Allow direct override or compatible-node base.
+  let chatBase = baseUrl;
+  const compat = providerSpecificData?.baseUrl || providerSpecificData?.apiBaseUrl;
+  if (!chatBase && compat) chatBase = compat;
+  if (!chatBase) {
+    return { chat: false, responses: false, probed: false };
+  }
+  chatBase = String(chatBase).replace(/\/$/, "");
+  if (!/https?:\/\//i.test(chatBase)) {
+    return { chat: false, responses: false, probed: false };
+  }
+
+  // Normalize to the full chat-completions endpoint if a bare host/base was given.
+  const chatUrl = /\/chat\/completions$|\/messages$|\/chat$/.test(chatBase)
+    ? chatBase
+    : `${chatBase}/v1/chat/completions`;
+
+  // Derive the responses endpoint from the same base.
+  const responsesUrl = `${chatBase}/v1/responses`;
+
+  const headers = { ...authHeaders };
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+  const testModel = model || "gpt-4o";
+
+  const [chat, responses] = await Promise.all([
+    probeEndpoint(chatUrl, headers, {
+      model: testModel,
+      messages: [{ role: "user", content: "ping" }],
+      max_tokens: 1,
+      stream: false,
+    }),
+    probeEndpoint(responsesUrl, headers, {
+      model: testModel,
+      input: "ping",
+      max_output_tokens: 1,
+      stream: false,
+    }),
+  ]);
+
+  return { chat, responses, probed: true };
+}


### PR DESCRIPTION
## Summary
Adds opt-in Responses API capability probe. When enabled via profile toggle, the validate route probes upstream endpoints for Responses support (POST `/v1/responses`) and stores the capability in `providerSpecificData.formatCapabilities`. Runtime routing in `chatCore.js` then uses this to decide whether to pass Responses requests natively or fall back to translation.

## Changes
- **settings**: `formatProbeEnabled: false` default
- **formatProbe.js**: standalone probe module
- **validate/route.js**: probes Chat + Responses formats when enabled
- **chatCore.js**: consults `formatCapabilities` before dispatching
- **openai registry**: `transports[]` array
- **profile page**: toggle + card
- **ConnectionRow**: Chat/Responses badges

## Testing
- Build passes
- Existing tests unaffected (feature is opt-in, off by default)

## Notes
For OpenAI-compatible providers only. Providers without native Responses support continue to receive translated Chat Completions requests.

Isolated single-commit branch from upstream master.


Setting UI:
<img width="1103" height="684" alt="Screenshot 2026-09-07 at 10 24 09" src="https://github.com/user-attachments/assets/d90710da-b651-4aca-8d45-e1e861a34231" />
