### PR TITLE
fix(nonstream): Responses-API upstreams for Claude/non-streaming clients

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -1,142 +1,28 @@
 import { FORMATS } from "../../translator/formats.js";
 import { needsTranslation } from "../../translator/index.js";
-import { fromOpenAIFinish } from "../../translator/concerns/finishReason.js";
 import { ollamaBodyToOpenAI } from "../../translator/response/ollama-to-openai.js";
 import { addBufferToUsage, filterUsageForFormat } from "../../utils/usageTracking.js";
 import { createErrorResult } from "../../utils/error.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
+import { PROVIDERS } from "../../config/providers.js";
 import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
+import { parseResponsesSSEToJSON } from "../../transformer/streamToJsonConverter.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats, formatDoneLine } from "./requestDetail.js";
-import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
+import { saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
-import { ROLE, RESPONSES_ITEM } from "../../translator/schema/index.js";
+import {
+  openAICompletionToClaudeMessage,
+  openAICompletionToResponses,
+  responsesToOpenAICompletion,
+  responsesToClaudeMessage,
+} from "./responseFormats.js";
 
-function parseToolArguments(value) {
-  if (!value) return {};
-  if (typeof value === "object") return value;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return {};
-  }
-}
-
-function openAICompletionToClaudeMessage(responseBody) {
-  if (!responseBody?.choices?.[0]) return responseBody;
-  const choice = responseBody.choices[0];
-  const message = choice.message || {};
-  const content = [];
-
-  const reasoning = message.reasoning_content || message.provider_specific_fields?.reasoning_content || "";
-  if (reasoning) {
-    content.push({ type: "thinking", thinking: reasoning });
-  }
-  if (typeof message.content === "string" && message.content.length > 0) {
-    content.push({ type: "text", text: message.content });
-  }
-  for (const toolCall of message.tool_calls || []) {
-    const fn = toolCall.function || {};
-    content.push({
-      type: "tool_use",
-      id: toolCall.id || `toolu_${Date.now()}_${content.length}`,
-      name: fn.name || toolCall.name || "",
-      input: parseToolArguments(fn.arguments || toolCall.arguments),
-    });
-  }
-  if (content.length === 0) content.push({ type: "text", text: "" });
-
-  const usage = responseBody.usage || {};
-  return {
-    id: String(responseBody.id || `msg_${Date.now()}`).replace(/^chatcmpl-/, ""),
-    type: "message",
-    role: "assistant",
-    model: responseBody.model || "unknown",
-    content,
-    stop_reason: fromOpenAIFinish(choice.finish_reason, FORMATS.CLAUDE),
-    stop_sequence: null,
-    usage: {
-      input_tokens: usage.prompt_tokens || usage.input_tokens || 0,
-      output_tokens: usage.completion_tokens || usage.output_tokens || 0,
-    },
-  };
-}
-
-/**
- * Convert an OpenAI Chat Completions non-streaming response body into the
- * OpenAI Responses API shape. Used when a Responses-format client (e.g. Codex)
- * is routed to a Chat Completions upstream and `stream:false` — the streaming
- * path already emits Responses events, but the JSON path returned a raw
- * `chat.completion` body, so tool_calls were invisible to Responses clients.
- */
-function extractCustomToolInput(argumentsValue) {
-  const argumentsText = typeof argumentsValue === "string" ? argumentsValue : JSON.stringify(argumentsValue || {});
-  try {
-    const parsed = JSON.parse(argumentsText);
-    if (parsed && typeof parsed === "object" && typeof parsed.input === "string") return parsed.input;
-  } catch { /* raw freeform input */ }
-  return argumentsText;
-}
-
-function openAICompletionToResponses(responseBody, customToolNames = null) {
-  const choice = responseBody?.choices?.[0];
-  if (!choice) return responseBody;
-
-  const message = choice.message || {};
-  const output = [];
-
-  // Reasoning → a reasoning item (summary text), mirroring the streaming path.
-  const reasoning = message.reasoning_content || message.reasoning;
-  if (typeof reasoning === "string" && reasoning.length > 0) {
-    output.push({
-      type: RESPONSES_ITEM.REASONING,
-      summary: [{ type: RESPONSES_ITEM.SUMMARY_TEXT, text: reasoning }],
-    });
-  }
-
-  // Assistant text → a message item with output_text content.
-  const text = typeof message.content === "string" ? message.content : "";
-  if (text.length > 0) {
-    output.push({
-      type: RESPONSES_ITEM.MESSAGE,
-      role: ROLE.ASSISTANT,
-      content: [{ type: RESPONSES_ITEM.OUTPUT_TEXT, text, annotations: [] }],
-    });
-  }
-
-  // tool_calls → function_call/custom_tool_call items (Responses-native tool shape).
-  for (const tc of message.tool_calls || []) {
-    const fn = tc.function || {};
-    const custom = customToolNames?.has(fn.name);
-    output.push({
-      type: custom ? RESPONSES_ITEM.CUSTOM_TOOL_CALL : RESPONSES_ITEM.FUNCTION_CALL,
-      id: `${custom ? "ctc" : "fc"}_${tc.id || ""}`,
-      call_id: tc.id || "",
-      name: fn.name || "",
-      ...(custom
-        ? { input: extractCustomToolInput(fn.arguments) }
-        : { arguments: typeof fn.arguments === "string" ? fn.arguments : JSON.stringify(fn.arguments || {}) }),
-    });
-  }
-
-  const usage = responseBody.usage || {};
-  const status = choice.finish_reason === "tool_calls" ? "completed" : (choice.finish_reason === "stop" ? "completed" : (choice.finish_reason || "completed"));
-
-  return {
-    id: `resp_${responseBody.id || ""}`.replace(/^resp_chatcmpl-/, "resp_"),
-    object: "response",
-    created_at: responseBody.created || Math.floor(Date.now() / 1000),
-    model: responseBody.model || "unknown",
-    status,
-    background: false,
-    error: null,
-    output,
-    usage: {
-      input_tokens: usage.prompt_tokens || usage.input_tokens || 0,
-      output_tokens: usage.completion_tokens || usage.output_tokens || 0,
-      total_tokens: usage.total_tokens || (usage.prompt_tokens || 0) + (usage.completion_tokens || 0),
-    },
-  };
-}
+export {
+  openAICompletionToClaudeMessage,
+  openAICompletionToResponses,
+  responsesToOpenAICompletion,
+  responsesToClaudeMessage,
+};
 
 /**
  * Translate non-streaming response body from provider format → OpenAI format.
@@ -152,6 +38,15 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
     return openAICompletionToClaudeMessage(responseBody);
   }
   if (targetFormat === FORMATS.OPENAI) return responseBody;
+
+  // Provider responded in OpenAI Responses API shape
+  if (targetFormat === FORMATS.OPENAI_RESPONSES) {
+    const openAIResponse = responsesToOpenAICompletion(responseBody);
+    if (sourceFormat === FORMATS.CLAUDE) {
+      return openAICompletionToClaudeMessage(openAIResponse);
+    }
+    return openAIResponse;
+  }
 
   // Gemini / Antigravity
   if (targetFormat === FORMATS.GEMINI || targetFormat === FORMATS.ANTIGRAVITY || targetFormat === FORMATS.GEMINI_CLI || targetFormat === FORMATS.VERTEX) {
@@ -211,6 +106,12 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
         result.usage.completion_tokens_details = { reasoning_tokens: usage.thoughtsTokenCount };
       }
     }
+    if (sourceFormat === FORMATS.CLAUDE) {
+      return openAICompletionToClaudeMessage(result);
+    }
+    if (sourceFormat === FORMATS.OPENAI_RESPONSES) {
+      return openAICompletionToResponses(result, customToolNames);
+    }
     return result;
   }
 
@@ -267,12 +168,22 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
         total_tokens: (responseBody.usage.input_tokens || 0) + (responseBody.usage.output_tokens || 0)
       };
     }
+    if (sourceFormat === FORMATS.OPENAI_RESPONSES) {
+      return openAICompletionToResponses(result, customToolNames);
+    }
     return result;
   }
 
   // Ollama
   if (targetFormat === FORMATS.OLLAMA) {
-    return ollamaBodyToOpenAI(responseBody);
+    const result = ollamaBodyToOpenAI(responseBody);
+    if (sourceFormat === FORMATS.CLAUDE) {
+      return openAICompletionToClaudeMessage(result);
+    }
+    if (sourceFormat === FORMATS.OPENAI_RESPONSES) {
+      return openAICompletionToResponses(result, customToolNames);
+    }
+    return result;
   }
 
   return responseBody;
@@ -288,10 +199,23 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
 
   if (contentType.includes("text/event-stream")) {
     const sseText = await providerResponse.text();
-    const parsed = parseSSEToOpenAIResponse(sseText, model);
+    const isResponsesUpstream = targetFormat === FORMATS.OPENAI_RESPONSES || PROVIDERS[provider]?.format === FORMATS.OPENAI_RESPONSES;
+    let parsed;
+    if (isResponsesUpstream) {
+      parsed = parseResponsesSSEToJSON(sseText, model);
+    } else {
+      parsed = parseSSEToOpenAIResponse(sseText, model);
+    }
     if (!parsed) {
       appendLog({ status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}` });
       return createErrorResult(HTTP_STATUS.BAD_GATEWAY, "Invalid SSE response for non-streaming request");
+    }
+    if (parsed.error) {
+      appendLog({ status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}` });
+      return createErrorResult(
+        HTTP_STATUS.BAD_GATEWAY,
+        parsed.error.message || "Upstream SSE stream failed"
+      );
     }
     responseBody = parsed;
   } else {
@@ -379,9 +303,18 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
     providerRequest: finalBody || translatedBody || null,
     providerResponse: responseBody || null,
     response: {
-      content: translatedResponse?.choices?.[0]?.message?.content || translatedResponse?.content || null,
-      thinking: translatedResponse?.choices?.[0]?.message?.reasoning_content || translatedResponse?.reasoning_content || null,
-      finish_reason: translatedResponse?.choices?.[0]?.finish_reason || "unknown"
+      content: translatedResponse?.choices?.[0]?.message?.content
+        || (Array.isArray(translatedResponse?.content)
+          ? translatedResponse.content.filter(c => c.type === "text").map(c => c.text || "").join("")
+          : translatedResponse?.content)
+        || null,
+      thinking: translatedResponse?.choices?.[0]?.message?.reasoning_content
+        || (Array.isArray(translatedResponse?.content)
+          ? translatedResponse.content.find(c => c.type === "thinking")?.thinking
+          : null)
+        || translatedResponse?.reasoning_content
+        || null,
+      finish_reason: translatedResponse?.choices?.[0]?.finish_reason || translatedResponse?.stop_reason || "unknown"
     },
     pxpipe,
     status: "success"

--- a/open-sse/handlers/chatCore/responseFormats.js
+++ b/open-sse/handlers/chatCore/responseFormats.js
@@ -1,0 +1,245 @@
+import { FORMATS } from "../../translator/formats.js";
+import { fromOpenAIFinish } from "../../translator/concerns/finishReason.js";
+import { ROLE, RESPONSES_ITEM } from "../../translator/schema/index.js";
+
+export function parseToolArguments(value) {
+  if (!value) return {};
+  if (typeof value === "object") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return {};
+  }
+}
+
+export function openAICompletionToClaudeMessage(responseBody) {
+  if (!responseBody?.choices?.[0]) return responseBody;
+  const choice = responseBody.choices[0];
+  const message = choice.message || {};
+  const content = [];
+
+  const reasoning = message.reasoning_content || message.provider_specific_fields?.reasoning_content || "";
+  if (reasoning) {
+    content.push({ type: "thinking", thinking: reasoning });
+  }
+  if (typeof message.content === "string" && message.content.length > 0) {
+    content.push({ type: "text", text: message.content });
+  }
+  for (const toolCall of message.tool_calls || []) {
+    const fn = toolCall.function || {};
+    content.push({
+      type: "tool_use",
+      id: toolCall.id || `toolu_${Date.now()}_${content.length}`,
+      name: fn.name || toolCall.name || "",
+      input: parseToolArguments(fn.arguments || toolCall.arguments),
+    });
+  }
+  if (content.length === 0) content.push({ type: "text", text: "" });
+
+  const usage = responseBody.usage || {};
+  const claudeUsage = {
+    input_tokens: usage.prompt_tokens || usage.input_tokens || 0,
+    output_tokens: usage.completion_tokens || usage.output_tokens || 0,
+  };
+  const cacheRead = usage.cache_read_input_tokens || usage.cached_tokens || usage.prompt_tokens_details?.cached_tokens || 0;
+  if (cacheRead > 0) claudeUsage.cache_read_input_tokens = cacheRead;
+  const cacheCreate = usage.cache_creation_input_tokens || usage.prompt_tokens_details?.cache_creation_tokens || 0;
+  if (cacheCreate > 0) claudeUsage.cache_creation_input_tokens = cacheCreate;
+
+  let msgId = String(responseBody.id || `msg_${Date.now()}`).replace(/^chatcmpl-/, "").replace(/^resp_/, "");
+  if (!msgId.startsWith("msg_")) msgId = `msg_${msgId}`;
+
+  return {
+    id: msgId,
+    type: "message",
+    role: "assistant",
+    model: responseBody.model || "unknown",
+    content,
+    stop_reason: fromOpenAIFinish(choice.finish_reason, FORMATS.CLAUDE),
+    stop_sequence: null,
+    usage: claudeUsage,
+  };
+}
+
+export function extractCustomToolInput(argumentsValue) {
+  const argumentsText = typeof argumentsValue === "string" ? argumentsValue : JSON.stringify(argumentsValue || {});
+  try {
+    const parsed = JSON.parse(argumentsText);
+    if (parsed && typeof parsed === "object" && typeof parsed.input === "string") return parsed.input;
+  } catch { /* raw freeform input */ }
+  return argumentsText;
+}
+
+export function openAICompletionToResponses(responseBody, customToolNames = null) {
+  const choice = responseBody?.choices?.[0];
+  if (!choice) return responseBody;
+
+  const message = choice.message || {};
+  const output = [];
+
+  const reasoning = message.reasoning_content || message.reasoning;
+  if (typeof reasoning === "string" && reasoning.length > 0) {
+    output.push({
+      type: RESPONSES_ITEM.REASONING,
+      summary: [{ type: RESPONSES_ITEM.SUMMARY_TEXT, text: reasoning }],
+    });
+  }
+
+  const text = typeof message.content === "string" ? message.content : "";
+  if (text.length > 0) {
+    output.push({
+      type: RESPONSES_ITEM.MESSAGE,
+      role: ROLE.ASSISTANT,
+      content: [{ type: RESPONSES_ITEM.OUTPUT_TEXT, text, annotations: [] }],
+    });
+  }
+
+  for (const tc of message.tool_calls || []) {
+    const fn = tc.function || {};
+    const custom = customToolNames?.has(fn.name);
+    output.push({
+      type: custom ? RESPONSES_ITEM.CUSTOM_TOOL_CALL : RESPONSES_ITEM.FUNCTION_CALL,
+      id: `${custom ? "ctc" : "fc"}_${tc.id || ""}`,
+      call_id: tc.id || "",
+      name: fn.name || "",
+      ...(custom
+        ? { input: extractCustomToolInput(fn.arguments) }
+        : { arguments: typeof fn.arguments === "string" ? fn.arguments : JSON.stringify(fn.arguments || {}) }),
+    });
+  }
+
+  const usage = responseBody.usage || {};
+  const status = choice.finish_reason === "tool_calls" ? "completed" : (choice.finish_reason === "stop" ? "completed" : (choice.finish_reason || "completed"));
+
+  return {
+    id: `resp_${responseBody.id || ""}`.replace(/^resp_chatcmpl-/, "resp_"),
+    object: "response",
+    created_at: responseBody.created || Math.floor(Date.now() / 1000),
+    model: responseBody.model || "unknown",
+    status,
+    background: false,
+    error: null,
+    output,
+    usage: {
+      input_tokens: usage.prompt_tokens || usage.input_tokens || 0,
+      output_tokens: usage.completion_tokens || usage.output_tokens || 0,
+      total_tokens: usage.total_tokens || (usage.prompt_tokens || 0) + (usage.completion_tokens || 0),
+    },
+  };
+}
+
+export function extractTextFromResponsesOutput(output) {
+  if (!Array.isArray(output)) return "";
+  const texts = [];
+  for (const item of output) {
+    if (item?.type === "message" && Array.isArray(item.content)) {
+      for (const part of item.content) {
+        if (part?.type === "output_text" && typeof part.text === "string") {
+          texts.push(part.text);
+        } else if (typeof part?.text === "string") {
+          texts.push(part.text);
+        }
+      }
+    }
+  }
+  return texts.join("");
+}
+
+export function extractReasoningFromResponsesOutput(output) {
+  if (!Array.isArray(output)) return "";
+  const reasoningTexts = [];
+  for (const item of output) {
+    if (item?.type === "reasoning") {
+      if (Array.isArray(item.summary)) {
+        for (const s of item.summary) {
+          if (typeof s?.text === "string") reasoningTexts.push(s.text);
+        }
+      } else if (typeof item.reasoning === "string") {
+        reasoningTexts.push(item.reasoning);
+      }
+    }
+  }
+  return reasoningTexts.join("\n");
+}
+
+export function extractToolCallsFromResponsesOutput(output) {
+  if (!Array.isArray(output)) return [];
+  const toolCalls = [];
+  for (const item of output) {
+    if (!item || typeof item !== "object") continue;
+    if (item.type === "function_call") {
+      toolCalls.push({
+        id: item.call_id || item.id || `call_${item.name || "tool"}_${Date.now()}_${toolCalls.length}`,
+        type: "function",
+        function: {
+          name: item.name || "",
+          arguments: typeof item.arguments === "string" ? item.arguments : JSON.stringify(item.arguments || {}),
+        },
+      });
+    } else if (item.type === "custom_tool_call") {
+      toolCalls.push({
+        id: item.call_id || item.id || `call_${item.name || "tool"}_${Date.now()}_${toolCalls.length}`,
+        type: "function",
+        function: {
+          name: item.name || "",
+          arguments: typeof item.input === "string" ? item.input : JSON.stringify(item.input || {}),
+        },
+      });
+    }
+  }
+  return toolCalls;
+}
+
+export function responsesToOpenAICompletion(responseBody) {
+  if (!responseBody || typeof responseBody !== "object") return responseBody;
+  if (responseBody.choices) return responseBody;
+
+  const output = responseBody.output || [];
+  const textContent = extractTextFromResponsesOutput(output);
+  const reasoningContent = extractReasoningFromResponsesOutput(output);
+  const toolCalls = extractToolCallsFromResponsesOutput(output);
+  const hasToolCalls = toolCalls.length > 0;
+
+  const message = { role: "assistant" };
+  if (textContent) message.content = textContent;
+  if (reasoningContent) message.reasoning_content = reasoningContent;
+  if (hasToolCalls) message.tool_calls = toolCalls;
+  if (!message.content && !message.tool_calls) message.content = "";
+
+  const responseDone = responseBody.status === "completed" || responseBody.status === "done";
+  const finishReason = hasToolCalls ? "tool_calls" : (responseDone ? "stop" : (responseBody.status || "stop"));
+
+  const usage = responseBody.usage || {};
+  const cacheRead = usage.cache_read_input_tokens || usage.cached_tokens || usage.input_tokens_details?.cached_tokens || 0;
+  const cacheCreate = usage.cache_creation_input_tokens || 0;
+  const inTokens = (usage.input_tokens || usage.prompt_tokens || 0) + cacheRead + cacheCreate;
+  const outTokens = usage.output_tokens || usage.completion_tokens || 0;
+
+  const cacheDetails = (cacheRead > 0 || cacheCreate > 0)
+    ? {
+        prompt_tokens_details: {
+          ...(cacheRead > 0 ? { cached_tokens: cacheRead } : {}),
+          ...(cacheCreate > 0 ? { cache_creation_tokens: cacheCreate } : {}),
+        },
+      }
+    : {};
+
+  return {
+    id: String(responseBody.id || `chatcmpl-${Date.now()}`).replace(/^resp_/, "chatcmpl-"),
+    object: "chat.completion",
+    created: responseBody.created_at || Math.floor(Date.now() / 1000),
+    model: responseBody.model || "unknown",
+    choices: [{ index: 0, message, finish_reason: finishReason }],
+    usage: {
+      prompt_tokens: inTokens,
+      completion_tokens: outTokens,
+      total_tokens: usage.total_tokens || (inTokens + outTokens),
+      ...cacheDetails,
+    },
+  };
+}
+
+export function responsesToClaudeMessage(responseBody) {
+  const openAIComp = responsesToOpenAICompletion(responseBody);
+  return openAICompletionToClaudeMessage(openAIComp);
+}

--- a/open-sse/handlers/chatCore/responseFormats.js
+++ b/open-sse/handlers/chatCore/responseFormats.js
@@ -128,18 +128,29 @@ export function openAICompletionToResponses(responseBody, customToolNames = null
   };
 }
 
+/**
+ * Extract assistant text from Responses API output.
+ * In the OpenAI Responses API:
+ * - Assistant message generation text has type: "output_text" (part.text)
+ * - Message-level refusal parts have type: "refusal" (part.refusal)
+ * - Top-level refusal output items have type: "refusal" (item.refusal)
+ * - Compatibility: some third-party bridges emit type: "text" (part.text)
+ * All other part types (images, audio, tool calls, annotations) are strictly ignored.
+ */
 export function extractTextFromResponsesOutput(output) {
   if (!Array.isArray(output)) return "";
   const texts = [];
   for (const item of output) {
     if (item?.type === "message" && Array.isArray(item.content)) {
       for (const part of item.content) {
-        if (part?.type === "output_text" && typeof part.text === "string") {
+        if ((part?.type === "output_text" || part?.type === "text") && typeof part.text === "string") {
           texts.push(part.text);
-        } else if (typeof part?.text === "string") {
-          texts.push(part.text);
+        } else if (part?.type === "refusal" && typeof part.refusal === "string") {
+          texts.push(part.refusal);
         }
       }
+    } else if (item?.type === "refusal" && typeof item.refusal === "string") {
+      texts.push(item.refusal);
     }
   }
   return texts.join("");

--- a/open-sse/handlers/chatCore/responseFormats.js
+++ b/open-sse/handlers/chatCore/responseFormats.js
@@ -210,10 +210,13 @@ export function responsesToOpenAICompletion(responseBody) {
   const finishReason = hasToolCalls ? "tool_calls" : (responseDone ? "stop" : (responseBody.status || "stop"));
 
   const usage = responseBody.usage || {};
-  const cacheRead = usage.cache_read_input_tokens || usage.cached_tokens || usage.input_tokens_details?.cached_tokens || 0;
-  const cacheCreate = usage.cache_creation_input_tokens || 0;
-  const inTokens = (usage.input_tokens || usage.prompt_tokens || 0) + cacheRead + cacheCreate;
+  // Per Responses API spec, input_tokens is already cache-inclusive.
+  // Cache info (cached_tokens) is reported in input_tokens_details as a subset breakdown,
+  // not an additive value.
+  const inTokens = usage.input_tokens || usage.prompt_tokens || 0;
   const outTokens = usage.output_tokens || usage.completion_tokens || 0;
+  const cacheRead = usage.cache_read_input_tokens || usage.cached_tokens || usage.input_tokens_details?.cached_tokens || 0;
+  const cacheCreate = usage.cache_creation_input_tokens || usage.input_tokens_details?.cache_creation_tokens || 0;
 
   const cacheDetails = (cacheRead > 0 || cacheCreate > 0)
     ? {

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -208,11 +208,8 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
       saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, silent: true });
       if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency: { total: Date.now() - requestStartTime } }));
 
-      // Same cache-inclusive total for the recorded detail, so the DB and the
-      // client-facing usage can never disagree.
-      const inTokensForLog = (usage.input_tokens || 0)
-        + (usage.cache_read_input_tokens || usage.cached_tokens || 0)
-        + (usage.cache_creation_input_tokens || 0);
+      // jsonResponse.usage comes from convertResponsesStreamToJson and is cache-inclusive.
+      const inTokensForLog = usage.input_tokens || usage.prompt_tokens || 0;
       const { msgItem, textContent } = pickAssistantMessageForChatCompletion(jsonResponse.output);
       const totalLatency = Date.now() - requestStartTime;
 
@@ -230,15 +227,13 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
       }
 
       // Build client-format response.
-      // input_tokens EXCLUDES cached tokens on cache-capable upstreams, so summing
-      // only input+output under-reports prompt_tokens — measured: 2012 reported
-      // where the real prompt was ~5344 with 5332 served from cache. Fold the cache
-      // counters in, and keep them visible in prompt_tokens_details so a client can
-      // tell a cache hit from a small prompt.
-      const cacheRead = usage.cache_read_input_tokens || usage.cached_tokens || 0;
-      const cacheCreate = usage.cache_creation_input_tokens || 0;
-      const inTokens = (usage.input_tokens || 0) + cacheRead + cacheCreate;
+      // Responses API usage.input_tokens is already cache-inclusive.
+      // Cache tokens ride in input_tokens_details.cached_tokens (or cache_read_input_tokens / cached_tokens).
+      const cacheRead = usage.cache_read_input_tokens || usage.cached_tokens || usage.input_tokens_details?.cached_tokens || 0;
+      const cacheCreate = usage.cache_creation_input_tokens || usage.input_tokens_details?.cache_creation_tokens || 0;
+      const inTokens = usage.input_tokens || usage.prompt_tokens || 0;
       const outTokens = usage.output_tokens || 0;
+      const totalTokens = usage.total_tokens || (inTokens + outTokens);
       const cacheDetails = (cacheRead > 0 || cacheCreate > 0)
         ? { prompt_tokens_details: {
               ...(cacheRead > 0 ? { cached_tokens: cacheRead } : {}),
@@ -262,7 +257,7 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
         finalResp = {
           response: {
             candidates: [{ content: { role: "model", parts: [{ text: textContent || "" }] }, finishReason: "STOP", index: 0 }],
-            usageMetadata: { promptTokenCount: inTokens, candidatesTokenCount: outTokens, totalTokenCount: inTokens + outTokens },
+            usageMetadata: { promptTokenCount: inTokens, candidatesTokenCount: outTokens, totalTokenCount: totalTokens },
             modelVersion: model,
             responseId: jsonResponse.id || `resp_${Date.now()}`
           }
@@ -280,7 +275,7 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
           created: jsonResponse.created_at || Math.floor(Date.now() / 1000),
           model: jsonResponse.model || model,
           choices: [{ index: 0, message, finish_reason: finishReason }],
-          usage: { prompt_tokens: inTokens, completion_tokens: outTokens, total_tokens: inTokens + outTokens, ...cacheDetails }
+          usage: { prompt_tokens: inTokens, completion_tokens: outTokens, total_tokens: totalTokens, ...cacheDetails }
         };
       }
 

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -5,6 +5,7 @@ import { FORMATS } from "../../translator/formats.js";
 import { PROVIDERS } from "../../config/providers.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { ROLE, RESPONSES_ITEM } from "../../translator/schema/index.js";
+import { openAICompletionToClaudeMessage, responsesToClaudeMessage } from "./responseFormats.js";
 
 // Responses-API providers (e.g. codex) may emit SSE without content-type + use Responses output shape
 const isResponsesProvider = (p) => PROVIDERS[p]?.format === FORMATS.OPENAI_RESPONSES;
@@ -266,6 +267,8 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
             responseId: jsonResponse.id || `resp_${Date.now()}`
           }
         };
+      } else if (sourceFormat === FORMATS.CLAUDE) {
+        finalResp = responsesToClaudeMessage(jsonResponse);
       } else {
         const message = { role: "assistant", content: textContent || (hasToolCalls ? null : "") };
         if (hasToolCalls) message.tool_calls = toolCalls;
@@ -349,7 +352,9 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
     // already imports parseSSEToOpenAIResponse from this module.
     const finalBody = sourceFormat === FORMATS.OPENAI_RESPONSES
       ? chatCompletionToResponses(parsed, customToolNames)
-      : parsed;
+      : (sourceFormat === FORMATS.CLAUDE
+        ? openAICompletionToClaudeMessage(parsed)
+        : parsed);
 
     return { success: true, response: new Response(JSON.stringify(finalBody), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
   } catch (err) {

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -4,8 +4,7 @@ import { HTTP_STATUS } from "../../config/runtimeConfig.js";
 import { FORMATS } from "../../translator/formats.js";
 import { PROVIDERS } from "../../config/providers.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
-import { ROLE, RESPONSES_ITEM } from "../../translator/schema/index.js";
-import { openAICompletionToClaudeMessage, responsesToClaudeMessage } from "./responseFormats.js";
+import { openAICompletionToClaudeMessage, openAICompletionToResponses, responsesToClaudeMessage } from "./responseFormats.js";
 
 // Responses-API providers (e.g. codex) may emit SSE without content-type + use Responses output shape
 const isResponsesProvider = (p) => PROVIDERS[p]?.format === FORMATS.OPENAI_RESPONSES;
@@ -34,76 +33,6 @@ function pickAssistantMessageForChatCompletion(output) {
   }
   const last = messages[messages.length - 1];
   return { msgItem: last, textContent: textFromResponsesMessageItem(last) };
-}
-
-/**
- * Convert an OpenAI Chat Completions JSON body into the Responses API shape.
- * Inlined here (not imported from nonStreamingHandler.js) to avoid a circular
- * import. Mirrors openAICompletionToResponses in nonStreamingHandler.js.
- */
-function extractCustomToolInput(argumentsValue) {
-  const argumentsText = typeof argumentsValue === "string" ? argumentsValue : JSON.stringify(argumentsValue || {});
-  try {
-    const parsed = JSON.parse(argumentsText);
-    if (parsed && typeof parsed === "object" && typeof parsed.input === "string") return parsed.input;
-  } catch { /* raw freeform input */ }
-  return argumentsText;
-}
-
-function chatCompletionToResponses(responseBody, customToolNames = null) {
-  const choice = responseBody?.choices?.[0];
-  if (!choice) return responseBody;
-
-  const message = choice.message || {};
-  const output = [];
-
-  const reasoning = message.reasoning_content || message.reasoning;
-  if (typeof reasoning === "string" && reasoning.length > 0) {
-    output.push({
-      type: RESPONSES_ITEM.REASONING,
-      summary: [{ type: RESPONSES_ITEM.SUMMARY_TEXT, text: reasoning }],
-    });
-  }
-
-  const text = typeof message.content === "string" ? message.content : "";
-  if (text.length > 0) {
-    output.push({
-      type: RESPONSES_ITEM.MESSAGE,
-      role: ROLE.ASSISTANT,
-      content: [{ type: RESPONSES_ITEM.OUTPUT_TEXT, text, annotations: [] }],
-    });
-  }
-
-  for (const tc of message.tool_calls || []) {
-    const fn = tc.function || {};
-    const custom = customToolNames?.has(fn.name);
-    output.push({
-      type: custom ? RESPONSES_ITEM.CUSTOM_TOOL_CALL : RESPONSES_ITEM.FUNCTION_CALL,
-      id: `${custom ? "ctc" : "fc"}_${tc.id || ""}`,
-      call_id: tc.id || "",
-      name: fn.name || "",
-      ...(custom
-        ? { input: extractCustomToolInput(fn.arguments) }
-        : { arguments: typeof fn.arguments === "string" ? fn.arguments : JSON.stringify(fn.arguments || {}) }),
-    });
-  }
-
-  const usage = responseBody.usage || {};
-  return {
-    id: `resp_${responseBody.id || ""}`.replace(/^resp_chatcmpl-/, "resp_"),
-    object: "response",
-    created_at: responseBody.created || Math.floor(Date.now() / 1000),
-    model: responseBody.model || "unknown",
-    status: "completed",
-    background: false,
-    error: null,
-    output,
-    usage: {
-      input_tokens: usage.prompt_tokens || usage.input_tokens || 0,
-      output_tokens: usage.completion_tokens || usage.output_tokens || 0,
-      total_tokens: usage.total_tokens || (usage.prompt_tokens || 0) + (usage.completion_tokens || 0),
-    },
-  };
 }
 
 /**
@@ -342,11 +271,9 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
     // A Responses-format client (e.g. Codex) forced this provider to stream,
     // but wants JSON back. parseSSEToOpenAIResponse yields a Chat Completions
     // body; convert it to the Responses `output` shape so tool_calls are not
-    // lost on the non-streaming return path. Inlined (not imported from
-    // nonStreamingHandler.js) to avoid a circular import: nonStreamingHandler
-    // already imports parseSSEToOpenAIResponse from this module.
+    // lost on the non-streaming return path.
     const finalBody = sourceFormat === FORMATS.OPENAI_RESPONSES
-      ? chatCompletionToResponses(parsed, customToolNames)
+      ? openAICompletionToResponses(parsed, customToolNames)
       : (sourceFormat === FORMATS.CLAUDE
         ? openAICompletionToClaudeMessage(parsed)
         : parsed);

--- a/open-sse/transformer/streamToJsonConverter.js
+++ b/open-sse/transformer/streamToJsonConverter.js
@@ -1,8 +1,24 @@
 /**
  * Stream-to-JSON Converter
  * Converts Responses API SSE stream to single JSON response
- * Used when client requests non-streaming but provider forces streaming (e.g., Codex)
+ * Used when client requests non-streaming but provider forces streaming (e.g., Codex, OpenCode Go)
  */
+
+const EMPTY_RESPONSE = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };
+
+function createInitialState() {
+  return {
+    responseId: "",
+    model: "",
+    created: Math.floor(Date.now() / 1000),
+    status: "in_progress",
+    usage: { ...EMPTY_RESPONSE },
+    items: new Map(),
+    itemIdMap: new Map(),
+    hasEvents: false,
+    error: null,
+  };
+}
 
 /**
  * Process a single SSE message and update state accordingly.
@@ -10,43 +26,153 @@
 function processSSEMessage(msg, state) {
   if (!msg.trim()) return;
 
-  const eventMatch = msg.match(/^event:\s*(.+)$/m);
-  const dataMatch = msg.match(/^data:\s*(.+)$/m);
-  if (!eventMatch || !dataMatch) return;
+  const lines = msg.split(/\r?\n/);
+  let eventType = "";
+  const dataLines = [];
 
-  const eventType = eventMatch[1].trim();
-  const dataStr = dataMatch[1].trim();
+  for (const line of lines) {
+    if (line.startsWith("event:")) {
+      eventType = line.slice(6).trim();
+    } else if (line.startsWith("data:")) {
+      dataLines.push(line.slice(5).trim());
+    }
+  }
+
+  if (dataLines.length === 0) return;
+  const dataStr = dataLines.join("\n");
   if (dataStr === "[DONE]") return;
 
   let parsed;
-  try { parsed = JSON.parse(dataStr); }
-  catch { return; }
+  try {
+    parsed = JSON.parse(dataStr);
+  } catch {
+    return;
+  }
+
+  if (!eventType && parsed?.type) eventType = parsed.type;
+  state.hasEvents = true;
 
   if (eventType === "response.created") {
-    state.responseId = parsed.response?.id || state.responseId;
-    state.created = parsed.response?.created_at || state.created;
+    state.responseId = parsed.response?.id || parsed.id || state.responseId;
+    state.created = parsed.response?.created_at || parsed.created_at || state.created;
+    state.model = parsed.response?.model || parsed.model || state.model;
+  } else if (eventType === "response.output_item.added") {
+    const idx = parsed.output_index ?? state.items.size;
+    if (parsed.item) {
+      state.items.set(idx, { ...parsed.item });
+      if (parsed.item.id) state.itemIdMap.set(parsed.item.id, idx);
+    }
+  } else if (eventType === "response.content_part.added") {
+    const idx = parsed.output_index ?? 0;
+    const item = state.items.get(idx) || { type: "message", role: "assistant", content: [] };
+    if (!Array.isArray(item.content)) item.content = [];
+    if (parsed.part) item.content.push({ ...parsed.part });
+    state.items.set(idx, item);
+  } else if (eventType === "response.output_text.delta") {
+    const idx = parsed.output_index ?? (parsed.item_id ? state.itemIdMap.get(parsed.item_id) : 0) ?? 0;
+    const item = state.items.get(idx) || { type: "message", role: "assistant", content: [] };
+    if (!Array.isArray(item.content)) item.content = [];
+    let textPart = item.content.find((c) => c?.type === "output_text");
+    if (!textPart) {
+      textPart = { type: "output_text", text: "" };
+      item.content.push(textPart);
+    }
+    textPart.text = (textPart.text || "") + (parsed.delta || "");
+    state.items.set(idx, item);
+  } else if (eventType === "response.reasoning_summary_text.delta") {
+    const idx = parsed.output_index ?? (parsed.item_id ? state.itemIdMap.get(parsed.item_id) : 0) ?? 0;
+    const item = state.items.get(idx) || { type: "reasoning", summary: [] };
+    if (!Array.isArray(item.summary)) item.summary = [];
+    let summaryPart = item.summary.find((s) => s?.type === "summary_text");
+    if (!summaryPart) {
+      summaryPart = { type: "summary_text", text: "" };
+      item.summary.push(summaryPart);
+    }
+    summaryPart.text = (summaryPart.text || "") + (parsed.delta || "");
+    state.items.set(idx, item);
+  } else if (eventType === "response.function_call_arguments.delta") {
+    const idx = parsed.output_index ?? (parsed.item_id ? state.itemIdMap.get(parsed.item_id) : 0) ?? 0;
+    const item = state.items.get(idx) || { type: "function_call", arguments: "" };
+    item.arguments = (item.arguments || "") + (parsed.delta || "");
+    state.items.set(idx, item);
   } else if (eventType === "response.output_item.done") {
-    state.items.set(parsed.output_index ?? 0, parsed.item);
+    const idx = parsed.output_index ?? (parsed.item?.id ? state.itemIdMap.get(parsed.item.id) : null) ?? state.items.size;
+    const existing = state.items.get(idx);
+    const incoming = parsed.item;
+    if (incoming) {
+      if (existing) {
+        if (incoming.type === "function_call" && !incoming.arguments && existing.arguments) {
+          incoming.arguments = existing.arguments;
+        }
+        if (incoming.type === "message" && (!incoming.content || incoming.content.length === 0) && existing.content?.length > 0) {
+          incoming.content = existing.content;
+        }
+      }
+      state.items.set(idx, incoming);
+      if (incoming.id) state.itemIdMap.set(incoming.id, idx);
+    }
   } else if (eventType === "response.completed" || eventType === "response.done") {
     state.status = "completed";
-    if (parsed.response?.usage) {
-      state.usage.input_tokens = parsed.response.usage.input_tokens || 0;
-      state.usage.output_tokens = parsed.response.usage.output_tokens || 0;
-      state.usage.total_tokens = parsed.response.usage.total_tokens || 0;
+    if (parsed.response?.id) state.responseId = parsed.response.id;
+    if (parsed.response?.model) state.model = parsed.response.model;
+    if (Array.isArray(parsed.response?.output) && parsed.response.output.length > 0) {
+      parsed.response.output.forEach((outItem, i) => {
+        const existing = state.items.get(i);
+        if (!existing || (!existing.arguments && outItem.arguments) || (!existing.content?.length && outItem.content?.length)) {
+          state.items.set(i, outItem);
+        }
+      });
     }
-  } else if (eventType === "response.failed") {
+    if (parsed.response?.usage) {
+      state.usage.input_tokens = parsed.response.usage.input_tokens || parsed.response.usage.prompt_tokens || 0;
+      state.usage.output_tokens = parsed.response.usage.output_tokens || parsed.response.usage.completion_tokens || 0;
+      state.usage.total_tokens = parsed.response.usage.total_tokens || (state.usage.input_tokens + state.usage.output_tokens);
+      if (parsed.response.usage.input_tokens_details) {
+        state.usage.input_tokens_details = parsed.response.usage.input_tokens_details;
+      }
+      if (parsed.response.usage.cache_read_input_tokens) {
+        state.usage.cache_read_input_tokens = parsed.response.usage.cache_read_input_tokens;
+      }
+      if (parsed.response.usage.cache_creation_input_tokens) {
+        state.usage.cache_creation_input_tokens = parsed.response.usage.cache_creation_input_tokens;
+      }
+    }
+  } else if (eventType === "response.failed" || eventType === "error") {
     state.status = "failed";
+    state.error = parsed.error || parsed.response?.error || { message: "Response failed" };
   }
 }
 
-const EMPTY_RESPONSE = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };
+function buildResponsesJsonObject(state, fallbackModel = "unknown") {
+  const output = [];
+  const maxIndex = state.items.size > 0 ? Math.max(...state.items.keys()) : -1;
+  for (let i = 0; i <= maxIndex; i++) {
+    if (state.items.has(i)) {
+      output.push(state.items.get(i));
+    } else {
+      output.push({ type: "message", content: [], role: "assistant" });
+    }
+  }
+
+  return {
+    id: state.responseId || `resp_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    object: "response",
+    created_at: state.created,
+    status: state.status || "completed",
+    model: state.model || fallbackModel || "unknown",
+    output,
+    usage: state.usage,
+    ...(state.error ? { error: state.error } : {}),
+  };
+}
 
 /**
  * Convert Responses API SSE stream to single JSON response
  * @param {ReadableStream} stream - SSE stream from provider
+ * @param {string} [fallbackModel="unknown"]
  * @returns {Promise<Object>} Final JSON response in Responses API format
  */
-export async function convertResponsesStreamToJson(stream) {
+export async function convertResponsesStreamToJson(stream, fallbackModel = "unknown") {
   if (!stream || typeof stream.getReader !== "function") {
     return { id: `resp_${Date.now()}`, object: "response", created_at: Math.floor(Date.now() / 1000), status: "failed", output: [], usage: { ...EMPTY_RESPONSE } };
   }
@@ -54,14 +180,7 @@ export async function convertResponsesStreamToJson(stream) {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
-
-  const state = {
-    responseId: "",
-    created: Math.floor(Date.now() / 1000),
-    status: "in_progress",
-    usage: { ...EMPTY_RESPONSE },
-    items: new Map()
-  };
+  const state = createInitialState();
 
   try {
     while (true) {
@@ -69,7 +188,7 @@ export async function convertResponsesStreamToJson(stream) {
       if (done) break;
 
       buffer += decoder.decode(value, { stream: true });
-      const messages = buffer.split("\n\n");
+      const messages = buffer.split(/\r?\n\r?\n/);
       buffer = messages.pop() || "";
 
       for (const msg of messages) {
@@ -85,19 +204,24 @@ export async function convertResponsesStreamToJson(stream) {
     reader.releaseLock();
   }
 
-  // Build output array from accumulated items (ordered by index)
-  const output = [];
-  const maxIndex = state.items.size > 0 ? Math.max(...state.items.keys()) : -1;
-  for (let i = 0; i <= maxIndex; i++) {
-    output.push(state.items.get(i) || { type: "message", content: [], role: "assistant" });
+  return buildResponsesJsonObject(state, fallbackModel);
+}
+
+/**
+ * Parse raw Responses API SSE text into a single JSON response
+ * @param {string} rawSSE - Raw SSE text
+ * @param {string} [fallbackModel="unknown"]
+ * @returns {Object|null} Final JSON response in Responses API format, or null if no valid events
+ */
+export function parseResponsesSSEToJSON(rawSSE, fallbackModel = "unknown") {
+  if (!rawSSE || typeof rawSSE !== "string") return null;
+
+  const state = createInitialState();
+  const messages = rawSSE.split(/\r?\n\r?\n/);
+  for (const msg of messages) {
+    processSSEMessage(msg, state);
   }
 
-  return {
-    id: state.responseId || `resp_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
-    object: "response",
-    created_at: state.created,
-    status: state.status || "completed",
-    output,
-    usage: state.usage
-  };
+  if (!state.hasEvents && state.items.size === 0) return null;
+  return buildResponsesJsonObject(state, fallbackModel);
 }

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -262,6 +262,9 @@ function isCustomTool(state, name) {
   return !!name && state.customToolNames?.has(name);
 }
 
+// NOTE: intentionally local (not imported from handlers/chatCore/responseFormats.js):
+// translator modules must not depend on handlers (dependency flows handlers → translator).
+// Non-string input returns "" here (streaming fragments are always strings at call sites).
 function extractCustomToolInput(argumentsText) {
   if (typeof argumentsText !== "string") return "";
   try {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "next build --webpack",
     "postbuild": "node scripts/copy-standalone-assets.mjs",
     "postbuild:bun": "node scripts/copy-standalone-assets.mjs",
-    "start": "node custom-server.js --port 20127",
+    "start": "node custom-server.js --port 20128",
     "dev:bun": "bun --bun next dev --webpack --port 20127",
     "build:bun": "bun --bun next build --webpack",
     "start:bun": "bun ./.next/standalone/custom-server.js",

--- a/tests/unit/responses-to-claude-nonstream.test.js
+++ b/tests/unit/responses-to-claude-nonstream.test.js
@@ -253,8 +253,6 @@ describe("translateNonStreamingResponse for Responses API upstream", () => {
     expect(claudeOut.usage.output_tokens).toBe(25);
     expect(claudeOut.usage.cache_read_input_tokens).toBe(40);
   });
-
-
 });
 
 describe("handleNonStreamingResponse with Responses API upstream returning SSE", () => {
@@ -397,6 +395,28 @@ describe("handleForcedSSEToJson with Claude client", () => {
   });
 });
 
+describe("extractTextFromResponsesOutput handling", () => {
+  it("extracts output_text, message refusal, top-level refusal, and loose text parts strictly, ignoring non-text parts", () => {
+    const output = [
+      {
+        type: "message",
+        role: "assistant",
+        content: [
+          { type: "output_text", text: "Part 1. " },
+          { type: "non_text_part", text: "Should be ignored" },
+          { type: "refusal", refusal: "Cannot fulfill request. " },
+          { type: "text", text: "Compatibility part. " },
+        ],
+      },
+      {
+        type: "refusal",
+        refusal: "Top level refusal.",
+      },
+    ];
+    const text = extractTextFromResponsesOutput(output);
+    expect(text).toBe("Part 1. Cannot fulfill request. Compatibility part. Top level refusal.");
+  });
+});
 
 describe("parseResponsesSSEToJSON parser robustness", () => {
   it("parses raw SSE string without event headers", () => {

--- a/tests/unit/responses-to-claude-nonstream.test.js
+++ b/tests/unit/responses-to-claude-nonstream.test.js
@@ -1,0 +1,383 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}),
+  saveRequestUsage: vi.fn(async () => {}),
+}));
+
+const { FORMATS } = await import("../../open-sse/translator/formats.js");
+const {
+  translateNonStreamingResponse,
+  handleNonStreamingResponse,
+  responsesToOpenAICompletion,
+  responsesToClaudeMessage,
+} = await import("../../open-sse/handlers/chatCore/nonStreamingHandler.js");
+const { extractTextFromResponsesOutput } = await import("../../open-sse/handlers/chatCore/responseFormats.js");
+const { handleForcedSSEToJson } = await import("../../open-sse/handlers/chatCore/sseToJsonHandler.js");
+const { parseResponsesSSEToJSON } = await import("../../open-sse/transformer/streamToJsonConverter.js");
+
+const RESPONSES_TEXT_BODY = {
+  id: "resp_abc123",
+  object: "response",
+  created_at: 1700000000,
+  model: "muse-spark-1.3-contributor",
+  status: "completed",
+  output: [
+    {
+      type: "message",
+      role: "assistant",
+      content: [{ type: "output_text", text: "Hello from muse-spark 1.3!" }],
+    },
+  ],
+  usage: { input_tokens: 12, output_tokens: 7, total_tokens: 19 },
+};
+
+const RESPONSES_THINKING_BODY = {
+  id: "resp_think456",
+  object: "response",
+  created_at: 1700000000,
+  model: "muse-spark-1.3-contributor",
+  status: "completed",
+  output: [
+    {
+      type: "reasoning",
+      summary: [{ type: "summary_text", text: "Thinking step by step..." }],
+    },
+    {
+      type: "message",
+      role: "assistant",
+      content: [{ type: "output_text", text: "Here is the final answer." }],
+    },
+  ],
+  usage: { input_tokens: 20, output_tokens: 15, total_tokens: 35 },
+};
+
+const RESPONSES_TOOL_BODY = {
+  id: "resp_tool789",
+  object: "response",
+  created_at: 1700000000,
+  model: "muse-spark-1.3-contributor",
+  status: "completed",
+  output: [
+    {
+      type: "function_call",
+      id: "fc_1",
+      call_id: "call_weather_1",
+      name: "get_weather",
+      arguments: '{"city":"Tokyo"}',
+    },
+    {
+      type: "function_call",
+      id: "fc_2",
+      call_id: "call_weather_2",
+      name: "get_weather",
+      arguments: '{"city":"Kyoto"}',
+    },
+  ],
+  usage: { input_tokens: 25, output_tokens: 30, total_tokens: 55 },
+};
+
+describe("translateNonStreamingResponse for Responses API upstream", () => {
+  it("translates Responses text response to Claude Message for Claude client", () => {
+    const out = translateNonStreamingResponse(RESPONSES_TEXT_BODY, FORMATS.OPENAI_RESPONSES, FORMATS.CLAUDE);
+    expect(out.type).toBe("message");
+    expect(out.role).toBe("assistant");
+    expect(out.model).toBe("muse-spark-1.3-contributor");
+    expect(out.content).toEqual([{ type: "text", text: "Hello from muse-spark 1.3!" }]);
+    expect(out.stop_reason).toBe("end_turn");
+    expect(out.usage).toEqual({ input_tokens: 12, output_tokens: 7 });
+  });
+
+  it("translates Responses reasoning + text response to Claude Message with thinking block", () => {
+    const out = translateNonStreamingResponse(RESPONSES_THINKING_BODY, FORMATS.OPENAI_RESPONSES, FORMATS.CLAUDE);
+    expect(out.type).toBe("message");
+    expect(out.role).toBe("assistant");
+    expect(out.content).toHaveLength(2);
+    expect(out.content[0]).toEqual({ type: "thinking", thinking: "Thinking step by step..." });
+    expect(out.content[1]).toEqual({ type: "text", text: "Here is the final answer." });
+    expect(out.stop_reason).toBe("end_turn");
+  });
+
+  it("translates Responses tool calls to Claude Message with tool_use blocks and stop_reason tool_use", () => {
+    const out = translateNonStreamingResponse(RESPONSES_TOOL_BODY, FORMATS.OPENAI_RESPONSES, FORMATS.CLAUDE);
+    expect(out.type).toBe("message");
+    expect(out.role).toBe("assistant");
+    expect(out.stop_reason).toBe("tool_use");
+    expect(out.content).toHaveLength(2);
+    expect(out.content[0]).toEqual({
+      type: "tool_use",
+      id: "call_weather_1",
+      name: "get_weather",
+      input: { city: "Tokyo" },
+    });
+    expect(out.content[1]).toEqual({
+      type: "tool_use",
+      id: "call_weather_2",
+      name: "get_weather",
+      input: { city: "Kyoto" },
+    });
+  });
+
+  it("translates Responses API response to OpenAI chat.completion for OpenAI client", () => {
+    const out = translateNonStreamingResponse(RESPONSES_TOOL_BODY, FORMATS.OPENAI_RESPONSES, FORMATS.OPENAI);
+    expect(out.object).toBe("chat.completion");
+    expect(out.choices[0].finish_reason).toBe("tool_calls");
+    expect(out.choices[0].message.tool_calls).toHaveLength(2);
+    expect(out.choices[0].message.tool_calls[0]).toEqual({
+      id: "call_weather_1",
+      type: "function",
+      function: { name: "get_weather", arguments: '{"city":"Tokyo"}' },
+    });
+  });
+
+  it("translates Gemini response to Claude Message for Claude client", () => {
+    const geminiBody = {
+      candidates: [
+        {
+          content: { parts: [{ text: "Gemini response text" }] },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: { promptTokenCount: 8, candidatesTokenCount: 4, totalTokenCount: 12 },
+    };
+    const out = translateNonStreamingResponse(geminiBody, FORMATS.GEMINI, FORMATS.CLAUDE);
+    expect(out.type).toBe("message");
+    expect(out.content).toEqual([{ type: "text", text: "Gemini response text" }]);
+    expect(out.stop_reason).toBe("end_turn");
+  });
+
+  it("translates Responses custom_tool_call to OpenAI chat tool_calls", () => {
+    const customBody = {
+      id: "resp_custom1",
+      object: "response",
+      created_at: 1700000000,
+      model: "muse-spark-1.3-contributor",
+      status: "completed",
+      output: [
+        {
+          type: "custom_tool_call",
+          id: "ctc_1",
+          call_id: "call_exec_1",
+          name: "exec",
+          input: '{"cmd":"ls"}',
+        },
+      ],
+      usage: { input_tokens: 30, output_tokens: 10, total_tokens: 40 },
+    };
+    const out = translateNonStreamingResponse(customBody, FORMATS.OPENAI_RESPONSES, FORMATS.OPENAI);
+    expect(out.object).toBe("chat.completion");
+    expect(out.choices[0].finish_reason).toBe("tool_calls");
+    expect(out.choices[0].message.tool_calls).toEqual([
+      {
+        id: "call_exec_1",
+        type: "function",
+        function: { name: "exec", arguments: '{"cmd":"ls"}' },
+      },
+    ]);
+  });
+
+  it("translates Responses custom_tool_call to Claude tool_use block", () => {
+    const customBody = {
+      id: "resp_custom2",
+      object: "response",
+      created_at: 1700000000,
+      model: "muse-spark-1.3-contributor",
+      status: "completed",
+      output: [
+        {
+          type: "custom_tool_call",
+          id: "ctc_1",
+          call_id: "call_exec_1",
+          name: "exec",
+          input: '{"cmd":"ls"}',
+        },
+      ],
+      usage: { input_tokens: 30, output_tokens: 10, total_tokens: 40 },
+    };
+    const out = translateNonStreamingResponse(customBody, FORMATS.OPENAI_RESPONSES, FORMATS.CLAUDE);
+    expect(out.type).toBe("message");
+    expect(out.stop_reason).toBe("tool_use");
+    expect(out.content).toEqual([
+      { type: "tool_use", id: "call_exec_1", name: "exec", input: { cmd: "ls" } },
+    ]);
+  });
+
+  it("translates Ollama response to Claude Message for Claude client", () => {
+    const ollamaBody = {
+      model: "llama3",
+      message: { role: "assistant", content: "Ollama says hi" },
+      done_reason: "stop",
+    };
+    const out = translateNonStreamingResponse(ollamaBody, FORMATS.OLLAMA, FORMATS.CLAUDE);
+    expect(out.type).toBe("message");
+    expect(out.content).toEqual([{ type: "text", text: "Ollama says hi" }]);
+    expect(out.stop_reason).toBe("end_turn");
+  });
+
+
+});
+
+describe("handleNonStreamingResponse with Responses API upstream returning SSE", () => {
+  const buildResponsesSSE = () => [
+    'event: response.created\ndata: {"response":{"id":"resp_sse_1","model":"muse-spark-1.3-contributor","created_at":1700000000}}',
+    'event: response.output_item.added\ndata: {"output_index":0,"item":{"id":"msg_0","type":"message","role":"assistant","content":[]}}',
+    'event: response.output_text.delta\ndata: {"output_index":0,"delta":"Hello "}',
+    'event: response.output_text.delta\ndata: {"output_index":0,"delta":"from SSE muse-spark!"}',
+    'event: response.output_item.done\ndata: {"output_index":0,"item":{"id":"msg_0","type":"message","role":"assistant","content":[{"type":"output_text","text":"Hello from SSE muse-spark!"}]}}',
+    'event: response.completed\ndata: {"response":{"id":"resp_sse_1","status":"completed","usage":{"input_tokens":15,"output_tokens":8,"total_tokens":23}}}',
+    "data: [DONE]",
+    "",
+  ].join("\n\n");
+
+  const buildResponsesToolSSE = () => [
+    'event: response.created\ndata: {"response":{"id":"resp_sse_tools","model":"muse-spark-1.3-contributor","created_at":1700000000}}',
+    'event: response.output_item.added\ndata: {"output_index":0,"item":{"id":"fc_0","type":"function_call","call_id":"call_read_1","name":"read_file","arguments":""}}',
+    'event: response.function_call_arguments.delta\ndata: {"item_id":"fc_0","delta":"{\\"path\\":\\"/tmp/file.txt\\"}"}',
+    'event: response.output_item.done\ndata: {"output_index":0,"item":{"id":"fc_0","type":"function_call","call_id":"call_read_1","name":"read_file","arguments":"{\\"path\\":\\"/tmp/file.txt\\"}"}}',
+    'event: response.completed\ndata: {"response":{"id":"resp_sse_tools","status":"completed","usage":{"input_tokens":30,"output_tokens":12,"total_tokens":42}}}',
+    "data: [DONE]",
+    "",
+  ].join("\n\n");
+
+  const makeCtx = (sourceFormat, targetFormat, sseText) => ({
+    providerResponse: new Response(sseText, { headers: { "content-type": "text/event-stream" } }),
+    provider: "opencode-go",
+    model: "muse-spark-1.3-contributor",
+    sourceFormat,
+    targetFormat,
+    body: { model: "muse-spark-1.3-contributor", stream: false },
+    stream: false,
+    requestStartTime: Date.now(),
+    connectionId: "conn-123",
+    clientRawRequest: { endpoint: "/v1/messages" },
+    reqLogger: {
+      logProviderResponse: vi.fn(),
+      logConvertedResponse: vi.fn(),
+    },
+    trackDone: vi.fn(),
+    appendLog: vi.fn(),
+  });
+
+  it("handles non-streaming Claude request to opencode-go muse-spark 1.3 returning SSE text", async () => {
+    const ctx = makeCtx(FORMATS.CLAUDE, FORMATS.OPENAI_RESPONSES, buildResponsesSSE());
+    const result = await handleNonStreamingResponse(ctx);
+    expect(result.success).toBe(true);
+    const json = await result.response.json();
+    expect(json.type).toBe("message");
+    expect(json.role).toBe("assistant");
+    expect(json.content).toEqual([{ type: "text", text: "Hello from SSE muse-spark!" }]);
+    expect(json.stop_reason).toBe("end_turn");
+    expect(json.usage).toEqual({ input_tokens: 2015, output_tokens: 8 });
+  });
+
+  it("handles non-streaming Claude request with tool calls returning SSE", async () => {
+    const ctx = makeCtx(FORMATS.CLAUDE, FORMATS.OPENAI_RESPONSES, buildResponsesToolSSE());
+    const result = await handleNonStreamingResponse(ctx);
+    expect(result.success).toBe(true);
+    const json = await result.response.json();
+    expect(json.type).toBe("message");
+    expect(json.stop_reason).toBe("tool_use");
+    expect(json.content).toEqual([
+      {
+        type: "tool_use",
+        id: "call_read_1",
+        name: "read_file",
+        input: { path: "/tmp/file.txt" },
+      },
+    ]);
+  });
+
+  it("handles non-streaming OpenAI chat request to Responses upstream returning SSE", async () => {
+    const ctx = makeCtx(FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, buildResponsesSSE());
+    const result = await handleNonStreamingResponse(ctx);
+    expect(result.success).toBe(true);
+    const json = await result.response.json();
+    expect(json.object).toBe("chat.completion");
+    expect(json.choices[0].message.content).toBe("Hello from SSE muse-spark!");
+    expect(json.choices[0].finish_reason).toBe("stop");
+  });
+
+  it("returns 502 when the Responses upstream SSE signals failure", async () => {
+    const failedSSE = [
+      'event: response.created\ndata: {"response":{"id":"resp_sse_fail","model":"muse-spark-1.3-contributor","created_at":1700000000}}',
+      'event: response.failed\ndata: {"error":{"message":"upstream boom"}}',
+      "data: [DONE]",
+      "",
+    ].join("\n\n");
+    const ctx = makeCtx(FORMATS.CLAUDE, FORMATS.OPENAI_RESPONSES, failedSSE);
+    const result = await handleNonStreamingResponse(ctx);
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(502);
+  });
+});
+
+describe("handleForcedSSEToJson with Claude client", () => {
+  const encoder = new TextEncoder();
+  const responsesSSE = [
+    'event: response.created\ndata: {"response":{"id":"resp_forced","model":"codex","created_at":1700000000}}',
+    'event: response.output_item.added\ndata: {"output_index":0,"item":{"id":"msg_1","type":"message","role":"assistant","content":[]}}',
+    'event: response.output_text.delta\ndata: {"output_index":0,"delta":"Codex forced stream result"}',
+    'event: response.output_item.done\ndata: {"output_index":0,"item":{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"output_text","text":"Codex forced stream result"}]}}',
+    'event: response.completed\ndata: {"response":{"id":"resp_forced","status":"completed","usage":{"input_tokens":10,"output_tokens":6,"total_tokens":16}}}',
+    "data: [DONE]",
+    "",
+  ].join("\n\n");
+
+  it("returns Claude Message for Claude client on Responses-format forced SSE", async () => {
+    const ctx = {
+      providerResponse: new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode(responsesSSE));
+            controller.close();
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } }
+      ),
+      sourceFormat: FORMATS.CLAUDE,
+      targetFormat: FORMATS.OPENAI_RESPONSES,
+      provider: "codex",
+      model: "gpt-5-codex",
+      body: { model: "gpt-5-codex", messages: [] },
+      stream: false,
+      requestStartTime: Date.now(),
+      connectionId: "test-conn",
+      clientRawRequest: { endpoint: "/v1/messages" },
+      trackDone: vi.fn(),
+      appendLog: vi.fn(),
+    };
+
+    const result = await handleForcedSSEToJson(ctx);
+    expect(result.success).toBe(true);
+    const json = await result.response.json();
+    expect(json.type).toBe("message");
+    expect(json.role).toBe("assistant");
+    expect(json.content).toEqual([{ type: "text", text: "Codex forced stream result" }]);
+    expect(json.stop_reason).toBe("end_turn");
+  });
+});
+
+
+describe("parseResponsesSSEToJSON parser robustness", () => {
+  it("parses raw SSE string without event headers", () => {
+    const raw = [
+      'data: {"type":"response.created","response":{"id":"resp_no_event","model":"m1"}}',
+      'data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","content":[{"type":"output_text","text":"Parsed without event header"}]}}',
+      'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":5,"output_tokens":5,"total_tokens":10}}}',
+      "data: [DONE]",
+      "",
+    ].join("\n\n");
+    const parsed = parseResponsesSSEToJSON(raw, "m1");
+    expect(parsed).toBeTruthy();
+    expect(parsed.id).toBe("resp_no_event");
+    expect(parsed.output[0].content[0].text).toBe("Parsed without event header");
+    expect(parsed.usage.total_tokens).toBe(10);
+  });
+
+  it("returns null on empty or non-event SSE", () => {
+    expect(parseResponsesSSEToJSON("")).toBeNull();
+    expect(parseResponsesSSEToJSON("data: [DONE]\n\n")).toBeNull();
+    expect(parseResponsesSSEToJSON(": comment only\n\n")).toBeNull();
+  });
+});

--- a/tests/unit/responses-to-claude-nonstream.test.js
+++ b/tests/unit/responses-to-claude-nonstream.test.js
@@ -215,6 +215,45 @@ describe("translateNonStreamingResponse for Responses API upstream", () => {
     expect(out.stop_reason).toBe("end_turn");
   });
 
+  it("handles Responses API cached tokens without inflating input_tokens or total_tokens", () => {
+    const cachedBody = {
+      id: "resp_cache_test",
+      object: "response",
+      created_at: 1700000000,
+      model: "muse-spark-1.3-contributor",
+      status: "completed",
+      output: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Response with cache" }],
+        },
+      ],
+      usage: {
+        input_tokens: 100,
+        output_tokens: 25,
+        total_tokens: 125,
+        input_tokens_details: { cached_tokens: 40 },
+      },
+    };
+
+    // 1. Convert to OpenAI chat.completion:
+    // prompt_tokens must be 100 (not 140), total_tokens must be 125, cached_tokens in prompt_tokens_details
+    const openAIOut = responsesToOpenAICompletion(cachedBody);
+    expect(openAIOut.usage.prompt_tokens).toBe(100);
+    expect(openAIOut.usage.completion_tokens).toBe(25);
+    expect(openAIOut.usage.total_tokens).toBe(125);
+    expect(openAIOut.usage.prompt_tokens_details).toEqual({ cached_tokens: 40 });
+
+    // 2. Convert to Claude message:
+    // input_tokens must be 100, output_tokens 25, cache_read_input_tokens 40
+    const claudeOut = responsesToClaudeMessage(cachedBody);
+    expect(claudeOut.type).toBe("message");
+    expect(claudeOut.usage.input_tokens).toBe(100);
+    expect(claudeOut.usage.output_tokens).toBe(25);
+    expect(claudeOut.usage.cache_read_input_tokens).toBe(40);
+  });
+
 
 });
 

--- a/tests/unit/responses-to-claude-nonstream.test.js
+++ b/tests/unit/responses-to-claude-nonstream.test.js
@@ -305,6 +305,8 @@ describe("handleNonStreamingResponse with Responses API upstream returning SSE",
     expect(json.role).toBe("assistant");
     expect(json.content).toEqual([{ type: "text", text: "Hello from SSE muse-spark!" }]);
     expect(json.stop_reason).toBe("end_turn");
+    // Fixture declares input_tokens: 15; handleNonStreamingResponse adds the
+    // standard +2000 buffer via addBufferToUsage before returning.
     expect(json.usage).toEqual({ input_tokens: 2015, output_tokens: 8 });
   });
 


### PR DESCRIPTION
Non-streaming requests through Responses-API upstreams (muse-spark, Codex) returned wrong shapes for Claude/OpenAI clients or lost SSE deltas.

Commits:
- feat(chatCore): support Responses-API upstreams for non-streaming clients (shared responseFormats.js, Responses/Gemini/Ollama translation, Responses SSE parsing with error propagation)
- fix(usage): cache-inclusive token accounting on Responses paths (input_tokens no longer double-counts cache; details kept as subset breakdown)
- refactor(sseToJson): reuse shared converters, tighten text extraction (drop local duplicate; ignore non-text parts)
- fix(config): align start script default port with documented 20128

Verification: ESLint clean; 54/54 pass across 7 related suites (incl. new tests/unit/responses-to-claude-nonstream.test.js, 17 tests). 1 unrelated failure in openai-to-claude.test.js is catalogued in tests/__baseline__/known-fails.txt.