### PR TITLE
fix(dashboard): support managed production model tests

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -92,6 +92,22 @@ const nextConfig = {
         destination: "/api/v1"
       }
     ];
+  },
+  async headers() {
+    return [
+      {
+        source: "/dashboard/:path*",
+        headers: [
+          { key: "Cache-Control", value: "no-store, no-cache, must-revalidate, max-age=0" },
+        ],
+      },
+      {
+        source: "/login",
+        headers: [
+          { key: "Cache-Control", value: "no-store, no-cache, must-revalidate, max-age=0" },
+        ],
+      },
+    ];
   }
 };
 

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -86,6 +86,18 @@ export default function APIPageClient({ machineId }) {
 
   const { copied, copy } = useCopyToClipboard();
 
+  const fetchTunnelStatus = async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    try {
+      const response = await fetch("/api/tunnel/status", { cache: "no-store", signal: controller.signal });
+      if (!response.ok) throw new Error(`Tunnel status HTTP ${response.status}`);
+      return await response.json();
+    } finally {
+      clearTimeout(timeout);
+    }
+  };
+
   // Security gate: block remote exposure while dashboard uses default password or login is off.
   const isLoginUnsafe = !requireLogin || !hasPassword;
   const unsafeReason = !requireLogin
@@ -173,9 +185,7 @@ export default function APIPageClient({ machineId }) {
   // Trust user intent (settingsEnabled): UI stays "enabled" while watchdog restarts process
   const syncTunnelStatus = async () => {
     try {
-      const statusRes = await fetch("/api/tunnel/status", { cache: "no-store" });
-      if (!statusRes.ok) return;
-      const data = await statusRes.json();
+      const data = await fetchTunnelStatus();
       const tEnabled = data.tunnel?.settingsEnabled ?? data.tunnel?.enabled ?? false;
       const tUrl = data.tunnel?.tunnelUrl || "";
       setTunnelUrl(tUrl);
@@ -196,7 +206,9 @@ export default function APIPageClient({ machineId }) {
     try {
       const [settingsRes, statusRes] = await Promise.all([
         fetch("/api/settings"),
-        fetch("/api/tunnel/status", { cache: "no-store" })
+        fetchTunnelStatus()
+          .then((data) => ({ ok: true, json: async () => data }))
+          .catch(() => ({ ok: false }))
       ]);
       if (settingsRes.ok) {
         const data = await settingsRes.json();
@@ -222,6 +234,8 @@ export default function APIPageClient({ machineId }) {
       }
     } catch (error) {
       console.log("Error loading settings:", error);
+      setTunnelEnabled(false);
+      setTsEnabled(false);
     } finally {
       setTunnelChecking(false);
     }

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -31,7 +31,7 @@ export default function APIPageClient({ machineId }) {
  const [tunnelDashboardAccess, setTunnelDashboardAccess] = useState(false);
 
  // Cloudflare Tunnel state
-  const [tunnelChecking, setTunnelChecking] = useState(true);
+  const [tunnelChecking, setTunnelChecking] = useState(false);
   const [tunnelEnabled, setTunnelEnabled] = useState(false);
   const [tunnelReachable, setTunnelReachable] = useState(false);
   const [tunnelUrl, setTunnelUrl] = useState("");
@@ -202,7 +202,6 @@ export default function APIPageClient({ machineId }) {
   };
 
   const loadSettings = async () => {
-    setTunnelChecking(true);
     try {
       const [settingsRes, statusRes] = await Promise.all([
         fetch("/api/settings"),

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import PropTypes from "prop-types";
-import { Card, Button, Input, Modal, CardSkeleton, Toggle, ConfirmModal } from "@/shared/components";
+import { Card, Button, Input, Modal, Toggle, ConfirmModal } from "@/shared/components";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import {
   TUNNEL_BENEFITS,
@@ -704,15 +704,6 @@ export default function APIPageClient({ machineId }) {
       setBaseUrl(`${window.location.origin}/v1`);
     }
   }, []);
-
-  if (loading) {
-    return (
-      <div className="flex flex-col gap-8">
-        <CardSkeleton />
-        <CardSkeleton />
-      </div>
-    );
-  }
 
   const currentEndpoint = baseUrl;
 

--- a/src/app/api/models/test/ping.js
+++ b/src/app/api/models/test/ping.js
@@ -1,6 +1,8 @@
 import { getApiKeys } from "@/lib/localDb";
 import { UPDATER_CONFIG } from "@/shared/constants/config";
 import { getConsistentMachineId } from "@/shared/utils/machineId";
+import { handleChat } from "@/sse/handlers/chat.js";
+import { initTranslators } from "open-sse/translator/index.js";
 
 const CLI_TOKEN_SALT = "9r-cli-auth";
 
@@ -37,7 +39,7 @@ function createSilentWavFile() {
   return new Blob([buffer], { type: "audio/wav" });
 }
 
-async function getInternalHeaders() {
+export async function getInternalHeaders() {
   let apiKey = null;
   try {
     const keys = await getApiKeys();
@@ -48,6 +50,27 @@ async function getInternalHeaders() {
   if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
   headers["x-9r-cli-token"] = await getConsistentMachineId(CLI_TOKEN_SALT);
   return headers;
+}
+
+export async function pingModelDirect(model) {
+  await initTranslators();
+  const response = await handleChat(new Request("http://internal/api/v1/chat/completions", {
+    method: "POST",
+    headers: await getInternalHeaders(),
+    body: JSON.stringify({ model, max_tokens: 1024, stream: false, messages: [{ role: "user", content: "hi" }] }),
+  }));
+  const rawText = await response.text().catch(() => "");
+  let parsed = null;
+  try { parsed = rawText ? JSON.parse(rawText) : null; } catch {}
+  if (!response.ok) {
+    const detail = parsed?.error?.message || parsed?.error || rawText;
+    return { ok: false, status: response.status, error: `HTTP ${response.status}${detail ? `: ${String(detail).slice(0, 240)}` : ""}` };
+  }
+  if (parsed?.error) return { ok: false, status: response.status, error: String(parsed.error.message || parsed.error).slice(0, 240) };
+  if (!Array.isArray(parsed?.choices) || parsed.choices.length === 0) {
+    return { ok: false, status: response.status, error: "Provider returned no completion choices for this model" };
+  }
+  return { ok: true, status: response.status, error: null };
 }
 
 export async function pingModelByKind(model, kind, baseUrl = `http://127.0.0.1:${process.env.PORT || UPDATER_CONFIG.appPort}`) {

--- a/src/app/api/models/test/route.js
+++ b/src/app/api/models/test/route.js
@@ -1,12 +1,18 @@
 import { NextResponse } from "next/server";
-import { pingModelByKind } from "./ping";
+import { pingModelByKind, pingModelDirect } from "./ping";
 
 // POST /api/models/test - Ping a single model via internal completions or embeddings
 export async function POST(request) {
   try {
     const { model, kind } = await request.json();
     if (!model) return NextResponse.json({ error: "Model required" }, { status: 400 });
-    const result = await pingModelByKind(model, kind || "llm");
+    if ((kind || "llm") === "llm") return NextResponse.json(await pingModelDirect(model));
+    const forwardedHost = request.headers.get("x-forwarded-host") || request.headers.get("host");
+    const forwardedProto = request.headers.get("x-forwarded-proto") || "https";
+    const origin = forwardedHost
+      ? `${forwardedProto}://${forwardedHost}`
+      : new URL(request.url).origin;
+    const result = await pingModelByKind(model, kind || "llm", origin);
     return NextResponse.json(result);
   } catch (err) {
     return NextResponse.json({ ok: false, error: err.message }, { status: 500 });


### PR DESCRIPTION
## Problem

Managed deployments showed dashboard issues:

- The model test endpoint returned HTTP 500 because it self-fetched through a fixed localhost port.
- Refreshing the endpoint page showed a full-page skeleton until initial API requests completed.
- Tunnel status could remain stuck on `Checking...` because the initial state was `true` and `loadSettings()` waited for multiple requests.
- Dashboard HTML could remain stale behind long-lived CDN caching.

## Fix

- Run LLM model probes in-process through `handleChat`.
- Use forwarded host/protocol for non-LLM probe requests.
- Render the endpoint page shell immediately while endpoint data loads.
- Initialize tunnel checking as `false`; bound tunnel status requests to three seconds and fall back safely on failure.
- Mark dashboard and login HTML as `no-store` to prevent stale application documents.

## Verification

- Production `/api/models/test` returns HTTP 200 for `cx/gpt-6-astra`.
- Production `/api/models/test` returns HTTP 200 for `cx/gpt-5.6-luna`.
- Production `/v1/chat/completions` returns HTTP 200 for both models.
- Production endpoint page returns current HTML without the old loading skeleton.
- Targeted model routing tests pass.

No credentials, database exports, or deployment-only files are included.