### PR TITLE
chore(jsconfig): drop baseUrl so the configs survive TypeScript 7

### DIFF
--- a/gitbook/jsconfig.json
+++ b/gitbook/jsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
     }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "open-sse": ["./open-sse"],


### PR DESCRIPTION
TypeScript 6 reports this as an error, which is what an editor shows today:

```
jsconfig.json(3,5): Option 'baseUrl' is deprecated and will stop functioning in
TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

Both `jsconfig.json` and `gitbook/jsconfig.json` are affected. In each, `baseUrl` only anchors `paths`, and every path is **already written relatively** (`"./src/*"`, `"./open-sse"`, `"./open-sse/*"`, `"./*"`), so deleting the line is the whole change — one line per file.

I picked this over `"ignoreDeprecations": "6.0"`, which buys one major version and then has to be revisited.

## Why this is safe, when it is not merely a type-level setting

Next reads these files to resolve modules, so this one is load-bearing. The fallback is exact — `next/dist/build/load-jsconfig.js`:

```js
if (jsConfig?.compilerOptions?.baseUrl) { /* explicit */ }
else if (implicitBaseurl) { baseUrl: implicitBaseurl, isImplicit: true }
```

`implicitBaseurl` is `dirname(jsconfig.json)` — the repo root for the main app, `gitbook/` for the docs app. That is precisely what `"."` resolved to. `JsConfigPathsPlugin` is installed either way, so `paths` keep working.

One behaviour genuinely changes, in `webpack-config.js`:

```js
// Only add the baseUrl if it's explicitly set in tsconfig/jsconfig
if (resolvedBaseUrl && !resolvedBaseUrl.isImplicit)
  webpackConfig.resolve.modules.push(resolvedBaseUrl.baseUrl)
```

so **bare specifiers no longer resolve against the project root**. Nothing here uses that. I scanned every import in 1132 files (main app) and 14 (gitbook) for non-relative specifiers that are neither matched by `paths` nor present in `node_modules`. What remains is only optional npm packages — `figlet`, `gradient-string`, `chalk-animation`, `got-scraping`, `lowdb` — plus `bun:sqlite`. No local module.

## Verification — by building, not by reading

| app | result |
|---|---|
| main | `next build` → **✓ Compiled successfully in 28.0s**, 137 static pages, 0 resolution errors |
| gitbook | `next build` → **✓ Compiled successfully in 7.7s** |

## One thing you may want to know about, unrelated to this PR

`gitbook`'s build compiles but then fails while prerendering:

```
ReferenceError: useEffect is not defined
Export encountered an error on /[lang]/[...slug]/page, exiting the build.
```

`components/LanguageSwitcher.js` calls `useEffect` at line 27 but imports only `useState, useLayoutEffect`. It looks like a call site missed when *fix(eslint): resolve setState-in-effect errors…* converted the others.

I confirmed it is **pre-existing** by building `gitbook` on `master` without this change and getting the identical error, and the `gitbook-pages` workflow has been failing on `master` since that commit. It is out of scope here, so I left it alone — happy to send the one-line fix separately if useful.
