### PR TITLE
fix(gitbook): restore useEffect import and drop the orphaned mounted effect

### DIFF
--- a/gitbook/components/LanguageSwitcher.js
+++ b/gitbook/components/LanguageSwitcher.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useLayoutEffect } from "react";
+import { useState, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { useRouter, usePathname } from "next/navigation";
 import { Globe, X } from "lucide-react";
@@ -18,10 +18,6 @@ export default function LanguageSwitcher({ currentLang }) {
   const router = useRouter();
   const pathname = usePathname();
   const current = getLanguage(currentLang);
-
-  useLayoutEffect(() => {
-    setMounted(true);
-  }, []);
 
   // Lock body scroll when modal is open
   useEffect(() => {


### PR DESCRIPTION
**The docs site has not been deploying.** `gitbook-pages` fails on `master` at the prerender step:

```
ReferenceError: useEffect is not defined
Error occurred prerendering page "/ja/integration/claude-code"
Export encountered an error on /[lang]/[...slug]/page, exiting the build.
```

## Why

`#1362` removed the `mounted` state and the `mounted &&` guard on `createPortal`. **That call was right** — `modal` is only built when `open` is true, `open` starts `false` and can only be flipped by a click, so `document.body` is never reached during SSR. The guard was redundant.

What it missed is that `LanguageSwitcher` had *two* effects. It deleted the state, kept the effect that fed it, and rewrote the import to match:

```diff
-import { useState, useEffect } from "react";
+import { useState, useLayoutEffect } from "react";
...
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => {
+  useLayoutEffect(() => {
     setMounted(true);
   }, []);
```

The second `useEffect` — the body-scroll lock, thirty lines further down — was left untouched and lost its import.

So there are two undefined references, not one:

| identifier | when it bites |
|---|---|
| `useEffect` (line 27) | at render → **breaks the build** |
| `setMounted` (line 23) | on the client, once the import is restored |

Restoring the import alone therefore trades a build failure for a runtime one. The effect has had no state to write since `#1362`; deleting it finishes that commit rather than reviving something nothing reads.

## Verification

Real builds, same tree, `gitbook/`:

| | result |
|---|---|
| `master` (eb712ca8) | ✗ `ReferenceError: useEffect is not defined`, export aborts |
| with this change | ✓ compiled in 7.0s, **103/103 static pages generated** |

`no-undef` is not enabled by `eslint-config-next/core-web-vitals`, which is why lint has stayed green on a file that cannot render. Turning it on for just this file:

| variant | `no-undef` |
|---|---|
| `master` | 2 errors — `setMounted`, `useEffect` |
| import restored only | 1 error — `setMounted` |
| this PR | clean |

Nothing else is touched; it is one import and five deleted lines.
