### PR TITLE
feat(models): preserve custom model token limits end to end

### DIFF
--- a/docs/plans/custom-model-limits.md
+++ b/docs/plans/custom-model-limits.md
@@ -1,0 +1,20 @@
+# Custom model token limits
+
+Refs: [#3854](https://github.com/decolua/9router/issues/3854), [#1294](https://github.com/decolua/9router/issues/1294), [PR #1347](https://github.com/decolua/9router/pull/1347), [#3032](https://github.com/decolua/9router/issues/3032), [#3750](https://github.com/decolua/9router/issues/3750), [#3812](https://github.com/decolua/9router/issues/3812).
+
+## Goal
+
+Carry provider-reported or manually entered context-window and maximum-output token limits through custom-model discovery, storage, dashboard metadata, `/v1/models`, and `/v1/models/info`.
+
+## Design
+
+- Normalize common upstream names into `caps.contextWindow` and `caps.maxOutput`. Keep missing values absent. Reject supplied values unless they are positive safe integers.
+- Save limits with the existing custom-model `caps` object. Re-adding a model updates supplied metadata and retains omitted metadata.
+- Add optional context-window and max-output fields to the LLM custom-model modal. Suggested-model and account-catalog imports pass through limits returned by upstream.
+- Resolve custom metadata by provider plus model ID. A custom model's explicit values override static/name fallback values, including when its ID matches a built-in model. Never borrow custom limits from another provider with the same model ID.
+- Preserve static fallback limits for built-in and live catalog models. Do not publish fallback token limits as known metadata for a custom model whose limits were not supplied.
+- Expose known limits consistently as dashboard `caps.contextWindow` / `caps.maxOutput` and OpenAI-style top-level fields on `/v1/models` and `/v1/models/info`.
+
+## Verification
+
+Add focused tests for normalization and validation, persistence updates, provider isolation, custom-over-static precedence, unknown omission, discovery import metadata, list metadata, and info metadata. Run those tests and a bounded production build.

--- a/src/app/(dashboard)/dashboard/providers/[id]/AddCustomModelModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/AddCustomModelModal.js
@@ -10,13 +10,22 @@ const defaultCaps = () => Object.fromEntries(Object.keys(CAPACITY_META).map((key
 export default function AddCustomModelModal({ isOpen, providerAlias, providerDisplayAlias, onSave, onClose }) {
   const [modelId, setModelId] = useState("");
   const [caps, setCaps] = useState(defaultCaps);
+  const [contextWindow, setContextWindow] = useState("");
+  const [maxOutput, setMaxOutput] = useState("");
   const [testStatus, setTestStatus] = useState(null); // null | "testing" | "ok" | "error"
   const [testError, setTestError] = useState("");
   const [saving, setSaving] = useState(false);
 
   // Reset state when modal opens
   useEffect(() => {
-    if (isOpen) { setModelId(""); setCaps(defaultCaps()); setTestStatus(null); setTestError(""); }
+    if (isOpen) {
+      setModelId("");
+      setCaps(defaultCaps());
+      setContextWindow("");
+      setMaxOutput("");
+      setTestStatus(null);
+      setTestError("");
+    }
   }, [isOpen]);
 
   // Strip provider's own alias prefix (e.g. "cc/model" -> "model" for cc provider)
@@ -50,7 +59,11 @@ export default function AddCustomModelModal({ isOpen, providerAlias, providerDis
     if (!cleanId || saving) return;
     setSaving(true);
     try {
-      await onSave(cleanId, caps);
+      await onSave(cleanId, {
+        ...caps,
+        ...(contextWindow ? { contextWindow: Number(contextWindow) } : {}),
+        ...(maxOutput ? { maxOutput: Number(maxOutput) } : {}),
+      });
     } finally {
       setSaving(false);
     }
@@ -103,6 +116,33 @@ export default function AddCustomModelModal({ isOpen, providerAlias, providerDis
                 size="sm"
               />
             ))}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div>
+            <label className="text-sm font-medium mb-1.5 block">Context window</label>
+            <input
+              type="number"
+              min="1"
+              step="1"
+              value={contextWindow}
+              onChange={(e) => setContextWindow(e.target.value)}
+              placeholder="Optional, in tokens"
+              className="w-full px-3 py-2 text-sm border border-border rounded-lg bg-background focus:outline-none focus:border-primary"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium mb-1.5 block">Maximum output</label>
+            <input
+              type="number"
+              min="1"
+              step="1"
+              value={maxOutput}
+              onChange={(e) => setMaxOutput(e.target.value)}
+              placeholder="Optional, in tokens"
+              className="w-full px-3 py-2 text-sm border border-border rounded-lg bg-background focus:outline-none focus:border-primary"
+            />
           </div>
         </div>
 

--- a/src/app/(dashboard)/dashboard/providers/[id]/CompatibleModelsSection.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/CompatibleModelsSection.js
@@ -4,7 +4,7 @@ import { useState } from "react";
 import PropTypes from "prop-types";
 import { Button } from "@/shared/components";
 import { getProviderCustomModelRows } from "@/shared/utils/providerCustomModels";
-function CompatibleModelRow({ modelId, fullModel, copied, onCopy, onDeleteAlias, onTest, testStatus, isTesting }) {
+function CompatibleModelRow({ modelId, fullModel, caps, copied, onCopy, onDeleteAlias, onTest, testStatus, isTesting }) {
   const borderColor = testStatus === "ok"
     ? "border-green-500/40"
     : testStatus === "error"
@@ -59,6 +59,13 @@ function CompatibleModelRow({ modelId, fullModel, copied, onCopy, onDeleteAlias,
             </div>
           )}
         </div>
+        {(caps?.contextWindow || caps?.maxOutput) && (
+          <p className="mt-1 text-[10px] text-text-muted">
+            {caps.contextWindow ? `${caps.contextWindow.toLocaleString()} context` : ""}
+            {caps.contextWindow && caps.maxOutput ? " · " : ""}
+            {caps.maxOutput ? `${caps.maxOutput.toLocaleString()} max output` : ""}
+          </p>
+        )}
       </div>
       <button
         onClick={onDeleteAlias}
@@ -73,6 +80,8 @@ function CompatibleModelRow({ modelId, fullModel, copied, onCopy, onDeleteAlias,
 
 export default function CompatibleModelsSection({ providerStorageAlias, providerDisplayAlias, modelAliases, customModels, copied, onCopy, onDeleteAlias, onAddCustomModel, onDeleteCustomModel, connections, isAnthropic }) {
   const [newModel, setNewModel] = useState("");
+  const [contextWindow, setContextWindow] = useState("");
+  const [maxOutput, setMaxOutput] = useState("");
   const [adding, setAdding] = useState(false);
   const [importing, setImporting] = useState(false);
   const [testingModelId, setTestingModelId] = useState(null);
@@ -113,8 +122,13 @@ export default function CompatibleModelsSection({ providerStorageAlias, provider
 
     setAdding(true);
     try {
-      await onAddCustomModel(modelId);
+      await onAddCustomModel(modelId, {
+        ...(contextWindow ? { contextWindow: Number(contextWindow) } : {}),
+        ...(maxOutput ? { maxOutput: Number(maxOutput) } : {}),
+      });
       setNewModel("");
+      setContextWindow("");
+      setMaxOutput("");
     } catch (error) {
       console.log("Error adding model:", error);
     } finally {
@@ -145,7 +159,7 @@ export default function CompatibleModelsSection({ providerStorageAlias, provider
         const modelId = model.id || model.name || model.model;
         if (!modelId) continue;
         if (allModels.some((entry) => entry.id === modelId)) continue;
-        await onAddCustomModel(modelId);
+        await onAddCustomModel(modelId, model.caps);
         importedCount += 1;
       }
       if (importedCount === 0) {
@@ -187,6 +201,35 @@ export default function CompatibleModelsSection({ providerStorageAlias, provider
         </Button>
       </div>
 
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div>
+          <label htmlFor="compatible-model-context-window" className="text-xs text-text-muted mb-1 block">Context window</label>
+          <input
+            id="compatible-model-context-window"
+            type="number"
+            min="1"
+            step="1"
+            value={contextWindow}
+            onChange={(event) => setContextWindow(event.target.value)}
+            placeholder="Optional, in tokens"
+            className="w-full px-3 py-2 text-sm border border-border rounded-lg bg-background focus:outline-none focus:border-primary"
+          />
+        </div>
+        <div>
+          <label htmlFor="compatible-model-max-output" className="text-xs text-text-muted mb-1 block">Maximum output</label>
+          <input
+            id="compatible-model-max-output"
+            type="number"
+            min="1"
+            step="1"
+            value={maxOutput}
+            onChange={(event) => setMaxOutput(event.target.value)}
+            placeholder="Optional, in tokens"
+            className="w-full px-3 py-2 text-sm border border-border rounded-lg bg-background focus:outline-none focus:border-primary"
+          />
+        </div>
+      </div>
+
       {!canImport && (
         <p className="text-xs text-text-muted">
           Add a connection to enable importing models.
@@ -195,11 +238,12 @@ export default function CompatibleModelsSection({ providerStorageAlias, provider
 
       {allModels.length > 0 && (
         <div className="flex flex-col gap-3">
-          {allModels.map(({ id, alias, source }) => (
+          {allModels.map(({ id, alias, source, caps }) => (
             <CompatibleModelRow
               key={`${source}-${providerStorageAlias}/${id}`}
               modelId={id}
               fullModel={`${providerDisplayAlias}/${id}`}
+              caps={caps}
               copied={copied}
               onCopy={onCopy}
               onDeleteAlias={() => source === "custom" ? onDeleteCustomModel(id) : onDeleteAlias(alias)}

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -596,7 +596,7 @@ export default function ProviderDetailPage() {
           continue;
         }
 
-        await handleAddCustomModel(cleanModelId, "llm", providerStorageAlias);
+        await handleAddCustomModel(cleanModelId, "llm", providerStorageAlias, model.caps);
         importedCount += 1;
       }
       
@@ -1084,7 +1084,7 @@ export default function ProviderDetailPage() {
           onCopy={copy}
           onSetAlias={handleSetAlias}
           onDeleteAlias={handleDeleteAlias}
-          onAddCustomModel={(modelId) => handleAddCustomModel(modelId, "llm", providerStorageAlias)}
+          onAddCustomModel={(modelId, caps) => handleAddCustomModel(modelId, "llm", providerStorageAlias, caps)}
           onDeleteCustomModel={(modelId) => handleDeleteCustomModel(modelId, "llm", providerStorageAlias)}
           connections={connections}
           isAnthropic={isAnthropicCompatible}
@@ -1132,7 +1132,7 @@ export default function ProviderDetailPage() {
             isTesting={testingModelIds.has(model.id)}
             isCustom
             isFree={false}
-            caps={getCaps(`${providerId}/${model.id}`)}
+            caps={model.caps || getCaps(`${providerStorageAlias}/${model.id}`)}
             thinkingSuffix={resolveThinkingSuffix(model.id)}
           />
         ))}
@@ -1206,10 +1206,10 @@ export default function ProviderDetailPage() {
                   <button
                     key={m.id}
                     onClick={async () => {
-                      await handleAddCustomModel(m.id, "llm", providerStorageAlias);
+                      await handleAddCustomModel(m.id, "llm", providerStorageAlias, m.caps);
                     }}
                     className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg border border-black/10 dark:border-white/10 text-xs text-text-muted hover:text-primary hover:border-primary/40 hover:bg-primary/5 transition-colors"
-                    title={`${m.name} · ${(m.contextLength / 1000).toFixed(0)}k ctx`}
+                    title={m.contextLength ? `${m.name} · ${(m.contextLength / 1000).toFixed(0)}k ctx` : m.name}
                   >
                     <span className="material-symbols-outlined text-[13px]">add</span>
                     {m.id.split("/").pop()}

--- a/src/app/api/models/custom/route.js
+++ b/src/app/api/models/custom/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getCustomModels, addCustomModel, deleteCustomModel } from "@/models";
 import { CAPACITY_META } from "@/shared/constants/models";
+import { validateModelLimits } from "@/shared/utils/modelTokenLimits";
 
 export const dynamic = "force-dynamic";
 
@@ -28,12 +29,24 @@ export async function GET() {
 // POST /api/models/custom - Add custom model
 export async function POST(request) {
   try {
-    const { providerAlias, id, type, name, caps } = await request.json();
+    const body = await request.json();
+    const { providerAlias, id, type, name, caps } = body;
     if (!providerAlias || !id) {
       return NextResponse.json({ error: "providerAlias and id required" }, { status: 400 });
     }
     const cleanCaps = sanitizeCaps(caps);
-    const added = await addCustomModel({ providerAlias, id, type: type || "llm", name, ...(cleanCaps ? { caps: cleanCaps } : {}) });
+    const { limits, errors } = validateModelLimits(body);
+    if (errors.length) {
+      return NextResponse.json({ error: errors.join("; ") }, { status: 400 });
+    }
+    const storedCaps = { ...(cleanCaps || {}), ...limits };
+    const added = await addCustomModel({
+      providerAlias,
+      id,
+      type: type || "llm",
+      name,
+      ...(Object.keys(storedCaps).length ? { caps: storedCaps } : {}),
+    });
     return NextResponse.json({ success: true, added });
   } catch (error) {
     console.log("Error adding custom model:", error);

--- a/src/app/api/models/route.js
+++ b/src/app/api/models/route.js
@@ -4,12 +4,19 @@ import { getDisabledModels } from "@/lib/disabledModelsDb";
 import { AI_MODELS } from "@/shared/constants/config";
 import { getProviderAlias } from "@/shared/constants/providers";
 import { getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { applyModelLimitsToCaps, withoutModelLimits } from "@/shared/utils/modelTokenLimits";
 
 // GET /api/models - Get models with aliases
 export async function GET() {
   try {
     const modelAliases = await getModelAliases();
     const disabled = await getDisabledModels();
+    const allCustomModels = await getCustomModels();
+    const customByFullModel = new Map(
+      allCustomModels
+        .filter((m) => m?.providerAlias && m?.id && (m.kind || m.type || "llm") === "llm")
+        .map((m) => [`${m.providerAlias}/${m.id}`, m]),
+    );
 
     const models = AI_MODELS
       .filter((m) => {
@@ -22,24 +29,25 @@ export async function GET() {
         const providerAlias = getProviderAlias(m.provider) || m.provider;
         const routedModel = `${providerAlias}/${m.model}`;
         const c = getCapabilitiesForModel(m.provider, m.model);
+        const custom = customByFullModel.get(fullModel) || customByFullModel.get(routedModel);
         return {
           ...m,
           fullModel,
           routedModel,
           alias: modelAliases[fullModel] || m.model,
-          caps: {
+          caps: applyModelLimitsToCaps({
             vision: c.vision,
             search: c.search,
             reasoning: c.reasoning,
             contextWindow: c.contextWindow,
             maxOutput: c.maxOutput,
-          },
+          }, custom),
         };
       });
 
     // Custom models ride along; their stored caps override the name heuristic
     const seenFull = new Set(models.map((m) => m.fullModel));
-    const customModels = (await getCustomModels()).filter((m) => {
+    const customModels = allCustomModels.filter((m) => {
       if (!m?.id || (m.kind || m.type || "llm") !== "llm") return false;
       return !seenFull.has(`${m.providerAlias}/${m.id}`);
     });
@@ -53,14 +61,13 @@ export async function GET() {
         fullModel,
         routedModel: fullModel,
         alias: modelAliases[fullModel] || m.id,
-        caps: {
+        caps: applyModelLimitsToCaps({
+          ...withoutModelLimits(c),
           vision: c.vision,
           search: c.search,
           reasoning: c.reasoning,
-          contextWindow: c.contextWindow,
-          maxOutput: c.maxOutput,
           ...(m.caps || {}),
-        },
+        }, m),
       });
     }
 

--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -11,6 +11,7 @@ import { resolveQoderModels } from "open-sse/services/qoderModels.js";
 import { resolveGrokCliModels } from "open-sse/services/grokCliModels.js";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { resolveCursorModels } from "open-sse/services/cursorModels.js";
+import { normalizeDiscoveredModels } from "@/shared/utils/modelTokenLimits";
 
 const GEMINI_CLI_MODELS_URL = "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels";
 
@@ -472,7 +473,7 @@ export async function GET(request, { params }) {
       }
 
       const data = await response.json();
-      const models = data.data || data.models || [];
+      const models = normalizeDiscoveredModels(data.data || data.models || []);
 
       return NextResponse.json({
         provider: connection.provider,
@@ -513,7 +514,7 @@ export async function GET(request, { params }) {
       }
 
       const data = await response.json();
-      const models = data.data || data.models || [];
+      const models = normalizeDiscoveredModels(data.data || data.models || []);
 
       return NextResponse.json({
         provider: connection.provider,
@@ -539,7 +540,7 @@ export async function GET(request, { params }) {
       return NextResponse.json({
         provider: connection.provider,
         connectionId: connection.id,
-        models: result.models,
+        models: normalizeDiscoveredModels(result.models),
         ...(result.warning ? { warning: result.warning } : {})
       });
     }
@@ -584,7 +585,7 @@ export async function GET(request, { params }) {
     }
 
     const data = await response.json();
-    const models = config.parseResponse(data);
+    const models = normalizeDiscoveredModels(config.parseResponse(data));
 
     return NextResponse.json({
       provider: connection.provider,

--- a/src/app/api/providers/suggested-models/filters.js
+++ b/src/app/api/providers/suggested-models/filters.js
@@ -13,7 +13,12 @@ export const FILTERS = {
           m.pricing?.completion === "0" &&
           m.context_length >= 200000
       )
-      .map((m) => ({ id: m.id, name: m.name, contextLength: m.context_length }))
+      .map((m) => ({
+        id: m.id,
+        name: m.name,
+        contextLength: m.context_length,
+        maxOutput: m.top_provider?.max_completion_tokens,
+      }))
       .sort((a, b) => b.contextLength - a.contextLength),
 
   "opencode-free": (models) =>

--- a/src/app/api/providers/suggested-models/route.js
+++ b/src/app/api/providers/suggested-models/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { FILTERS } from "./filters.js";
+import { normalizeDiscoveredModels } from "@/shared/utils/modelTokenLimits";
 
 export const dynamic = "force-dynamic";
 
@@ -24,7 +25,7 @@ export async function GET(request) {
     }
     const json = await res.json();
     const raw = json.data ?? json.models ?? json;
-    const data = filter(Array.isArray(raw) ? raw : []);
+    const data = normalizeDiscoveredModels(filter(Array.isArray(raw) ? raw : []));
     return NextResponse.json({ data });
   } catch {
     return NextResponse.json({ data: [] });

--- a/src/app/api/v1/models/info/route.js
+++ b/src/app/api/v1/models/info/route.js
@@ -1,6 +1,9 @@
 import { PROVIDER_MODELS } from "open-sse/config/providerModels.js";
 import { AI_PROVIDERS, ALIAS_TO_ID } from "@/shared/constants/providers";
 import { getModelKind } from "@/shared/constants/models";
+import { getCustomModels, getProviderConnections } from "@/lib/localDb";
+import { getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { applyModelLimitsToCaps, modelLimitsForOpenAI, withoutModelLimits } from "@/shared/utils/modelTokenLimits";
 
 const KIND_ENDPOINT = {
   llm: "/v1/chat/completions",
@@ -15,7 +18,7 @@ const KIND_ENDPOINT = {
 
 const TTS_VOICES_API = new Set(["elevenlabs", "edge-tts", "deepgram", "inworld", "local-device"]);
 
-function buildInfo({ alias, providerId, model, kind, providerInfo }) {
+function buildInfo({ alias, providerId, model, kind, providerInfo, caps }) {
   const out = {
     id: `${alias}/${model.id}`,
     name: model.name || model.id,
@@ -24,10 +27,10 @@ function buildInfo({ alias, providerId, model, kind, providerInfo }) {
     endpoint: KIND_ENDPOINT[kind] || null,
   };
   if (model.params) out.params = model.params;
-  if (model.capabilities) out.capabilities = model.capabilities;
+  if (caps || model.capabilities) out.capabilities = caps || model.capabilities;
   if (model.options) out.options = model.options;
   if (model.dimensions) out.dimensions = model.dimensions;
-  if (model.contextWindow) out.contextWindow = model.contextWindow;
+  if (caps?.contextWindow || model.contextWindow) out.contextWindow = caps?.contextWindow || model.contextWindow;
   if (kind === "tts" && TTS_VOICES_API.has(providerId)) {
     out.voicesUrl = `/v1/audio/voices?provider=${providerId}`;
   }
@@ -37,17 +40,29 @@ function buildInfo({ alias, providerId, model, kind, providerInfo }) {
     if (cfg.maxMaxResults) out.maxResults = cfg.maxMaxResults;
     if (cfg.requiredOptions) out.required = cfg.requiredOptions;
   }
-  return out;
+  return kind === "llm" ? { ...out, ...modelLimitsForOpenAI({ caps: caps || model }) } : out;
 }
 
 // id format: "{alias}/{modelId}" - alias may also be providerId
 // requestedKind: optional, disambiguates duplicate ids across kinds (e.g. gemini-2.5-pro llm vs stt)
-function lookup(fullId, requestedKind) {
+async function lookup(fullId, requestedKind) {
   if (!fullId || !fullId.includes("/")) return null;
   const slash = fullId.indexOf("/");
   const alias = fullId.slice(0, slash);
   const modelId = fullId.slice(slash + 1);
-  const providerId = ALIAS_TO_ID[alias] || alias;
+  let providerId = ALIAS_TO_ID[alias] || alias;
+  let storageAliases = new Set([alias, providerId]);
+  try {
+    const matchingConnection = (await getProviderConnections()).find((connection) =>
+      connection?.providerSpecificData?.prefix === alias || connection?.provider === alias
+    );
+    if (matchingConnection?.provider) {
+      providerId = matchingConnection.provider;
+      storageAliases = new Set([alias, providerId]);
+    }
+  } catch {
+    // Static model info remains available when connections cannot be read.
+  }
   const providerInfo = AI_PROVIDERS[providerId];
 
   // PROVIDER_MODELS lookup (by alias key, fallback to providerId)
@@ -55,9 +70,38 @@ function lookup(fullId, requestedKind) {
   const m = requestedKind
     ? list.find((x) => x.id === modelId && getModelKind(x, "llm") === requestedKind)
     : list.find((x) => x.id === modelId);
+
+  let customModel = null;
+  try {
+    const customModels = await getCustomModels();
+    customModel = customModels.find((item) =>
+      item?.id === modelId
+      && storageAliases.has(item.providerAlias)
+      && (!requestedKind || getModelKind(item, "llm") === requestedKind)
+    ) || null;
+  } catch {
+    // Keep static lookup available when persistence is temporarily unavailable.
+  }
+
+  if (customModel) {
+    const kind = getModelKind(customModel, "llm");
+    const fallback = getCapabilitiesForModel(providerId, modelId);
+    const caps = applyModelLimitsToCaps({
+      ...(m ? fallback : withoutModelLimits(fallback)),
+      ...(customModel.caps || {}),
+    }, customModel);
+    return buildInfo({ alias, providerId, model: customModel, kind, providerInfo, caps });
+  }
   if (m) {
     const kind = getModelKind(m, "llm");
-    return buildInfo({ alias, providerId, model: m, kind, providerInfo });
+    return buildInfo({
+      alias,
+      providerId,
+      model: m,
+      kind,
+      providerInfo,
+      caps: kind === "llm" ? getCapabilitiesForModel(providerId, modelId) : null,
+    });
   }
 
   // Web search/fetch — virtual model id "search" / "fetch"
@@ -93,7 +137,7 @@ export async function GET(request) {
       { status: 400, headers: { "Access-Control-Allow-Origin": "*" } },
     );
   }
-  const info = lookup(id, kind);
+  const info = await lookup(id, kind);
   if (!info) {
     return Response.json(
       { error: { message: `Model not found: ${id}`, type: "not_found" } },

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -18,6 +18,7 @@ import { resolveZedModels } from "open-sse/shared/zedAuth.js";
 import { updateProviderCredentials } from "@/sse/services/tokenRefresh";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { capabilitiesFromServiceKind, getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { applyModelLimitsToCaps, modelLimitsForOpenAI, withoutModelLimits } from "@/shared/utils/modelTokenLimits";
 
 // Per-provider live model resolvers. Each receives a connection record and
 // returns { models: [{ id, name? }, ...] } | null on failure.
@@ -237,6 +238,17 @@ function comboMatchesKinds(combo, kindFilter) {
   return kindFilter.includes(kind);
 }
 
+function withLlmMetadata(entry, caps) {
+  if (!caps) return entry;
+  return { ...entry, capabilities: caps, ...modelLimitsForOpenAI({ caps }) };
+}
+
+function customModelCaps(customModel, fallbackCaps, useLimitFallback) {
+  if (!customModel) return fallbackCaps;
+  const base = useLimitFallback ? fallbackCaps : withoutModelLimits(fallbackCaps);
+  return applyModelLimitsToCaps({ ...base, ...(customModel.caps || {}) }, customModel);
+}
+
 /**
  * Build OpenAI-format models list filtered by service kinds.
  * @param {string[]} kindFilter - List of service kinds to include (e.g. ["llm"], ["webSearch","webFetch"]).
@@ -317,11 +329,18 @@ export async function buildModelsList(kindFilter, options = {}) {
       for (const model of providerModels) {
         if (!kindFilter.includes(modelKind(model))) continue;
         if (isDisabled(alias, model.id)) continue;
-        models.push({
+        const customModel = customModels.find((item) =>
+          item?.providerAlias === alias && item.id === model.id && (item.kind || item.type || LLM_KIND) === LLM_KIND
+        );
+        const entry = {
           id: `${alias}/${model.id}`,
           object: "model",
           owned_by: alias,
-        });
+        };
+        const caps = getCapabilitiesForModel(providerId, model.id);
+        models.push(modelKind(model) === LLM_KIND
+          ? withLlmMetadata(entry, customModelCaps(customModel, caps, true))
+          : entry);
       }
     }
 
@@ -335,11 +354,16 @@ export async function buildModelsList(kindFilter, options = {}) {
       const modelId = String(customModel.id).trim();
       if (!modelId) continue;
 
-      models.push({
+      const caps = customModelCaps(
+        customModel,
+        getCapabilitiesForModel(providerAlias, modelId),
+        false,
+      );
+      models.push(withLlmMetadata({
         id: `${providerAlias}/${modelId}`,
         object: "model",
         owned_by: providerAlias,
-      });
+      }, caps));
     }
   } else {
     for (const [providerId, conn] of activeConnectionByProvider.entries()) {
@@ -362,6 +386,7 @@ export async function buildModelsList(kindFilter, options = {}) {
       const staticModelKindById = new Map(
         providerModels.map((m) => [m.id, modelKind(m)])
       );
+      const staticModelIds = new Set(providerModels.map((m) => m.id));
       let liveModelKindById = new Map();
       let liveCapabilitiesById = new Map();
 
@@ -420,6 +445,7 @@ export async function buildModelsList(kindFilter, options = {}) {
         .filter((modelId) => typeof modelId === "string" && modelId.trim() !== "");
 
       const customModelKindById = new Map();
+      const customModelById = new Map();
       const customModelIds = customModels
         .filter((m) => {
           if (!m?.id) return false;
@@ -432,7 +458,10 @@ export async function buildModelsList(kindFilter, options = {}) {
         })
         .map((m) => {
           const modelId = String(m.id).trim();
-          if (modelId) customModelKindById.set(modelId, getModelKind(m) || LLM_KIND);
+          if (modelId) {
+            customModelKindById.set(modelId, getModelKind(m) || LLM_KIND);
+            customModelById.set(modelId, m);
+          }
           return modelId;
         })
         .filter((modelId) => modelId !== "");
@@ -481,9 +510,13 @@ export async function buildModelsList(kindFilter, options = {}) {
         // { id, name } — no per-model capability data. Fall back to the same
         // pattern-matched capabilities the dashboard uses (useModelCaps.js) so
         // dynamically-discovered LLM models still surface vision/reasoning/search/tools.
-        const caps = liveCapabilitiesById.get(modelId)
+        let caps = liveCapabilitiesById.get(modelId)
           || capabilitiesFromServiceKind(customKind || liveKind)
           || (kind === LLM_KIND ? getCapabilitiesForModel(providerId, modelId) : null);
+        const customModel = customModelById.get(modelId);
+        if (customModel && (kind === LLM_KIND || allowAsLlm)) {
+          caps = customModelCaps(customModel, caps || getCapabilitiesForModel(providerId, modelId), staticModelIds.has(modelId));
+        }
         if (caps) model.capabilities = caps;
         // Token limits under the snake_case names the OpenAI/OpenRouter
         // convention uses. `capabilities.contextWindow` is camelCase and nested,
@@ -498,13 +531,15 @@ export async function buildModelsList(kindFilter, options = {}) {
           // Live-catalog and service-kind capabilities are usually partial
           // (often just { tools: true }), so fill the gaps from the static
           // table rather than emitting null and leaving clients to guess.
-          if (!Number.isFinite(contextWindow) || !Number.isFinite(maxOutput)) {
+          if ((!Number.isFinite(contextWindow) || !Number.isFinite(maxOutput)) && !customModel) {
             const fallback = getCapabilitiesForModel(providerId, modelId);
             if (!Number.isFinite(contextWindow)) contextWindow = fallback.contextWindow;
             if (!Number.isFinite(maxOutput)) maxOutput = fallback.maxOutput;
           }
           if (Number.isFinite(contextWindow)) model.context_length = contextWindow;
+          if (Number.isFinite(contextWindow)) model.max_input_tokens = contextWindow;
           if (Number.isFinite(maxOutput)) model.max_completion_tokens = maxOutput;
+          if (Number.isFinite(maxOutput)) model.max_output_tokens = maxOutput;
         }
         models.push(model);
       }

--- a/src/lib/db/repos/aliasRepo.js
+++ b/src/lib/db/repos/aliasRepo.js
@@ -39,7 +39,11 @@ export async function addCustomModel({ providerAlias, id, type = "llm", name, ca
     const row = db.get(`SELECT value FROM kv WHERE scope = 'customModels' AND key = ?`, [k]);
     if (row) {
       const prev = parseJson(row.value) || {};
-      const next = { ...prev, ...(name ? { name } : {}), ...(caps ? { caps } : {}) };
+      const next = {
+        ...prev,
+        ...(name ? { name } : {}),
+        ...(caps ? { caps: { ...(prev.caps || {}), ...caps } } : {}),
+      };
       db.run(`UPDATE kv SET value = ? WHERE scope = 'customModels' AND key = ?`, [stringifyJson(next), k]);
       return;
     }

--- a/src/shared/hooks/useModelCaps.js
+++ b/src/shared/hooks/useModelCaps.js
@@ -7,7 +7,7 @@ import { getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
 let cache = null; // { byFull, byId } | null
 let inflight = null;
 
-function buildMaps(models) {
+export function buildMaps(models) {
   const byFull = {};
   const byId = {};
   for (const m of models || []) {
@@ -38,12 +38,14 @@ function loadModelCaps() {
 }
 
 // Resolve caps from a "provider/model" string or a bare model id.
-function resolveCaps(byFull, byId, key) {
+export function resolveCaps(byFull, byId, key) {
   if (!key) return null;
   if (byFull[key]) return byFull[key];
-  const bare = key.includes("/") ? key.slice(key.indexOf("/") + 1) : key;
-  if (byId[bare]) return byId[bare];
-  const provider = key.includes("/") ? key.slice(0, key.indexOf("/")) : null;
+  const qualified = key.includes("/");
+  const bare = qualified ? key.slice(key.indexOf("/") + 1) : key;
+  // Do not leak custom limits from another provider with the same model ID.
+  if (!qualified && byId[bare]) return byId[bare];
+  const provider = qualified ? key.slice(0, key.indexOf("/")) : null;
   const c = getCapabilitiesForModel(provider, bare);
   return {
     vision: c.vision,

--- a/src/shared/utils/modelTokenLimits.js
+++ b/src/shared/utils/modelTokenLimits.js
@@ -1,0 +1,133 @@
+const CONTEXT_KEYS = [
+  "context_length",
+  "contextWindow",
+  "contextLength",
+  "max_input_tokens",
+  "maxInputTokens",
+  "inputTokenLimit",
+  "max_context_window_tokens",
+  "context_window",
+  "context",
+];
+
+const OUTPUT_KEYS = [
+  "maxOutput",
+  "max_output_tokens",
+  "maxOutputTokens",
+  "max_completion_tokens",
+  "outputTokenLimit",
+  "output",
+];
+
+function firstPresent(objects, keys) {
+  for (const object of objects) {
+    if (!object || typeof object !== "object") continue;
+    for (const key of keys) {
+      if (object[key] !== undefined && object[key] !== null && object[key] !== "") {
+        return { present: true, value: object[key] };
+      }
+    }
+  }
+  return { present: false, value: undefined };
+}
+
+function limitSources(input) {
+  return [
+    input?.caps,
+    input,
+    input?.limit,
+    input?.limits,
+    input?.capabilities?.limits,
+    input?.capabilities,
+  ];
+}
+
+function positiveInteger(value, coerceStrings = false) {
+  const number = coerceStrings && typeof value === "string" && value.trim() !== "" ? Number(value) : value;
+  return Number.isSafeInteger(number) && number > 0 ? number : undefined;
+}
+
+export function validateModelLimits(input = {}) {
+  const sources = limitSources(input);
+  const context = firstPresent(sources, CONTEXT_KEYS);
+  const output = firstPresent(sources, OUTPUT_KEYS);
+  const limits = {};
+  const errors = new Set();
+
+  for (const source of sources) {
+    if (!source || typeof source !== "object") continue;
+    for (const key of CONTEXT_KEYS) {
+      if (source[key] !== undefined && source[key] !== null && source[key] !== ""
+        && positiveInteger(source[key]) === undefined) {
+        errors.add("contextWindow must be a positive integer");
+      }
+    }
+    for (const key of OUTPUT_KEYS) {
+      if (source[key] !== undefined && source[key] !== null && source[key] !== ""
+        && positiveInteger(source[key]) === undefined) {
+        errors.add("maxOutput must be a positive integer");
+      }
+    }
+  }
+
+  if (context.present) {
+    const value = positiveInteger(context.value);
+    if (value === undefined) errors.add("contextWindow must be a positive integer");
+    else limits.contextWindow = value;
+  }
+  if (output.present) {
+    const value = positiveInteger(output.value);
+    if (value === undefined) errors.add("maxOutput must be a positive integer");
+    else limits.maxOutput = value;
+  }
+
+  return { limits, errors: Array.from(errors) };
+}
+
+export function normalizeModelLimits(input = {}) {
+  const sources = limitSources(input);
+  const context = firstPresent(sources, CONTEXT_KEYS);
+  const output = firstPresent(sources, OUTPUT_KEYS);
+  const limits = {};
+  if (context.present) {
+    const value = positiveInteger(context.value, true);
+    if (value !== undefined) limits.contextWindow = value;
+  }
+  if (output.present) {
+    const value = positiveInteger(output.value, true);
+    if (value !== undefined) limits.maxOutput = value;
+  }
+  return limits;
+}
+
+export function applyModelLimitsToCaps(fallbackCaps = {}, explicit = {}) {
+  return { ...fallbackCaps, ...normalizeModelLimits(explicit) };
+}
+
+export function withoutModelLimits(caps = {}) {
+  const { contextWindow: _contextWindow, maxOutput: _maxOutput, ...rest } = caps || {};
+  return rest;
+}
+
+export function normalizeDiscoveredModel(model) {
+  if (!model || typeof model !== "object") return model;
+  const limits = normalizeModelLimits(model);
+  if (Object.keys(limits).length === 0) return model;
+  return { ...model, caps: { ...(model.caps || {}), ...limits } };
+}
+
+export function normalizeDiscoveredModels(models) {
+  return Array.isArray(models) ? models.map(normalizeDiscoveredModel) : [];
+}
+
+export function modelLimitsForOpenAI(model = {}) {
+  const { contextWindow, maxOutput } = normalizeModelLimits(model);
+  return {
+    ...(contextWindow !== undefined
+      ? { context_length: contextWindow, max_input_tokens: contextWindow }
+      : {}),
+    ...(maxOutput !== undefined
+      ? { max_output_tokens: maxOutput, max_completion_tokens: maxOutput }
+      : {}),
+  };
+}

--- a/src/shared/utils/providerCustomModels.js
+++ b/src/shared/utils/providerCustomModels.js
@@ -29,6 +29,7 @@ export function getProviderCustomModelRows({
       fullModel,
       source: "custom",
       type: rowType,
+      ...(model.caps ? { caps: model.caps } : {}),
     });
   }
 

--- a/tests/unit/custom-model-info.test.js
+++ b/tests/unit/custom-model-info.test.js
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ getCustomModels: vi.fn(), getProviderConnections: vi.fn() }));
+
+vi.mock("@/lib/localDb", () => ({
+  getCustomModels: mocks.getCustomModels,
+  getProviderConnections: mocks.getProviderConnections,
+}));
+
+const { GET } = await import("../../src/app/api/v1/models/info/route.js");
+
+describe("custom model info metadata", () => {
+  beforeEach(() => {
+    mocks.getCustomModels.mockReset();
+    mocks.getProviderConnections.mockReset().mockResolvedValue([]);
+  });
+
+  it("returns provider-owned custom limits", async () => {
+    mocks.getCustomModels.mockResolvedValue([
+      { providerAlias: "provider-a", id: "shared", type: "llm", caps: { contextWindow: 123456, maxOutput: 7890 } },
+      { providerAlias: "provider-b", id: "shared", type: "llm", caps: { contextWindow: 999999, maxOutput: 99999 } },
+    ]);
+
+    const response = await GET(new Request("https://router.test/v1/models/info?id=provider-a/shared"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      id: "provider-a/shared",
+      contextWindow: 123456,
+      context_length: 123456,
+      max_input_tokens: 123456,
+      max_output_tokens: 7890,
+      max_completion_tokens: 7890,
+      capabilities: { contextWindow: 123456, maxOutput: 7890 },
+    });
+  });
+
+  it("does not invent limits for an unknown custom model", async () => {
+    mocks.getCustomModels.mockResolvedValue([
+      { providerAlias: "provider-a", id: "unknown-custom", type: "llm" },
+    ]);
+
+    const response = await GET(new Request("https://router.test/v1/models/info?id=provider-a/unknown-custom"));
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body).not.toHaveProperty("context_length");
+    expect(body).not.toHaveProperty("max_output_tokens");
+    expect(body.capabilities).not.toHaveProperty("contextWindow");
+    expect(body.capabilities).not.toHaveProperty("maxOutput");
+  });
+
+  it("resolves a configured prefix while retaining provider-id storage", async () => {
+    mocks.getProviderConnections.mockResolvedValue([{
+      provider: "openai-compatible-node-1",
+      providerSpecificData: { prefix: "qa-limits" },
+    }]);
+    mocks.getCustomModels.mockResolvedValue([{
+      providerAlias: "openai-compatible-node-1",
+      id: "shared",
+      type: "llm",
+      caps: { contextWindow: 262144, maxOutput: 16384 },
+    }]);
+
+    const response = await GET(new Request("https://router.test/v1/models/info?id=qa-limits/shared"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      id: "qa-limits/shared",
+      context_length: 262144,
+      max_completion_tokens: 16384,
+    });
+  });
+});

--- a/tests/unit/custom-model-limits-route.test.js
+++ b/tests/unit/custom-model-limits-route.test.js
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  addCustomModel: vi.fn(),
+}));
+
+vi.mock("@/models", () => ({
+  getCustomModels: vi.fn(),
+  addCustomModel: mocks.addCustomModel,
+  deleteCustomModel: vi.fn(),
+}));
+
+const { POST } = await import("../../src/app/api/models/custom/route.js");
+
+function request(body) {
+  return new Request("https://router.test/api/models/custom", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("custom model limit persistence route", () => {
+  beforeEach(() => {
+    mocks.addCustomModel.mockReset().mockResolvedValue(true);
+  });
+
+  it("accepts top-level compatibility names and stores canonical caps", async () => {
+    const response = await POST(request({
+      providerAlias: "provider-a",
+      id: "model-a",
+      max_input_tokens: 131072,
+      max_output_tokens: 8192,
+    }));
+
+    expect(response.status).toBe(200);
+    expect(mocks.addCustomModel).toHaveBeenCalledWith({
+      providerAlias: "provider-a",
+      id: "model-a",
+      type: "llm",
+      name: undefined,
+      caps: { contextWindow: 131072, maxOutput: 8192 },
+    });
+  });
+
+  it("prefers an explicit context length over max input tokens", async () => {
+    await POST(request({
+      providerAlias: "provider-a",
+      id: "model-a",
+      context_length: 64000,
+      max_input_tokens: 32000,
+    }));
+
+    expect(mocks.addCustomModel.mock.calls[0][0].caps.contextWindow).toBe(64000);
+  });
+
+  it("accepts direct canonical fields in caps", async () => {
+    await POST(request({
+      providerAlias: "provider-a",
+      id: "model-a",
+      caps: { contextWindow: 100000, maxOutput: 4000, vision: true },
+    }));
+
+    expect(mocks.addCustomModel.mock.calls[0][0].caps).toEqual({
+      vision: true,
+      contextWindow: 100000,
+      maxOutput: 4000,
+    });
+  });
+
+  it("rejects invalid explicitly supplied limits", async () => {
+    const response = await POST(request({
+      providerAlias: "provider-a",
+      id: "model-a",
+      contextWindow: false,
+    }));
+
+    expect(response.status).toBe(400);
+    expect(mocks.addCustomModel).not.toHaveBeenCalled();
+  });
+
+  it("rejects numeric strings from the manual persistence API", async () => {
+    const response = await POST(request({
+      providerAlias: "provider-a",
+      id: "model-a",
+      context_length: "131072",
+    }));
+
+    expect(response.status).toBe(400);
+    expect(mocks.addCustomModel).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/custom-model-v1-list.test.js
+++ b/tests/unit/custom-model-v1-list.test.js
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getProviderConnections: vi.fn(),
+  getCombos: vi.fn(),
+  getCustomModels: vi.fn(),
+  getModelAliases: vi.fn(),
+  getDisabledModels: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: mocks.getProviderConnections,
+  getCombos: mocks.getCombos,
+  getCustomModels: mocks.getCustomModels,
+  getModelAliases: mocks.getModelAliases,
+}));
+vi.mock("@/lib/disabledModelsDb", () => ({ getDisabledModels: mocks.getDisabledModels }));
+
+const { buildModelsList } = await import("../../src/app/api/v1/models/route.js");
+
+describe("custom model /v1/models metadata", () => {
+  beforeEach(() => {
+    mocks.getCombos.mockResolvedValue([]);
+    mocks.getModelAliases.mockResolvedValue({});
+    mocks.getDisabledModels.mockResolvedValue({});
+    mocks.getProviderConnections.mockResolvedValue([
+      {
+        provider: "openai-compatible-node-a",
+        isActive: true,
+        providerSpecificData: { prefix: "prefix-a", enabledModels: ["shared", "unknown"] },
+      },
+      {
+        provider: "openai-compatible-node-b",
+        isActive: true,
+        providerSpecificData: { prefix: "prefix-b", enabledModels: ["shared"] },
+      },
+    ]);
+    mocks.getCustomModels.mockResolvedValue([
+      {
+        providerAlias: "openai-compatible-node-a",
+        id: "shared",
+        type: "llm",
+        caps: { contextWindow: 131072, maxOutput: 8192 },
+      },
+      {
+        providerAlias: "openai-compatible-node-b",
+        id: "shared",
+        type: "llm",
+        caps: { contextWindow: 262144, maxOutput: 16384 },
+      },
+      { providerAlias: "openai-compatible-node-a", id: "unknown", type: "llm" },
+    ]);
+  });
+
+  it("exposes provider-scoped saved limits under configured prefixes", async () => {
+    const models = await buildModelsList(["llm"], { skipDynamicFetch: true });
+    const a = models.find((model) => model.id === "prefix-a/shared");
+    const b = models.find((model) => model.id === "prefix-b/shared");
+
+    expect(a).toMatchObject({
+      context_length: 131072,
+      max_input_tokens: 131072,
+      max_completion_tokens: 8192,
+      max_output_tokens: 8192,
+      capabilities: { contextWindow: 131072, maxOutput: 8192 },
+    });
+    expect(b).toMatchObject({
+      context_length: 262144,
+      max_completion_tokens: 16384,
+      capabilities: { contextWindow: 262144, maxOutput: 16384 },
+    });
+  });
+
+  it("does not invent limits for an unknown custom model", async () => {
+    const models = await buildModelsList(["llm"], { skipDynamicFetch: true });
+    const unknown = models.find((model) => model.id === "prefix-a/unknown");
+
+    expect(unknown).toBeDefined();
+    expect(unknown).not.toHaveProperty("context_length");
+    expect(unknown).not.toHaveProperty("max_completion_tokens");
+    expect(unknown.capabilities).not.toHaveProperty("contextWindow");
+    expect(unknown.capabilities).not.toHaveProperty("maxOutput");
+  });
+});

--- a/tests/unit/db-sqlite-vs-lowdb.test.js
+++ b/tests/unit/db-sqlite-vs-lowdb.test.js
@@ -163,12 +163,25 @@ describe("DB SQLite layer — public API parity", () => {
   });
 
   it("customModels: add/list/delete with dedupe", async () => {
-    const ok1 = await sqliteDb.addCustomModel({ providerAlias: "p1", id: "m1", type: "llm", name: "Model 1" });
-    const dup = await sqliteDb.addCustomModel({ providerAlias: "p1", id: "m1", type: "llm" });
+    const ok1 = await sqliteDb.addCustomModel({
+      providerAlias: "p1",
+      id: "m1",
+      type: "llm",
+      name: "Model 1",
+      caps: { contextWindow: 100000, vision: true },
+    });
+    const dup = await sqliteDb.addCustomModel({
+      providerAlias: "p1",
+      id: "m1",
+      type: "llm",
+      caps: { maxOutput: 8000 },
+    });
     expect(ok1).toBe(true);
     expect(dup).toBe(false);
     const list = await sqliteDb.getCustomModels();
-    expect(list.find((m) => m.id === "m1")).toBeDefined();
+    expect(list.find((m) => m.id === "m1")).toMatchObject({
+      caps: { contextWindow: 100000, maxOutput: 8000, vision: true },
+    });
     await sqliteDb.deleteCustomModel({ providerAlias: "p1", id: "m1" });
     const after = await sqliteDb.getCustomModels();
     expect(after.find((m) => m.id === "m1")).toBeUndefined();

--- a/tests/unit/model-caps-provider-isolation.test.js
+++ b/tests/unit/model-caps-provider-isolation.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { buildMaps, resolveCaps } from "../../src/shared/hooks/useModelCaps.js";
+
+describe("dashboard model capability ownership", () => {
+  it("does not use another provider's custom caps for a qualified model", () => {
+    const maps = buildMaps([
+      {
+        fullModel: "provider-a/shared-id",
+        routedModel: "provider-a/shared-id",
+        model: "shared-id",
+        caps: { contextWindow: 123456, maxOutput: 7890 },
+      },
+    ]);
+
+    expect(resolveCaps(maps.byFull, maps.byId, "provider-a/shared-id")).toMatchObject({
+      contextWindow: 123456,
+      maxOutput: 7890,
+    });
+    expect(resolveCaps(maps.byFull, maps.byId, "provider-b/shared-id")).not.toMatchObject({
+      contextWindow: 123456,
+      maxOutput: 7890,
+    });
+  });
+});

--- a/tests/unit/model-token-limits.test.js
+++ b/tests/unit/model-token-limits.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyModelLimitsToCaps,
+  modelLimitsForOpenAI,
+  normalizeDiscoveredModel,
+  normalizeModelLimits,
+  validateModelLimits,
+} from "../../src/shared/utils/modelTokenLimits.js";
+
+describe("custom model token limits", () => {
+  it("normalizes common direct and nested upstream fields", () => {
+    expect(normalizeModelLimits({ context_length: 131072, max_output_tokens: "8192" })).toEqual({
+      contextWindow: 131072,
+      maxOutput: 8192,
+    });
+    expect(normalizeModelLimits({ limit: { context: 200000, output: 64000 } })).toEqual({
+      contextWindow: 200000,
+      maxOutput: 64000,
+    });
+    expect(normalizeModelLimits({ capabilities: { limits: { max_context_window_tokens: 300000, max_output_tokens: 12000 } } })).toEqual({
+      contextWindow: 300000,
+      maxOutput: 12000,
+    });
+  });
+
+  it("keeps unknown limits absent and rejects invalid supplied values", () => {
+    expect(normalizeModelLimits({ id: "unknown" })).toEqual({});
+    expect(validateModelLimits({ contextWindow: 0, max_output_tokens: 2.5 })).toEqual({
+      limits: {},
+      errors: ["contextWindow must be a positive integer", "maxOutput must be a positive integer"],
+    });
+  });
+
+  it("keeps discovery normalization lenient but manual validation strict", () => {
+    expect(normalizeModelLimits({ context_length: "131072" })).toEqual({ contextWindow: 131072 });
+    expect(validateModelLimits({ context_length: "131072" })).toEqual({
+      limits: {},
+      errors: ["contextWindow must be a positive integer"],
+    });
+  });
+
+  it("adds discovered limits without replacing existing capabilities", () => {
+    expect(normalizeDiscoveredModel({
+      id: "model-a",
+      capabilities: { tools: true },
+      max_input_tokens: 100000,
+      max_completion_tokens: 4096,
+    })).toEqual({
+      id: "model-a",
+      capabilities: { tools: true },
+      max_input_tokens: 100000,
+      max_completion_tokens: 4096,
+      caps: { contextWindow: 100000, maxOutput: 4096 },
+    });
+  });
+
+  it("lets explicit limits override fallback without inventing a missing limit", () => {
+    expect(applyModelLimitsToCaps({ contextWindow: 200000, maxOutput: 64000 }, { max_output_tokens: 8192 })).toEqual({
+      contextWindow: 200000,
+      maxOutput: 8192,
+    });
+    expect(applyModelLimitsToCaps({}, { id: "unknown" })).toEqual({});
+  });
+
+  it("emits OpenAI-compatible aliases only for known values", () => {
+    expect(modelLimitsForOpenAI({ caps: { contextWindow: 32000 } })).toEqual({
+      context_length: 32000,
+      max_input_tokens: 32000,
+    });
+    expect(modelLimitsForOpenAI({ id: "unknown" })).toEqual({});
+  });
+});

--- a/tests/unit/provider-custom-models.test.js
+++ b/tests/unit/provider-custom-models.test.js
@@ -59,6 +59,28 @@ describe("provider custom model rows", () => {
     ]);
   });
 
+  it("keeps stored caps on provider-owned dashboard rows", () => {
+    expect(getProviderCustomModelRows({
+      customModels: [{
+        providerAlias: "provider-a",
+        id: "shared-id",
+        type: "llm",
+        caps: { contextWindow: 123456, maxOutput: 7890 },
+      }],
+      providerAlias: "provider-a",
+    })[0].caps).toEqual({ contextWindow: 123456, maxOutput: 7890 });
+
+    expect(getProviderCustomModelRows({
+      customModels: [{
+        providerAlias: "provider-a",
+        id: "shared-id",
+        type: "llm",
+        caps: { contextWindow: 123456 },
+      }],
+      providerAlias: "provider-b",
+    })).toEqual([]);
+  });
+
   it("filters built-in models and typed custom models", () => {
     const rows = getProviderCustomModelRows({
       customModels: [


### PR DESCRIPTION
## Summary
- normalize provider-reported context-window and maximum-output limits and retain them during custom-model imports
- allow optional manual limits, validate persistence inputs, and preserve omitted metadata on re-upsert
- expose provider-scoped limits consistently in dashboard metadata, `/v1/models`, single-model lookup, and `/v1/models/info`
- keep unknown custom limits absent instead of publishing generic fallback values

Closes #3854.

<details>
<summary>Verification</summary>

- `./node_modules/.bin/vitest run unit/model-token-limits.test.js unit/custom-model-limits-route.test.js unit/custom-model-info.test.js unit/custom-model-v1-list.test.js unit/model-caps-provider-isolation.test.js unit/provider-custom-models.test.js unit/db-sqlite-vs-lowdb.test.js unit/v1-model-lookup-3588.test.js` — 8 files, 45 tests passed.
- Bounded full suite, excluding live/real tests, isolated `HOME`/`DATA_DIR`, 2 workers — 2,224 total; 2,088 passed; 112 known failures; 24 skipped. Differential against `eb712ca821f0ba6bc41043fbd14494c5af5daba5`: no new failed assertions or collection failures.
- `npm run build` — passed, including standalone asset copy.
- `node --check` on changed server/helper modules — passed.
- `git diff --check` — passed.
- Scoped ESLint remains red on existing `react-hooks/set-state-in-effect` findings in the touched provider page/modal; no lint-clean claim.

</details>

## Open gaps
- Rendered browser QA was prepared but not completed before publication.
- No live provider calls were run.

## Provenance
- Harness: Hermes Agent
- Model: cx/gpt-5.6-sol
- Provider: custom
- Profile/session: default / unavailable in current context
- Repository: decolua/9router
- Branch or SHA: `KostaGorod:feat/custom-model-limits` / `cb18678782980951a47169008464f80917661715`
- Source: #3854
