### PR TITLE
fix(stream): harden Anthropic SSE success boundary + scoped fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,5 +37,14 @@ NEXT_PUBLIC_CLOUD_URL=https://9router.com
 # Optional SearXNG endpoint for the built-in unauthenticated web-search provider.
 # SEARXNG_URL=http://searxng:8080/search
 
+# Optional stream hardening. Defaults shown below.
+# Set STREAM_PREFLIGHT_ENABLED=false for a quick rollback to raw streaming behavior.
+# STREAM_PREFLIGHT_ENABLED=true
+# STREAM_PREFLIGHT_TIMEOUT_MS=200000
+# STREAM_PREFLIGHT_MAX_BYTES=65536
+# STREAM_FIRST_CHUNK_TIMEOUT_MS=200000
+# STREAM_STALL_TIMEOUT_MS=360000
+# FETCH_CONNECT_TIMEOUT_MS=60000
+
 # Currently unused by application runtime (kept as reference)
 # INSTANCE_NAME=9router

--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -75,6 +75,24 @@ export const ERROR_RULES = [
   { status: 429, backoff: true },
 ];
 
+/**
+ * Request-scoped error rules: the failure is caused by THIS request (too long,
+ * malformed input), not by the account/credential. For these:
+ *   - lockAccount: false  → do NOT cool down / lock the account (retrying the
+ *     same request on another account would fail identically).
+ *   - comboFallback: true → a combo SHOULD advance to the next model (a smaller-
+ *     context model may accept it); a solo request returns the error as-is.
+ * Matched case-insensitively as a substring, and optionally gated by status.
+ */
+export const REQUEST_SCOPED_ERROR_RULES = [
+  { text: "content_length_exceeds_threshold" },
+  { text: "input is too long" },
+  { text: "prompt is too long" },
+  { text: "context length exceeded" },
+  { text: "maximum context length" },
+  { text: "too many tokens" },
+];
+
 // Backward compat: COOLDOWN_MS object (used by index.js re-export)
 export const COOLDOWN_MS = {
   unauthorized: COOLDOWN.long,

--- a/open-sse/config/runtimeConfig.js
+++ b/open-sse/config/runtimeConfig.js
@@ -55,6 +55,21 @@ export const STREAM_STALL_TIMEOUT_MS = envMs("STREAM_STALL_TIMEOUT_MS", 360 * 10
 // Time-to-first-token timeout (prompt prefill). Env: STREAM_FIRST_CHUNK_TIMEOUT_MS.
 export const STREAM_FIRST_CHUNK_TIMEOUT_MS = envMs("STREAM_FIRST_CHUNK_TIMEOUT_MS", 200 * 1000);
 
+// Stream preflight: validate a valid first output event before committing HTTP 200,
+// so a stream that never starts (empty/malformed 200) fails pre-commit and lets
+// combo/account fallback run instead of returning an empty 200 to the client.
+function envBool(name, def) {
+  const raw = process.env[name]?.trim().toLowerCase();
+  if (raw == null || raw === "") return def;
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+export const STREAM_PREFLIGHT_ENABLED = envBool("STREAM_PREFLIGHT_ENABLED", true);
+// Max time to wait for the first valid output event during preflight.
+export const STREAM_PREFLIGHT_TIMEOUT_MS = envMs("STREAM_PREFLIGHT_TIMEOUT_MS", STREAM_FIRST_CHUNK_TIMEOUT_MS);
+// Max bytes buffered during preflight before giving up (guards against a slow
+// dribble of comments/heartbeats that never yields a real first event).
+export const STREAM_PREFLIGHT_MAX_BYTES = envMs("STREAM_PREFLIGHT_MAX_BYTES", 64 * 1024);
+
 // Fetch connect timeout: abort if upstream doesn't return response headers within this duration
 export const FETCH_CONNECT_TIMEOUT_MS = envMs("FETCH_CONNECT_TIMEOUT_MS", 60 * 1000);
 

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -3,8 +3,16 @@ import { needsTranslation } from "../../translator/index.js";
 import { createSSETransformStreamWithLogger, createPassthroughStreamWithLogger } from "../../utils/stream.js";
 import { pipeWithDisconnect } from "../../utils/streamHandler.js";
 import { PROVIDERS } from "../../config/providers.js";
-import { STREAM_STALL_TIMEOUT_MS } from "../../config/runtimeConfig.js";
+import {
+  STREAM_FIRST_CHUNK_TIMEOUT_MS,
+  STREAM_STALL_TIMEOUT_MS,
+  STREAM_PREFLIGHT_ENABLED,
+  STREAM_PREFLIGHT_TIMEOUT_MS,
+  STREAM_PREFLIGHT_MAX_BYTES
+} from "../../config/runtimeConfig.js";
 import { buildAbortedResponsesTerminalBytes } from "../../utils/responsesStreamHelpers.js";
+import { buildAbortedAnthropicTerminalBytes } from "../../utils/anthropicStreamHelpers.js";
+import { preflightTransformedStream, StreamPreflightError } from "../../utils/streamPreflight.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { saveRequestDetail } from "@/lib/usageDb.js";
 import { SSE_HEADERS_CORS as SSE_HEADERS } from "../../utils/sseConstants.js";
@@ -37,20 +45,17 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
     return createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, customToolNames, credentials);
   }
 
-  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey);
+  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey, sourceFormat);
 }
 
 /**
  * Handle streaming response — pipe provider SSE through transform stream to client.
  */
 export async function handleStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, customToolNames, streamController, onStreamComplete, streamDetailId, pxpipe, reqTag, log, credentials }) {
-  if (onRequestSuccess) {
-    Promise.resolve()
-      .then(onRequestSuccess)
-      .catch(err => {
-        console.error("[ChatCore] onRequestSuccess failed:", err?.message || err);
-      });
-  }
+  // onRequestSuccess (clears the account error) is NOT called here: an HTTP 200
+  // with SSE headers does not mean the stream will complete. It is invoked from
+  // the onStreamComplete path once a real terminal event is observed, so an
+  // account is never cleared on a stream that stalls or aborts mid-flight.
 
   // When upstream returns HTML/text instead of SSE (e.g. Cloudflare 5xx error
   // page), piping it through the SSE transform stream causes Next.js
@@ -66,13 +71,21 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
     const sanitizedTitle = (titleMatch?.[1] || '').replace(/<[^>]*>/g, '').replace(/[\r\n]+/g, ' ').trim().slice(0, 160);
     const shortMsg = sanitizedTitle
       || (bodyText.length < 200 ? bodyText.replace(/<[^>]*>/g, '').trim().slice(0, 160) : `Upstream returned non-SSE response (${upstreamContentType})`);
-    const status = providerResponse.status || 502;
+    const status = providerResponse.ok ? 502 : (providerResponse.status || 502);
+    const error = `[${status}]: ${shortMsg}`;
     if (log?.errorLine) log.errorLine(reqTag, "✗", `BLOCKED ${status} · ${provider}/${model} · non-SSE (${upstreamContentType})\n    ${shortMsg}`);
     else console.warn(`[STREAM] ${provider} | ${model} | blocked pipe: ${shortMsg} [${status}]`);
     streamController?.handleError?.(new Error(`upstream non-SSE: ${status}`));
     return {
       success: false,
-      response: new Response(JSON.stringify({ error: { message: `[${status}]: ${shortMsg}` } }), {
+      status,
+      error,
+      streamStarted: false,
+      retryable: true,
+      errorScope: "transport",
+      lockAccount: true,
+      comboFallback: true,
+      response: new Response(JSON.stringify({ error: { message: error } }), {
         status,
         headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
       }),
@@ -81,12 +94,82 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
 
   const transformStream = buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, customToolNames, model, connectionId, body, onStreamComplete, apiKey, credentials });
 
-  // Responses passthrough: synthesize response.failed + [DONE] if the stream aborts/stalls before a terminal event
+  // Preserve each client protocol when an upstream stream aborts. A synthetic
+  // terminal reports failure; it must never masquerade as message_stop.
   const isResponsesPassthrough = sourceFormat === FORMATS.OPENAI_RESPONSES && targetFormat === FORMATS.OPENAI_RESPONSES;
-  const onAbortTerminal = isResponsesPassthrough ? buildAbortedResponsesTerminalBytes : null;
+  const onAbortTerminal = isResponsesPassthrough
+    ? buildAbortedResponsesTerminalBytes
+    : sourceFormat === FORMATS.CLAUDE
+      ? buildAbortedAnthropicTerminalBytes
+      : null;
+  const firstChunkTimeoutMs = PROVIDERS[provider]?.firstChunkTimeoutMs || STREAM_FIRST_CHUNK_TIMEOUT_MS;
   const stallTimeoutMs = PROVIDERS[provider]?.stallTimeoutMs || STREAM_STALL_TIMEOUT_MS;
-  const transformedBody = pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal, stallTimeoutMs);
+  const transformedBody = pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal, {
+    firstChunkTimeoutMs,
+    stallTimeoutMs
+  });
 
+  // Preflight: read up to the first valid transformed output event BEFORE committing
+  // HTTP 200. If the upstream stream is empty/malformed and never produces a valid
+  // first event, we fail pre-commit here (streamStarted:false) so combo/account
+  // fallback can run — instead of returning an empty 200 to the client. Buffered
+  // bytes are replayed verbatim, so a valid stream is passed through byte-for-byte.
+  if (STREAM_PREFLIGHT_ENABLED) {
+    try {
+      const committedBody = await preflightTransformedStream(transformedBody, sourceFormat, {
+        // Never shorten a provider's established TTFT budget. The global preflight
+        // override may lengthen it, but defaults to the same first-chunk timeout.
+        timeoutMs: Math.max(STREAM_PREFLIGHT_TIMEOUT_MS, firstChunkTimeoutMs),
+        maxBytes: STREAM_PREFLIGHT_MAX_BYTES
+      });
+      return commitStreamingResponse({
+        committedBody, provider, model, connectionId, requestStartTime,
+        body, stream, translatedBody, finalBody, pxpipe, streamDetailId
+      });
+    } catch (error) {
+      const status = error instanceof StreamPreflightError ? error.status : 502;
+      const msg = error?.message || "stream failed before first output";
+      if (log?.errorLine) log.errorLine(reqTag, "✗", `PREFLIGHT ${status} · ${provider}/${model} · ${msg}`);
+      else console.warn(`[STREAM] ${provider} | ${model} | preflight failed: ${msg} [${status}]`);
+      streamController?.handleError?.(error instanceof Error ? error : new Error(msg));
+      saveRequestDetail(buildRequestDetail({
+        provider, model, connectionId,
+        latency: { ttft: 0, total: Date.now() - requestStartTime },
+        tokens: { prompt_tokens: 0, completion_tokens: 0 },
+        request: extractRequestConfig(body, stream),
+        providerRequest: finalBody || translatedBody || null,
+        response: { error: msg, status, thinking: null },
+        pxpipe,
+        status: "error"
+      }, { id: streamDetailId })).catch(() => {});
+      return {
+        success: false,
+        status,
+        error: `[${status}]: ${msg}`,
+        streamStarted: false,
+        retryable: true,
+        errorScope: "transport",
+        lockAccount: true,
+        comboFallback: true,
+        response: new Response(JSON.stringify({ error: { message: `[${status}]: ${msg}` } }), {
+          status,
+          headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" }
+        })
+      };
+    }
+  }
+
+  return commitStreamingResponse({
+    committedBody: transformedBody, provider, model, connectionId, requestStartTime,
+    body, stream, translatedBody, finalBody, pxpipe, streamDetailId
+  });
+}
+
+/**
+ * Commit a streaming response: persist the in-progress request detail and hand the
+ * (possibly preflighted) body to the client as an SSE Response.
+ */
+function commitStreamingResponse({ committedBody, provider, model, connectionId, requestStartTime, body, stream, translatedBody, finalBody, pxpipe, streamDetailId }) {
   saveRequestDetail(buildRequestDetail({
     provider, model, connectionId,
     latency: { ttft: 0, total: Date.now() - requestStartTime },
@@ -103,17 +186,19 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
 
   return {
     success: true,
-    response: new Response(transformedBody, { headers: SSE_HEADERS })
+    streamStarted: true,
+    retryable: false,
+    response: new Response(committedBody, { headers: SSE_HEADERS })
   };
 }
 
 /**
  * Build onStreamComplete callback for streaming usage tracking.
  */
-export function buildOnStreamComplete({ provider, model, connectionId, apiKey, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, pxpipe, reqTag, log }) {
+export function buildOnStreamComplete({ provider, model, connectionId, apiKey, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, onRequestSuccess, pxpipe, reqTag, log }) {
   const streamDetailId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 
-  const onStreamComplete = (contentObj, usage, ttftAt) => {
+  const onStreamComplete = (contentObj, usage, ttftAt, { genuineTerminal = false } = {}) => {
     const latency = {
       ttft: ttftAt ? ttftAt - requestStartTime : Date.now() - requestStartTime,
       total: Date.now() - requestStartTime
@@ -121,6 +206,9 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
     const safeContent = contentObj?.content || "[Empty streaming response]";
     const safeThinking = contentObj?.thinking || null;
 
+    // A stream that reached the flush without a genuine success terminal ended
+    // incompletely (silent/incomplete close or synthetic error terminal). Record
+    // it as an error, not a success, so the request log reflects reality.
     saveRequestDetail(buildRequestDetail({
       provider, model, connectionId,
       latency,
@@ -128,9 +216,11 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
       request: extractRequestConfig(body, stream),
       providerRequest: finalBody || translatedBody || null,
       providerResponse: safeContent,
-      response: { content: safeContent, thinking: safeThinking, type: "streaming" },
+      response: genuineTerminal
+        ? { content: safeContent, thinking: safeThinking, type: "streaming" }
+        : { content: safeContent, thinking: safeThinking, type: "streaming", error: "stream closed before terminal event" },
       pxpipe,
-      status: "success"
+      status: genuineTerminal ? "success" : "error"
     }, { id: streamDetailId })).catch(err => {
       console.error("[RequestDetail] Failed to update streaming content:", err.message);
     });
@@ -138,6 +228,17 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
     // Persist stream usage to DB (no console line; the "📊 done" line below is authoritative)
     saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, label: "STREAM USAGE", silent: true });
     if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency }));
+
+    // Clear account error state only on genuine stream completion (real success terminal
+    // reached: message_stop / [DONE] / response.completed / finish_reason). Best-effort,
+    // non-throwing — NOT called at pipe-build time, nor on preflight, stall, abort, a
+    // silent/incomplete close, or an error terminal (genuineTerminal stays false there).
+    if (genuineTerminal && typeof onRequestSuccess === "function") {
+      try {
+        const maybe = onRequestSuccess();
+        if (maybe && typeof maybe.catch === "function") maybe.catch(() => {});
+      } catch { /* best-effort */ }
+    }
   };
 
   return { onStreamComplete, streamDetailId };

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -134,6 +134,10 @@ export const MODEL_CAPABILITIES = {
 };
 
 const KIRO_GPT_5_6_CAPABILITIES = { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 272000, maxOutput: 128000 };
+// Kiro ListAvailableModels uses 200K when tokenLimits.maxInputTokens is absent.
+// Keep legacy Claude 4.5 variants at that conservative Kiro-specific floor;
+// do not inherit newer Claude families' 1M assumption without live evidence.
+const KIRO_CLAUDE_45_CAPABILITIES = { vision: true, reasoning: true, search: true, thinkingFormat: "claude-budget", contextWindow: 200000, maxOutput: 64000 };
 
 // Codex OAuth (ChatGPT backend) — per-model context window reported by upstream
 // (lower than OpenAI API's 1.05M). Sol differs from Terra/Luna. #2720
@@ -163,6 +167,18 @@ export const PROVIDER_CAPABILITIES = {
     "gpt-5.6-luna-review":       CODEX_GPT_56_DEFAULT_CAPS,
   },
   "kiro": {
+    "claude-opus-4.5": KIRO_CLAUDE_45_CAPABILITIES,
+    "claude-opus-4.5-thinking": KIRO_CLAUDE_45_CAPABILITIES,
+    "claude-opus-4.5-agentic": KIRO_CLAUDE_45_CAPABILITIES,
+    "claude-opus-4.5-thinking-agentic": KIRO_CLAUDE_45_CAPABILITIES,
+    "claude-sonnet-4.5": KIRO_CLAUDE_45_CAPABILITIES,
+    "claude-sonnet-4.5-thinking": KIRO_CLAUDE_45_CAPABILITIES,
+    "claude-sonnet-4.5-agentic": KIRO_CLAUDE_45_CAPABILITIES,
+    "claude-sonnet-4.5-thinking-agentic": KIRO_CLAUDE_45_CAPABILITIES,
+    "claude-haiku-4.5": KIRO_CLAUDE_45_CAPABILITIES,
+    "claude-haiku-4.5-thinking": KIRO_CLAUDE_45_CAPABILITIES,
+    "claude-haiku-4.5-agentic": KIRO_CLAUDE_45_CAPABILITIES,
+    "claude-haiku-4.5-thinking-agentic": KIRO_CLAUDE_45_CAPABILITIES,
     "gpt-5.6-sol": KIRO_GPT_5_6_CAPABILITIES,
     "gpt-5.6-terra": KIRO_GPT_5_6_CAPABILITIES,
     "gpt-5.6-luna": KIRO_GPT_5_6_CAPABILITIES,
@@ -445,6 +461,32 @@ function refine(base, provider, model) {
   if (!result.vision && looksLikeVisionModel(model)) result.vision = true;
 
   return result;
+}
+
+// Declared (table/pattern) context window BEFORE any catalog refinement — used by
+// the context guard to decide whether a model has explicit metadata to trim
+// against. Deliberately does not consult catalogSource/refine: a live catalog
+// number is provider-reported and can change per request, not a stable static
+// declaration to size a conservative local trim against.
+export function getDeclaredContextWindowForModel(provider, model) {
+  if (!model) return null;
+  const baseModel = model.includes("/") ? model.split("/").pop() : model;
+
+  if (provider) {
+    const providerCaps = PROVIDER_CAPABILITIES[provider];
+    const providerMatch = providerCaps?.[model] || providerCaps?.[baseModel];
+    if (Number.isFinite(providerMatch?.contextWindow)) return providerMatch.contextWindow;
+  }
+
+  const exact = MODEL_CAPABILITIES[baseModel] || MODEL_CAPABILITIES[model];
+  if (Number.isFinite(exact?.contextWindow)) return exact.contextWindow;
+
+  for (const { pattern, caps } of PATTERN_CAPABILITIES) {
+    if ((matchPattern(pattern, baseModel) || matchPattern(pattern, model)) && Number.isFinite(caps?.contextWindow)) {
+      return caps.contextWindow;
+    }
+  }
+  return null;
 }
 
 export function getCapabilitiesForModel(provider, model) {

--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -1,4 +1,4 @@
-import { ERROR_RULES, BACKOFF_CONFIG, TRANSIENT_COOLDOWN_MS } from "../config/errorConfig.js";
+import { ERROR_RULES, REQUEST_SCOPED_ERROR_RULES, BACKOFF_CONFIG, TRANSIENT_COOLDOWN_MS } from "../config/errorConfig.js";
 
 /**
  * Calculate exponential backoff cooldown for rate limits (429)
@@ -13,40 +13,83 @@ export function getQuotaCooldown(backoffLevel = 0) {
 }
 
 /**
- * Check if error should trigger account fallback (switch to next account)
- * Config-driven: matches ERROR_RULES top-to-bottom (text rules first, then status)
- * @param {number} status - HTTP status code
- * @param {string} errorText - Error message text
- * @param {number} backoffLevel - Current backoff level for exponential backoff
- * @returns {{ shouldFallback: boolean, cooldownMs: number, newBackoffLevel?: number }}
+ * Classify an upstream failure by scope and fallback policy.
+ *
+ * scope:
+ *   request   — request content/size is invalid; account remains healthy
+ *   account   — credential/quota/account-specific failure
+ *   transport — transient provider/network failure (default)
+ *
+ * accountFallback controls trying another credential for the SAME model.
+ * comboFallback controls advancing to another model in a combo.
  */
-export function checkFallbackError(status, errorText, backoffLevel = 0) {
+export function classifyFallbackError(status, errorText, backoffLevel = 0) {
   const lowerError = errorText
     ? (typeof errorText === "string" ? errorText : JSON.stringify(errorText)).toLowerCase()
     : "";
 
-  for (const rule of ERROR_RULES) {
-    // Text-based rule: match substring in error message
-    if (rule.text && lowerError && lowerError.includes(rule.text)) {
-      if (rule.backoff) {
-        const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
-        return { shouldFallback: true, cooldownMs: getQuotaCooldown(newLevel), newBackoffLevel: newLevel };
-      }
-      return { shouldFallback: true, cooldownMs: rule.cooldownMs };
-    }
-
-    // Status-based rule: match HTTP status code
-    if (rule.status && rule.status === status) {
-      if (rule.backoff) {
-        const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
-        return { shouldFallback: true, cooldownMs: getQuotaCooldown(newLevel), newBackoffLevel: newLevel };
-      }
-      return { shouldFallback: true, cooldownMs: rule.cooldownMs };
+  for (const rule of REQUEST_SCOPED_ERROR_RULES) {
+    if ((!rule.status || rule.status === status) && rule.text && lowerError.includes(rule.text)) {
+      return {
+        scope: "request",
+        lockAccount: false,
+        accountFallback: false,
+        comboFallback: true,
+        shouldFallback: false,
+        cooldownMs: 0,
+      };
     }
   }
 
-  // Default: transient cooldown for any unmatched error
-  return { shouldFallback: true, cooldownMs: TRANSIENT_COOLDOWN_MS };
+  for (const rule of ERROR_RULES) {
+    const matched = (rule.text && lowerError && lowerError.includes(rule.text))
+      || (rule.status && rule.status === status);
+    if (!matched) continue;
+
+    if (rule.backoff) {
+      const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
+      return {
+        scope: "account",
+        lockAccount: true,
+        accountFallback: true,
+        comboFallback: true,
+        shouldFallback: true,
+        cooldownMs: getQuotaCooldown(newLevel),
+        newBackoffLevel: newLevel,
+      };
+    }
+    return {
+      scope: "account",
+      lockAccount: true,
+      accountFallback: true,
+      comboFallback: true,
+      shouldFallback: true,
+      cooldownMs: rule.cooldownMs,
+    };
+  }
+
+  return {
+    scope: "transport",
+    lockAccount: true,
+    accountFallback: true,
+    comboFallback: true,
+    shouldFallback: true,
+    cooldownMs: TRANSIENT_COOLDOWN_MS,
+  };
+}
+
+/**
+ * Backward-compatible account fallback wrapper. Existing call sites continue to
+ * receive { shouldFallback, cooldownMs, newBackoffLevel? }; new code should use
+ * classifyFallbackError when it needs request/account/combo policy.
+ */
+export function checkFallbackError(status, errorText, backoffLevel = 0) {
+  const classification = classifyFallbackError(status, errorText, backoffLevel);
+  return {
+    shouldFallback: classification.accountFallback,
+    cooldownMs: classification.cooldownMs,
+    ...(classification.newBackoffLevel != null ? { newBackoffLevel: classification.newBackoffLevel } : {}),
+  };
 }
 
 /**

--- a/open-sse/services/capacityAdapter.js
+++ b/open-sse/services/capacityAdapter.js
@@ -8,7 +8,7 @@
  * front only when none of the original models can handle the request — so this
  * never overrides a combo that already has a member covering the capability.
  */
-import { getCapabilitiesForModel } from "../providers/capabilities.js";
+import { getCapabilitiesForModel, getDeclaredContextWindowForModel } from "../providers/capabilities.js";
 
 const CAPABILITY_KEYS = ["vision", "pdf", "audioInput", "videoInput"];
 const HARD_CAPS = new Set(CAPABILITY_KEYS);
@@ -104,17 +104,60 @@ const HEAD_KEEP = 6;      // messages after system kept verbatim before dropping
 
 function blockLength(content) {
   if (typeof content === "string") return content.length;
-  if (Array.isArray(content)) {
-    return content.reduce((sum, b) => sum + (typeof b?.text === "string" ? b.text.length : 50), 0);
+  if (content == null) return 0;
+  // Structured tool/media blocks can be much larger than their top-level `.text`.
+  // Serialized length is a conservative, format-agnostic estimate and avoids
+  // undercounting nested tool_result/input payloads.
+  try { return JSON.stringify(content).length; } catch { return 0; }
+}
+
+function toolResultRefs(message) {
+  const refs = [];
+  if (message?.role === "tool" && message.tool_call_id) refs.push(`id:${message.tool_call_id}`);
+  for (const block of Array.isArray(message?.content) ? message.content : []) {
+    if (block?.type === "tool_result" && block.tool_use_id) refs.push(`id:${block.tool_use_id}`);
   }
-  return 0;
+  for (const part of Array.isArray(message?.parts) ? message.parts : []) {
+    const response = part?.functionResponse || part?.function_response;
+    if (response?.name) refs.push(`name:${response.name}`);
+  }
+  return refs;
+}
+
+function toolCallRefs(message) {
+  const refs = [];
+  for (const call of Array.isArray(message?.tool_calls) ? message.tool_calls : []) {
+    if (call?.id) refs.push(`id:${call.id}`);
+    const name = call?.function?.name || call?.name;
+    if (name) refs.push(`name:${name}`);
+  }
+  for (const block of Array.isArray(message?.content) ? message.content : []) {
+    if (block?.type === "tool_use" && block.id) refs.push(`id:${block.id}`);
+    if (block?.type === "tool_use" && block.name) refs.push(`name:${block.name}`);
+  }
+  for (const part of Array.isArray(message?.parts) ? message.parts : []) {
+    const call = part?.functionCall || part?.function_call;
+    if (call?.name) refs.push(`name:${call.name}`);
+  }
+  return new Set(refs);
+}
+
+function protectToolCallBridge(previousAssistant, tail) {
+  const results = tail.flatMap(toolResultRefs);
+  if (results.length === 0) return [];
+  if (!previousAssistant) return null;
+  const calls = toolCallRefs(previousAssistant);
+  // Every retained result must still reference a retained tool call. If the shape
+  // is unknown/malformed, fail open by returning the original request unchanged.
+  if (!results.every((ref) => calls.has(ref))) return null;
+  return [previousAssistant];
 }
 
 // Trim history to fit a (possibly smaller) context window by dropping the MIDDLE.
 // Preserves: all system/instruction messages (head), and the trailing user run
 // carrying the media the switch happened for (tail). Older middle turns between
 // the head instructions and the current turn are dropped first.
-export function stripHistoryForContext(body, contextWindow) {
+export function stripHistoryForContext(body, contextWindow, onStrip = null) {
   const key = Array.isArray(body.messages) ? "messages"
     : Array.isArray(body.input) ? "input"
     : Array.isArray(body.contents) ? "contents"
@@ -122,6 +165,14 @@ export function stripHistoryForContext(body, contextWindow) {
   if (!key) return body;
   const arr = body[key];
   if (!arr || arr.length === 0) return body;
+
+  const contentOf = (m) => m?.content ?? m?.parts;
+  // Cap at 80% of the model context — leaves response/tool-call headroom.
+  const budgetChars = (contextWindow || 200000) * 0.8 * CHARS_PER_TOKEN;
+  const beforeChars = arr.reduce((s, m) => s + blockLength(contentOf(m)), 0);
+  // Critical no-op boundary: requests under the conservative budget stay byte/
+  // object-identical. The old implementation trimmed every history > HEAD_KEEP.
+  if (beforeChars <= budgetChars) return body;
 
   const isSystem = (r) => r === "system" || r === "developer";
   const systemMsgs = arr.filter((m) => isSystem(m?.role));
@@ -131,28 +182,47 @@ export function stripHistoryForContext(body, contextWindow) {
   const isAssistant = (r) => r === "assistant" || r === "model";
   let i = rest.length - 1;
   while (i >= 0 && !isAssistant(rest[i]?.role)) i--;
-  const tail = rest.slice(i + 1);          // current user turn (has media) — always kept
-  const older = rest.slice(0, i + 1);      // everything before it
-  if (older.length === 0) return body;
+  const tail = rest.slice(i + 1);          // current user/tool/media run — always kept
+  const previousAssistant = i >= 0 ? rest[i] : null;
+  const protectedBridge = protectToolCallBridge(previousAssistant, tail);
+  if (protectedBridge === null) return body;
+  const older = rest.slice(0, protectedBridge.length > 0 ? i : i + 1);
+  if (older.length === 0 && protectedBridge.length === 0) return body;
 
-  const contentOf = (m) => m.content ?? m.parts;
-  // Cap at 80% of the adapter model's context window — leaves room for the response.
-  const budgetChars = (contextWindow || 200000) * 0.8 * CHARS_PER_TOKEN;
+  // Keep initial conversation/instructions; drop the middle first. If the current
+  // run contains tool_result(s), retain its immediately preceding matching
+  // assistant tool_use/tool_calls message as one atomic bridge.
+  let head = older.slice(0, HEAD_KEEP);
+  let afterChars = systemMsgs.concat(head, protectedBridge, tail).reduce((s, m) => s + blockLength(contentOf(m)), 0);
 
-  // Prefer keeping the first HEAD_KEEP messages (initial instructions/context) verbatim;
-  // only trim further if even that exceeds the adapter model's context window.
-  const headKept = older.slice(0, HEAD_KEEP);
-  let total = systemMsgs.concat(headKept, tail).reduce((s, m) => s + blockLength(contentOf(m)), 0);
-
-  // If head + tail overflow, drop head turns from the end (closest to middle) first.
-  let head = headKept;
-  while (total > budgetChars && head.length > 0) {
+  // If protected content still overflows, drop head turns nearest the middle.
+  // System/developer + tool bridge + current trailing run remain intact.
+  while (afterChars > budgetChars && head.length > 0) {
     const dropped = head.pop();
-    total -= blockLength(contentOf(dropped));
+    afterChars -= blockLength(contentOf(dropped));
   }
 
-  if (head.length === older.length) return body;
-  return { ...body, [key]: [...systemMsgs, ...head, ...tail] };
+  const next = { ...body, [key]: [...systemMsgs, ...head, ...protectedBridge, ...tail] };
+  onStrip?.({
+    key,
+    droppedMessages: arr.length - next[key].length,
+    beforeChars,
+    afterChars,
+    budgetChars,
+  });
+  return next;
+}
+
+// Apply the conservative context guard to any model with explicitly declared
+// context metadata (provider override, exact model, or explicit pattern). Models
+// with no declared limit stay untouched rather than inheriting an unverified floor.
+export function guardRequestForModelContext(body, modelStr, onStrip = null) {
+  const slash = modelStr.indexOf("/");
+  const provider = slash > 0 ? modelStr.slice(0, slash) : "";
+  const model = slash > 0 ? modelStr.slice(slash + 1) : modelStr;
+  const contextWindow = getDeclaredContextWindowForModel(provider, model);
+  if (!contextWindow) return body;
+  return stripHistoryForContext(body, contextWindow, onStrip);
 }
 
 // Wrap a handleSingleModel callback so calls to a capacity-adapter model strip

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -2,7 +2,7 @@
  * Shared combo (model combo) handling with fallback support
  */
 
-import { checkFallbackError, formatRetryAfter } from "./accountFallback.js";
+import { classifyFallbackError, formatRetryAfter } from "./accountFallback.js";
 import { unavailableResponse } from "../utils/error.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { extractTextContent } from "../translator/formats/gemini.js";
@@ -331,10 +331,12 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
         try { errorText = JSON.stringify(errorText); } catch { errorText = String(errorText); }
       }
 
-      // Check if should fallback to next model
-      const { shouldFallback, cooldownMs } = checkFallbackError(result.status, errorText);
+      // Combo advancement uses the comboFallback dimension: a request-scoped error
+      // (e.g. input too long) does NOT lock the account but SHOULD advance to the
+      // next combo model (a smaller-context model may accept it).
+      const { comboFallback, cooldownMs } = classifyFallbackError(result.status, errorText);
 
-      if (!shouldFallback) {
+      if (!comboFallback) {
         log.warn("COMBO", `Model ${modelStr} failed (no fallback)`, { status: result.status });
         return result;
       }

--- a/open-sse/utils/anthropicStreamHelpers.js
+++ b/open-sse/utils/anthropicStreamHelpers.js
@@ -1,0 +1,18 @@
+import { FORMATS } from "../translator/formats.js";
+import { formatSSE } from "./streamHelpers.js";
+
+const sharedEncoder = new TextEncoder();
+
+export function formatIncompleteAnthropicStreamFailure() {
+  return formatSSE({
+    type: "error",
+    error: {
+      type: "api_error",
+      message: "stream closed before message_stop"
+    }
+  }, FORMATS.CLAUDE);
+}
+
+export function buildAbortedAnthropicTerminalBytes() {
+  return sharedEncoder.encode(formatIncompleteAnthropicStreamFailure());
+}

--- a/open-sse/utils/error.js
+++ b/open-sse/utils/error.js
@@ -1,4 +1,5 @@
 import { ERROR_TYPES, DEFAULT_ERROR_MESSAGES } from "../config/errorConfig.js";
+import { classifyFallbackError } from "../services/accountFallback.js";
 
 /**
  * Build OpenAI-compatible error response body
@@ -96,11 +97,20 @@ export async function parseUpstreamError(response, executor = null) {
  * @returns {{ success: false, status: number, error: string, response: Response, resetsAtMs?: number }}
  */
 export function createErrorResult(statusCode, message, resetsAtMs) {
+  // Attach scope so the account layer can skip locking on request-scoped errors
+  // (e.g. Kiro CONTENT_LENGTH_EXCEEDS_THRESHOLD / input too long) while still
+  // letting a combo advance to the next model.
+  const { scope, lockAccount, accountFallback, comboFallback } = classifyFallbackError(statusCode, message);
   return {
     success: false,
     status: statusCode,
     error: message,
     resetsAtMs,
+    errorScope: scope,
+    lockAccount,
+    accountFallback,
+    comboFallback,
+    streamStarted: false,
     response: errorResponse(statusCode, message)
   };
 }

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -4,6 +4,7 @@ import { trackPendingRequest, appendRequestLog } from "@/lib/usageDb.js";
 import { extractUsage, mergeUsage, hasValidUsage, estimateUsage, logUsage, addBufferToUsage, filterUsageForFormat, COLORS } from "./usageTracking.js";
 import { parseSSELine, hasValuableContent, fixInvalidId, formatSSE } from "./streamHelpers.js";
 import { getOpenAIResponsesEventName, isOpenAIResponsesTerminalEvent, formatIncompleteOpenAIResponsesStreamFailure } from "./responsesStreamHelpers.js";
+import { formatIncompleteAnthropicStreamFailure } from "./anthropicStreamHelpers.js";
 import { dbg, isDebugEnabled } from "./debugLog.js";
 
 import { SSE_DONE, SSE_HEADERS, SSE_HEADERS_NO_BUFFER } from "./sseConstants.js";
@@ -21,6 +22,24 @@ const STREAM_MODE = {
   TRANSLATE: "translate",    // Full translation between formats
   PASSTHROUGH: "passthrough" // No translation, normalize output, extract usage
 };
+
+// Classify a terminal chunk: "success" = normal completion (clears account error),
+// "error" = a terminal error event (must NOT clear account), null = not terminal.
+// Only a "success" terminal is allowed to fire onRequestSuccess.
+function classifyTerminalChunk(chunk, responsesEventName = null) {
+  if (!chunk || typeof chunk !== "object") return null;
+  // Error-shaped terminals first — never treat these as success.
+  if (chunk.type === "error" || responsesEventName === "error" || responsesEventName === "response.failed") return "error";
+  const responseStatus = chunk?.response?.status;
+  if (responseStatus === "failed") return "error";
+  // Success terminals.
+  if (chunk.done === true || chunk.type === "message_stop") return "success";
+  if (responsesEventName === "response.completed" || responsesEventName === "response.done") return "success";
+  if (responseStatus === "completed") return "success";
+  if (chunk.choices?.some?.(choice => choice?.finish_reason != null)) return "success";
+  if (chunk.candidates?.some?.(candidate => candidate?.finishReason != null || candidate?.finish_reason != null)) return "success";
+  return null;
+}
 
 /**
  * Create unified SSE transform stream
@@ -76,6 +95,11 @@ export function createSSEStream(options = {}) {
   let openAIResponsesTerminalSeen = false;
   let openAIResponsesDoneSent = false;
   let streamDoneSent = false;  // track duplicate [DONE] across transform + flush
+  // Terminal state of transformed client-visible output. Only "success" clears an
+  // account error; "error" prevents duplicate synthetic terminals; null means EOF
+  // arrived before any terminal and must be surfaced as an incomplete-stream error.
+  let terminalState = null;
+  let genuineTerminalSeen = false;
   let finalized = false;
 
   // Usage/logging tail, callable from transform() as well as flush(): a client that
@@ -102,7 +126,7 @@ export function createSSEStream(options = {}) {
       onStreamComplete({
         content: accumulatedContent,
         thinking: accumulatedThinking
-      }, finalUsage, ttftAt);
+      }, finalUsage, ttftAt, { genuineTerminal: genuineTerminalSeen });
     }
   };
 
@@ -136,6 +160,11 @@ export function createSSEStream(options = {}) {
           let output;
           let injectedUsage = false;
           let responsesTerminal = false;
+
+          if (trimmed.startsWith("data:") && trimmed.slice(5).trim() === "[DONE]") {
+            genuineTerminalSeen = true;
+            terminalState = "success";
+          }
 
           if (trimmed.startsWith("data:") && trimmed.slice(5).trim() !== "[DONE]") {
             try {
@@ -200,6 +229,9 @@ export function createSSEStream(options = {}) {
               }
 
               responsesTerminal = isOpenAIResponsesTerminalEvent(currentOpenAIResponsesEvent, parsed);
+              const parsedTerminal = classifyTerminalChunk(parsed);
+              if (parsedTerminal) terminalState = parsedTerminal;
+              if (parsedTerminal === "success") genuineTerminalSeen = true;
 
               const isFinishChunk = parsed.choices?.[0]?.finish_reason;
               if (isFinishChunk && !hasValidUsage(parsed.usage)) {
@@ -255,6 +287,9 @@ export function createSSEStream(options = {}) {
 
         if (isOpenAIResponsesStream && isOpenAIResponsesTerminalEvent(openAIResponsesEventName, parsed)) {
           openAIResponsesTerminalSeen = true;
+        }
+        if (classifyTerminalChunk(parsed, openAIResponsesEventName) === "success") {
+          genuineTerminalSeen = true;
         }
 
         // For Ollama: done=true is the final chunk with finish_reason/usage, must translate
@@ -365,6 +400,9 @@ export function createSSEStream(options = {}) {
               item.usage = filterUsageForFormat(buffered, sourceFormat);
             }
 
+            if (item.type === "message_stop") terminalState = "success";
+            else if (item.type === "error") terminalState = "error";
+
             const output = formatSSE(item, sourceFormat);
             reqLogger?.appendConvertedChunk?.(output);
             controller.enqueue(sharedEncoder.encode(output));
@@ -392,13 +430,25 @@ export function createSSEStream(options = {}) {
             controller.enqueue(sharedEncoder.encode(output));
           }
 
+          // A silent/incomplete close on a Claude client stream must not look like
+          // a clean finish — synthesize event:error before the sentinel/finalize
+          // below, so the client sees an explicit failure and the account is not
+          // cleared (terminalState stays "error", genuineTerminalSeen stays false).
+          if (sourceFormat === FORMATS.CLAUDE && terminalState === null) {
+            const failedOutput = formatIncompleteAnthropicStreamFailure();
+            reqLogger?.appendConvertedChunk?.(failedOutput);
+            controller.enqueue(sharedEncoder.encode(failedOutput));
+            terminalState = "error";
+          }
+
           // IMPORTANT: In passthrough mode we still must terminate the SSE stream.
           // Some clients (e.g. OpenClaw) expect the OpenAI-style sentinel:
           //   data: [DONE]\n\n
           // Without it they can hang until timeout and trigger failover.
           // Gemini-family clients (Antigravity, Vertex, Gemini) reject this sentinel with 400 syntax errors.
+          // Claude uses message_stop or the event:error synthesized above and MUST NOT receive [DONE].
           const isGeminiFamily = provider === "antigravity" || provider === "gemini" || provider === "vertex";
-          if (!streamDoneSent && !isGeminiFamily) {
+          if (sourceFormat !== FORMATS.CLAUDE && !streamDoneSent && !isGeminiFamily) {
             const doneOutput = "data: [DONE]\n\n";
             reqLogger?.appendConvertedChunk?.(doneOutput);
             controller.enqueue(sharedEncoder.encode(doneOutput));
@@ -462,6 +512,18 @@ export function createSSEStream(options = {}) {
           }
         }
 
+        // Synthesize a Claude error terminal if a Claude client stream ends without one.
+        // A silent close (empty/malformed upstream) would otherwise look like a clean
+        // finish to the client; emit event:error so the client sees an explicit failure.
+        // This is NOT a success terminal — genuineTerminalSeen stays false so the account
+        // is not cleared and fallback bookkeeping treats it as a failed stream.
+        if (sourceFormat === FORMATS.CLAUDE && terminalState === null) {
+          const failedOutput = formatIncompleteAnthropicStreamFailure();
+          reqLogger?.appendConvertedChunk?.(failedOutput);
+          controller.enqueue(sharedEncoder.encode(failedOutput));
+          terminalState = "error";
+        }
+
         // Synthesize response.failed if a Responses passthrough stream never reached a terminal event
         const keepsOpenAIResponsesFormat = targetFormat === FORMATS.OPENAI_RESPONSES && sourceFormat === FORMATS.OPENAI_RESPONSES;
         if (keepsOpenAIResponsesFormat && !openAIResponsesTerminalSeen) {
@@ -506,9 +568,10 @@ export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, p
   });
 }
 
-export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null) {
+export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null, sourceFormat = FORMATS.OPENAI) {
   return createSSEStream({
     mode: STREAM_MODE.PASSTHROUGH,
+    sourceFormat,
     provider,
     reqLogger,
     model,

--- a/open-sse/utils/streamHandler.js
+++ b/open-sse/utils/streamHandler.js
@@ -1,5 +1,5 @@
 // Stream handler with disconnect detection - shared for all providers
-import { STREAM_STALL_TIMEOUT_MS } from "../config/runtimeConfig.js";
+import { STREAM_FIRST_CHUNK_TIMEOUT_MS, STREAM_STALL_TIMEOUT_MS } from "../config/runtimeConfig.js";
 import { dbg, isDebugEnabled } from "./debugLog.js";
 
 // Get HH:MM:SS timestamp
@@ -189,18 +189,34 @@ export function createDisconnectAwareStream(transformStream, streamController, o
  * @param {TransformStream} transformStream - Transform stream for SSE
  * @param {object} streamController - Stream controller from createStreamController
  */
-export function pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal = null, stallTimeoutMs = STREAM_STALL_TIMEOUT_MS) {
+export function pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal = null, timeoutOptions = STREAM_STALL_TIMEOUT_MS) {
+  // Backward compatibility: callers may still pass a single stall timeout.
+  const options = typeof timeoutOptions === "number"
+    ? { firstChunkTimeoutMs: STREAM_FIRST_CHUNK_TIMEOUT_MS, stallTimeoutMs: timeoutOptions }
+    : (timeoutOptions || {});
+  const firstChunkTimeoutMs = options.firstChunkTimeoutMs || STREAM_FIRST_CHUNK_TIMEOUT_MS;
+  const stallTimeoutMs = options.stallTimeoutMs || STREAM_STALL_TIMEOUT_MS;
+  let firstChunkTimer = null;
   let stallTimer = null;
   let chunkCount = 0;
   let totalBytes = 0;
   let lastChunkAt = Date.now();
   const t0 = Date.now();
   const tag = "STREAM";
-  const clearStall = () => {
+  const clearTimers = () => {
+    if (firstChunkTimer) { clearTimeout(firstChunkTimer); firstChunkTimer = null; }
     if (stallTimer) { clearTimeout(stallTimer); stallTimer = null; }
   };
+  const armFirstChunk = () => {
+    firstChunkTimer = setTimeout(() => {
+      firstChunkTimer = null;
+      dbg(tag, `FIRST CHUNK TIMEOUT ${firstChunkTimeoutMs}ms | chunks=${chunkCount} | bytes=${totalBytes}`);
+      streamController.handleError?.(new Error("stream first chunk timeout"));
+      streamController.abort?.();
+    }, firstChunkTimeoutMs);
+  };
   const armStall = () => {
-    clearStall();
+    if (stallTimer) clearTimeout(stallTimer);
     stallTimer = setTimeout(() => {
       stallTimer = null;
       dbg(tag, `STALL TIMEOUT ${stallTimeoutMs}ms | chunks=${chunkCount} | bytes=${totalBytes} | sinceLast=${Date.now() - lastChunkAt}ms`);
@@ -209,25 +225,24 @@ export function pipeWithDisconnect(providerResponse, transformStream, streamCont
     }, stallTimeoutMs);
   };
 
-  // Wrap controller so every termination path clears the stall timer.
-  // Without this, abort/cancel/downstream-error paths leave the timer armed
-  // and a stale abort could fire after the request has already ended.
+  // Wrap controller so every termination path clears both timers.
   const wrappedController = {
     signal: streamController.signal,
     startTime: streamController.startTime,
     isConnected: () => streamController.isConnected(),
-    handleComplete: () => { dbg(tag, `complete | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); streamController.handleComplete(); },
-    handleError: (e) => { dbg(tag, `error: ${e?.message} | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); streamController.handleError(e); },
-    handleDisconnect: (r) => { dbg(tag, `disconnect: ${r} | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); streamController.handleDisconnect(r); },
-    abort: () => { clearStall(); streamController.abort(); }
+    handleComplete: () => { dbg(tag, `complete | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearTimers(); streamController.handleComplete(); },
+    handleError: (e) => { dbg(tag, `error: ${e?.message} | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearTimers(); streamController.handleError(e); },
+    handleDisconnect: (r) => { dbg(tag, `disconnect: ${r} | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearTimers(); streamController.handleDisconnect(r); },
+    abort: () => { clearTimers(); streamController.abort(); }
   };
 
-  armStall();
-  dbg(tag, `pipe start | stallTimeout=${stallTimeoutMs}ms`);
+  armFirstChunk();
+  dbg(tag, `pipe start | firstChunkTimeout=${firstChunkTimeoutMs}ms | stallTimeout=${stallTimeoutMs}ms`);
 
   const upstreamTap = new TransformStream({
     transform(chunk, controller) {
       chunkCount++;
+      if (firstChunkTimer) { clearTimeout(firstChunkTimer); firstChunkTimer = null; }
       const sz = chunk?.byteLength || chunk?.length || 0;
       totalBytes += sz;
       const now = Date.now();
@@ -239,7 +254,7 @@ export function pipeWithDisconnect(providerResponse, transformStream, streamCont
       armStall();
       controller.enqueue(chunk);
     },
-    flush() { dbg(tag, `upstream EOF | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); }
+    flush() { dbg(tag, `upstream EOF | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearTimers(); }
   });
 
   const transformedBody = providerResponse.body

--- a/open-sse/utils/streamPreflight.js
+++ b/open-sse/utils/streamPreflight.js
@@ -1,0 +1,158 @@
+import { FORMATS } from "../translator/formats.js";
+
+const DEFAULT_MAX_BYTES = 64 * 1024;
+
+export class StreamPreflightError extends Error {
+  constructor(message, { status = 502, code = "stream_preflight_failed" } = {}) {
+    super(message);
+    this.name = "StreamPreflightError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function findEventEnd(text, start = 0) {
+  const lf = text.indexOf("\n\n", start);
+  const crlf = text.indexOf("\r\n\r\n", start);
+  if (lf === -1) return crlf === -1 ? null : { index: crlf, length: 4 };
+  if (crlf === -1) return { index: lf, length: 2 };
+  return lf < crlf ? { index: lf, length: 2 } : { index: crlf, length: 4 };
+}
+
+function parseSSEEvent(eventText) {
+  let eventName = "message";
+  const dataLines = [];
+  let meaningful = false;
+
+  for (const rawLine of eventText.split(/\r?\n/)) {
+    if (!rawLine || rawLine.startsWith(":")) continue;
+    meaningful = true;
+    const colon = rawLine.indexOf(":");
+    const field = colon === -1 ? rawLine : rawLine.slice(0, colon);
+    let value = colon === -1 ? "" : rawLine.slice(colon + 1);
+    if (value.startsWith(" ")) value = value.slice(1);
+    if (field === "event") eventName = value;
+    else if (field === "data") dataLines.push(value);
+  }
+
+  if (!meaningful) return null;
+  if (dataLines.length === 0) {
+    throw new StreamPreflightError("upstream SSE first event has no data");
+  }
+
+  let data;
+  try {
+    data = JSON.parse(dataLines.join("\n"));
+  } catch {
+    throw new StreamPreflightError("upstream SSE first event contains malformed JSON");
+  }
+
+  if (eventName === "error" || data?.type === "error") {
+    throw new StreamPreflightError(data?.error?.message || data?.message || "upstream returned an SSE error before message_start");
+  }
+  // Anthropic may emit heartbeat/ping events before message_start. These are
+  // benign — keep scanning rather than treating them as a malformed first event.
+  if (eventName === "ping" || data?.type === "ping") return false;
+  if (eventName !== "message_start" || data?.type !== "message_start") {
+    throw new StreamPreflightError(`upstream SSE first event is ${eventName || data?.type || "unknown"}, expected message_start`);
+  }
+  return true;
+}
+
+function replayBuffered(reader, chunks) {
+  let index = 0;
+  return new ReadableStream({
+    async pull(controller) {
+      if (index < chunks.length) {
+        controller.enqueue(chunks[index++]);
+        return;
+      }
+      try {
+        const { done, value } = await reader.read();
+        if (done) controller.close();
+        else controller.enqueue(value);
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    }
+  });
+}
+
+async function readWithTimeout(reader, remainingMs, configuredTimeoutMs) {
+  if (remainingMs <= 0) {
+    throw new StreamPreflightError(
+      `stream produced no valid first output within ${configuredTimeoutMs}ms`,
+      { status: 504, code: "stream_preflight_timeout" }
+    );
+  }
+  let timer;
+  try {
+    return await Promise.race([
+      reader.read(),
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new StreamPreflightError(
+          `stream produced no valid first output within ${configuredTimeoutMs}ms`,
+          { status: 504, code: "stream_preflight_timeout" }
+        )), remainingMs);
+      })
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Validate only enough transformed output to establish a safe success boundary.
+ * Buffered Uint8Array chunks are replayed byte-for-byte before the unread tail.
+ */
+export async function preflightTransformedStream(readable, sourceFormat, {
+  timeoutMs,
+  maxBytes = DEFAULT_MAX_BYTES
+} = {}) {
+  if (!readable) throw new StreamPreflightError("upstream returned an empty stream");
+
+  const reader = readable.getReader();
+  const chunks = [];
+  const decoder = new TextDecoder("utf-8", { fatal: false });
+  let text = "";
+  let scanStart = 0;
+  let totalBytes = 0;
+  const deadline = timeoutMs ? Date.now() + timeoutMs : null;
+
+  try {
+    while (true) {
+      const read = deadline ? await readWithTimeout(reader, deadline - Date.now(), timeoutMs) : await reader.read();
+      if (read.done) throw new StreamPreflightError("upstream stream ended before valid first output");
+
+      const chunk = read.value instanceof Uint8Array ? read.value : new Uint8Array(read.value);
+      chunks.push(chunk);
+      totalBytes += chunk.byteLength;
+      if (totalBytes > maxBytes) {
+        throw new StreamPreflightError(`stream preflight exceeded ${maxBytes} bytes before valid first output`);
+      }
+
+      const decoded = decoder.decode(chunk, { stream: true });
+      if (sourceFormat !== FORMATS.CLAUDE) {
+        if (decoded.trim().length > 0) return replayBuffered(reader, chunks);
+        continue;
+      }
+
+      text += decoded;
+      while (true) {
+        const end = findEventEnd(text, scanStart);
+        if (!end) break;
+        const eventText = text.slice(scanStart, end.index);
+        scanStart = end.index + end.length;
+        if (parseSSEEvent(eventText)) return replayBuffered(reader, chunks);
+      }
+    }
+  } catch (error) {
+    try { await reader.cancel(error); } catch { /* best-effort upstream cleanup */ }
+    throw error instanceof StreamPreflightError
+      ? error
+      : new StreamPreflightError(error?.message || "stream preflight failed");
+  }
+}

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -16,7 +16,7 @@ import { getTransform as getPxpipeTransform } from "@/lib/pxpipe/loader.js";
 import { appendPxpipeEvent } from "@/lib/pxpipe/events.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
 import { handleComboChat, handleFusionChat, detectRequiredCapabilities } from "open-sse/services/combo.js";
-import { augmentModelsWithCapacityAdapter, withCapacityAdapterStripping, getActiveAdapterStrategy } from "open-sse/services/capacityAdapter.js";
+import { augmentModelsWithCapacityAdapter, withCapacityAdapterStripping, getActiveAdapterStrategy, guardRequestForModelContext } from "open-sse/services/capacityAdapter.js";
 import { handleBypassRequest } from "open-sse/utils/bypassHandler.js";
 import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
 import { detectFormatByEndpoint } from "open-sse/translator/formats.js";
@@ -220,6 +220,16 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
 
   const { provider, model } = modelInfo;
 
+  // Conservative context guard for every model with explicit context metadata,
+  // including Kiro models (not only capacity-adapter-added models). Small requests
+  // remain object-identical; oversized histories drop the middle while preserving
+  // system/developer messages and the trailing current user/tool/media run.
+  body = guardRequestForModelContext(body, `${provider}/${model}`, ({
+    droppedMessages, beforeChars, afterChars, budgetChars
+  }) => {
+    log.warn("CONTEXT", `${provider}/${model} dropped ${droppedMessages} middle messages · chars ${beforeChars}→${afterChars} · budget ${Math.floor(budgetChars)}`);
+  });
+
   // Routing shown in the unified "▶" line (client model → provider/model)
 
   // Extract userAgent from request
@@ -320,11 +330,18 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       if (quotaResetMs) resetsAtMs = quotaResetMs;
     }
 
+    // Request-scoped failures (e.g. input too long) must not lock this healthy
+    // credential or retry another account for the same model. The Response then
+    // returns to combo.js, whose comboFallback policy can advance to another model.
+    const shouldLockAccount = result.lockAccount !== false;
+
     // Exhausted Antigravity model is blocked only in RAM cache until upstream resetAt.
     // Do not persist a modelLock_* for this path.
     const shouldFallback = provider === "antigravity" && quotaResetMs
       ? true
-      : (await markAccountUnavailable(credentials.connectionId, result.status, result.error, provider, model, resetsAtMs)).shouldFallback;
+      : shouldLockAccount
+        ? (await markAccountUnavailable(credentials.connectionId, result.status, result.error, provider, model, resetsAtMs)).shouldFallback
+        : result.accountFallback === true;
 
     if (shouldFallback) {
       log.warn("FALLBACK", `⇄ ACC:${credentials.connectionName} UNAVAILABLE (${result.status}) → NEXT ACCOUNT`);

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -1,6 +1,6 @@
 import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings, getProxyPools } from "@/lib/localDb";
 import { resolveConnectionProxyConfig, pickProxyPoolId } from "@/lib/network/connectionProxy";
-import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
+import { formatRetryAfter, classifyFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
 import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
 import { resolveProviderId, FREE_PROVIDERS } from "@/shared/constants/providers.js";
 import { getAntigravityQuotaCache } from "./antigravityQuota.js";
@@ -259,7 +259,16 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
       : Math.min(resetsAtMs - Date.now(), MAX_RATE_LIMIT_COOLDOWN_MS);
     newBackoffLevel = 0;
   } else {
-    ({ shouldFallback, cooldownMs, newBackoffLevel } = checkFallbackError(status, errorText, backoffLevel));
+    const classification = classifyFallbackError(status, errorText, backoffLevel);
+    // Request-scoped failures (e.g. input too long, CONTENT_LENGTH_EXCEEDS_THRESHOLD)
+    // are caused by THIS request, not the account — never lock the credential.
+    // A combo still advances to another model, but the account stays healthy.
+    if (!classification.lockAccount) {
+      return { shouldFallback: classification.accountFallback, cooldownMs: 0 };
+    }
+    shouldFallback = classification.accountFallback;
+    cooldownMs = classification.cooldownMs;
+    newBackoffLevel = classification.newBackoffLevel;
   }
   if (!shouldFallback) return { shouldFallback: false, cooldownMs: 0 };
 

--- a/tests/unit/account-fallback-scope.test.js
+++ b/tests/unit/account-fallback-scope.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkFallbackError,
+  classifyFallbackError,
+} from "../../open-sse/services/accountFallback.js";
+
+describe("fallback error scope", () => {
+  it.each([
+    "CONTENT_LENGTH_EXCEEDS_THRESHOLD",
+    "input is too long for this model",
+  ])("classifies Kiro context error as request-scoped: %s", (message) => {
+    expect(classifyFallbackError(400, message)).toEqual(expect.objectContaining({
+      scope: "request",
+      lockAccount: false,
+      accountFallback: false,
+      comboFallback: true,
+      cooldownMs: 0,
+    }));
+  });
+
+  it("keeps the backward wrapper account-oriented", () => {
+    expect(checkFallbackError(400, "CONTENT_LENGTH_EXCEEDS_THRESHOLD")).toEqual({
+      shouldFallback: false,
+      cooldownMs: 0,
+    });
+  });
+
+  it("keeps 429 account lock and combo fallback behavior", () => {
+    expect(classifyFallbackError(429, "rate limit", 2)).toEqual(expect.objectContaining({
+      scope: "account",
+      lockAccount: true,
+      accountFallback: true,
+      comboFallback: true,
+      newBackoffLevel: 3,
+    }));
+  });
+
+  it("classifies unmatched 5xx as transient transport failure", () => {
+    expect(classifyFallbackError(502, "socket closed")).toEqual(expect.objectContaining({
+      scope: "transport",
+      lockAccount: true,
+      accountFallback: true,
+      comboFallback: true,
+    }));
+  });
+});

--- a/tests/unit/anthropic-stream-terminal.test.js
+++ b/tests/unit/anthropic-stream-terminal.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  appendRequestLog: vi.fn(async () => {}),
+  trackPendingRequest: vi.fn(),
+}));
+
+const { FORMATS } = await import("../../open-sse/translator/formats.js");
+const { createPassthroughStreamWithLogger } = await import("../../open-sse/utils/stream.js");
+
+const encoder = new TextEncoder();
+
+async function runClaudePassthrough(input, onStreamComplete = null) {
+  const source = new ReadableStream({
+    start(controller) {
+      if (input) controller.enqueue(encoder.encode(input));
+      controller.close();
+    },
+  });
+  const output = source.pipeThrough(createPassthroughStreamWithLogger(
+    "anthropic",
+    null,
+    "claude-test",
+    "connection-test",
+    {},
+    onStreamComplete,
+    null,
+    FORMATS.CLAUDE,
+  ));
+  return new Response(output).text();
+}
+
+describe("Anthropic stream terminal boundary", () => {
+  it("emits event:error, not message_stop or DONE, on incomplete EOF", async () => {
+    const output = await runClaudePassthrough([
+      'event: message_start',
+      'data: {"type":"message_start","message":{"id":"msg_test"}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"partial"}}',
+      '',
+    ].join("\n"));
+
+    expect(output).toContain("event: error");
+    expect(output).toContain("stream closed before message_stop");
+    expect(output).not.toContain("event: message_stop");
+    expect(output).not.toContain("data: [DONE]");
+  });
+
+  it("preserves message_stop and marks genuine completion", async () => {
+    const onStreamComplete = vi.fn();
+    const input = [
+      'event: message_start',
+      'data: {"type":"message_start","message":{"id":"msg_test"}}',
+      '',
+      'event: message_stop',
+      'data: {"type":"message_stop"}',
+      '',
+    ].join("\n");
+
+    const output = await runClaudePassthrough(input, onStreamComplete);
+
+    expect(output).toContain("event: message_stop");
+    expect(output).not.toContain("event: error");
+    expect(output).not.toContain("data: [DONE]");
+    expect(onStreamComplete).toHaveBeenCalledWith(
+      expect.any(Object),
+      null,
+      expect.any(Number),
+      { genuineTerminal: true },
+    );
+  });
+
+  it("does not mark an incomplete close as genuine completion", async () => {
+    const onStreamComplete = vi.fn();
+    await runClaudePassthrough(
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_test"}}\n\n',
+      onStreamComplete,
+    );
+
+    expect(onStreamComplete).toHaveBeenCalledWith(
+      expect.any(Object),
+      null,
+      expect.any(Number),
+      { genuineTerminal: false },
+    );
+  });
+});

--- a/tests/unit/combo-stream-preflight-fallback.test.js
+++ b/tests/unit/combo-stream-preflight-fallback.test.js
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}),
+  saveRequestUsage: vi.fn(async () => {}),
+  trackPendingRequest: vi.fn(),
+}));
+
+const { FORMATS } = await import("../../open-sse/translator/formats.js");
+const { handleStreamingResponse } = await import("../../open-sse/handlers/chatCore/streamingHandler.js");
+const { handleComboChat } = await import("../../open-sse/services/combo.js");
+
+const encoder = new TextEncoder();
+
+function responseFromText(text) {
+  return new Response(new ReadableStream({
+    start(controller) {
+      if (text) controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  }), {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function streamController() {
+  let connected = true;
+  return {
+    signal: new AbortController().signal,
+    startTime: Date.now(),
+    isConnected: () => connected,
+    handleComplete: vi.fn(() => { connected = false; }),
+    handleDisconnect: vi.fn(() => { connected = false; }),
+    handleError: vi.fn(() => { connected = false; }),
+    abort: vi.fn(() => { connected = false; }),
+  };
+}
+
+async function run(providerResponse) {
+  return handleStreamingResponse({
+    providerResponse,
+    provider: "anthropic",
+    model: "claude-test",
+    sourceFormat: FORMATS.CLAUDE,
+    targetFormat: FORMATS.CLAUDE,
+    body: { messages: [{ role: "user", content: "hi" }] },
+    stream: true,
+    requestStartTime: Date.now(),
+    connectionId: "connection-test",
+    streamController: streamController(),
+    streamDetailId: "detail-test",
+    onStreamComplete: vi.fn(),
+  });
+}
+
+const log = {
+  info: vi.fn(),
+  warn: vi.fn(),
+};
+
+describe("combo streaming preflight fallback", () => {
+  it("fails an empty HTTP 200 before stream commit", async () => {
+    const result = await run(responseFromText(""));
+    expect(result).toEqual(expect.objectContaining({
+      success: false,
+      status: 502,
+      streamStarted: false,
+      comboFallback: true,
+    }));
+    expect(result.response.status).toBe(502);
+  });
+
+  it("tries model two after model one empty-200 preflight failure", async () => {
+    const attempts = [];
+    const valid = [
+      'event: message_start',
+      'data: {"type":"message_start","message":{"id":"msg_second"}}',
+      '',
+      'event: message_stop',
+      'data: {"type":"message_stop"}',
+      '',
+    ].join("\n");
+
+    const response = await handleComboChat({
+      body: { messages: [{ role: "user", content: "hi" }] },
+      models: ["anthropic/first", "anthropic/second"],
+      handleSingleModel: async (_body, model) => {
+        attempts.push(model);
+        const result = model.endsWith("/first")
+          ? await run(responseFromText(""))
+          : await run(responseFromText(valid));
+        return result.response;
+      },
+      log,
+    });
+
+    expect(attempts).toEqual(["anthropic/first", "anthropic/second"]);
+    expect(response.status).toBe(200);
+    const output = await response.text();
+    expect(output).toContain("msg_second");
+    expect(output).not.toContain("stream closed before message_stop");
+    expect(output).not.toContain("first");
+  });
+});

--- a/tests/unit/context-guard.test.js
+++ b/tests/unit/context-guard.test.js
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  guardRequestForModelContext,
+  stripHistoryForContext,
+} from "../../open-sse/services/capacityAdapter.js";
+
+function bigText(chars) {
+  return "x".repeat(chars);
+}
+
+describe("context guard", () => {
+  it("is a no-op for a small request (object identity preserved)", () => {
+    const body = {
+      messages: [
+        { role: "system", content: "be helpful" },
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "hello" },
+        { role: "user", content: "how are you" },
+      ],
+    };
+    expect(guardRequestForModelContext(body, "kiro/claude-opus-4.8")).toBe(body);
+  });
+
+  it("leaves models with no declared context untouched", () => {
+    const body = {
+      messages: Array.from({ length: 40 }, (_, i) => ({
+        role: i % 2 === 0 ? "user" : "assistant",
+        content: bigText(20000),
+      })),
+    };
+    // Unknown provider/model → no declared context window → no strip.
+    expect(guardRequestForModelContext(body, "totally-unknown/mystery-model")).toBe(body);
+  });
+
+  it("drops the middle but keeps system and current turn when over budget", () => {
+    const onStrip = vi.fn();
+    const messages = [
+      { role: "system", content: "SYSTEM RULES" },
+      ...Array.from({ length: 30 }, (_, i) => ({
+        role: i % 2 === 0 ? "user" : "assistant",
+        content: bigText(40000),
+      })),
+      { role: "user", content: "CURRENT QUESTION" },
+    ];
+    const result = stripHistoryForContext({ messages }, 200000, onStrip);
+
+    expect(result.messages).not.toBe(messages);
+    expect(result.messages[0]).toEqual({ role: "system", content: "SYSTEM RULES" });
+    expect(result.messages.at(-1)).toEqual({ role: "user", content: "CURRENT QUESTION" });
+    expect(result.messages.length).toBeLessThan(messages.length);
+    expect(onStrip).toHaveBeenCalledWith(expect.objectContaining({
+      key: "messages",
+      droppedMessages: expect.any(Number),
+    }));
+  });
+
+  it("keeps the assistant tool_use bridge when the current run is a tool_result", () => {
+    const messages = [
+      { role: "system", content: "SYSTEM" },
+      ...Array.from({ length: 20 }, (_, i) => ({
+        role: i % 2 === 0 ? "user" : "assistant",
+        content: bigText(40000),
+      })),
+      { role: "assistant", content: [{ type: "tool_use", id: "call_1", name: "read", input: {} }] },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "call_1", content: "file body" }] },
+    ];
+    const result = stripHistoryForContext({ messages }, 200000);
+
+    const last = result.messages.at(-1);
+    const bridge = result.messages.at(-2);
+    expect(last.content[0].tool_use_id).toBe("call_1");
+    expect(bridge.content[0]).toMatchObject({ type: "tool_use", id: "call_1" });
+    expect(result.messages.length).toBeLessThan(messages.length);
+  });
+
+  it("fails open when a tool_result has no matching preceding tool_use", () => {
+    const messages = [
+      { role: "system", content: "SYSTEM" },
+      ...Array.from({ length: 20 }, (_, i) => ({
+        role: i % 2 === 0 ? "user" : "assistant",
+        content: bigText(40000),
+      })),
+      { role: "assistant", content: [{ type: "tool_use", id: "call_A", name: "read", input: {} }] },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "call_MISSING", content: "x" }] },
+    ];
+    // Bridge cannot satisfy the orphan tool_result → return body unchanged.
+    expect(stripHistoryForContext({ messages }, 200000)).toEqual({ messages });
+  });
+
+  it("counts structured tool blocks by serialized size", () => {
+    const heavyToolResult = {
+      messages: [
+        { role: "user", content: "start" },
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "t1", name: "read", input: { path: bigText(60000) } }],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "t1", content: bigText(900000) }],
+        },
+        { role: "assistant", content: "ok" },
+        { role: "user", content: "final" },
+      ],
+    };
+    // 900k-char tool_result far exceeds the 200k*0.8*4 budget → must strip.
+    const result = stripHistoryForContext(heavyToolResult, 200000);
+    expect(result.messages.at(-1)).toEqual({ role: "user", content: "final" });
+  });
+});

--- a/tests/unit/kiro-request-scope-lock.test.js
+++ b/tests/unit/kiro-request-scope-lock.test.js
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({
+  getProviderConnections: vi.fn(),
+  updateProviderConnection: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/localDb", () => dbMocks);
+vi.mock("@/lib/network/connectionProxy", () => ({
+  pickProxyPoolId: vi.fn(),
+  resolveConnectionProxyConfig: vi.fn(),
+}));
+vi.mock("@/shared/constants/providers.js", () => ({
+  FREE_PROVIDERS: {},
+  resolveProviderId: (provider) => provider,
+}));
+vi.mock("@/sse/utils/logger.js", () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
+const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMocks.getProviderConnections.mockResolvedValue([{
+    id: "kiro-a",
+    provider: "kiro",
+    name: "kiro-a",
+    backoffLevel: 0,
+  }]);
+});
+
+describe("Kiro request-scoped context errors", () => {
+  it.each([
+    "CONTENT_LENGTH_EXCEEDS_THRESHOLD",
+    "input is too long for this model",
+  ])("does not write a model/account lock for %s", async (message) => {
+    const result = await markAccountUnavailable(
+      "kiro-a",
+      400,
+      message,
+      "kiro",
+      "claude-opus-4.8",
+    );
+
+    expect(result).toEqual({ shouldFallback: false, cooldownMs: 0 });
+    expect(dbMocks.updateProviderConnection).not.toHaveBeenCalled();
+  });
+
+  it("keeps 429 model locking and account fallback", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-09T12:00:00.000Z"));
+    try {
+      const result = await markAccountUnavailable(
+        "kiro-a",
+        429,
+        "rate limit exceeded",
+        "kiro",
+        "claude-opus-4.8",
+      );
+
+      expect(result.shouldFallback).toBe(true);
+      expect(dbMocks.updateProviderConnection).toHaveBeenCalledWith(
+        "kiro-a",
+        expect.objectContaining({
+          "modelLock_claude-opus-4.8": expect.any(String),
+          testStatus: "unavailable",
+          errorCode: 429,
+          backoffLevel: 1,
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/unit/stream-preflight.test.js
+++ b/tests/unit/stream-preflight.test.js
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import {
+  preflightTransformedStream,
+  StreamPreflightError,
+} from "../../open-sse/utils/streamPreflight.js";
+
+const encoder = new TextEncoder();
+
+function streamFromChunks(...chunks) {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+async function collect(stream) {
+  return new Response(stream).text();
+}
+
+describe("transformed stream preflight", () => {
+  it("preserves split Claude message_start bytes exactly", async () => {
+    const chunks = [
+      ": ping\n\nevent: message_",
+      'start\ndata: {"type":"message_start","message":{"id":"msg_1"}}\n\n',
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    ];
+
+    const replay = await preflightTransformedStream(
+      streamFromChunks(...chunks),
+      FORMATS.CLAUDE,
+      { timeoutMs: 100, maxBytes: 65536 },
+    );
+
+    await expect(collect(replay)).resolves.toBe(chunks.join(""));
+  });
+
+  it("rejects empty EOF before commit", async () => {
+    await expect(preflightTransformedStream(
+      streamFromChunks(),
+      FORMATS.CLAUDE,
+      { timeoutMs: 100 },
+    )).rejects.toMatchObject({
+      name: "StreamPreflightError",
+      status: 502,
+    });
+  });
+
+  it("rejects malformed Claude first event", async () => {
+    await expect(preflightTransformedStream(
+      streamFromChunks("event: message_start\ndata: {bad json}\n\n"),
+      FORMATS.CLAUDE,
+      { timeoutMs: 100 },
+    )).rejects.toThrow("malformed JSON");
+  });
+
+  it("converts first Claude error event into pre-commit failure", async () => {
+    await expect(preflightTransformedStream(
+      streamFromChunks('event: error\ndata: {"type":"error","error":{"message":"busy"}}\n\n'),
+      FORMATS.CLAUDE,
+      { timeoutMs: 100 },
+    )).rejects.toThrow("busy");
+  });
+
+  it("skips a leading ping event and preserves bytes exactly", async () => {
+    const chunks = [
+      'event: ping\ndata: {"type":"ping"}\n\n',
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1"}}\n\n',
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    ];
+    const replay = await preflightTransformedStream(
+      streamFromChunks(...chunks),
+      FORMATS.CLAUDE,
+      { timeoutMs: 100, maxBytes: 65536 },
+    );
+    await expect(collect(replay)).resolves.toBe(chunks.join(""));
+  });
+
+  it("accepts first non-empty output for non-Claude formats", async () => {
+    const chunks = [" \n", 'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'];
+    const replay = await preflightTransformedStream(
+      streamFromChunks(...chunks),
+      FORMATS.OPENAI,
+      { timeoutMs: 100 },
+    );
+    await expect(collect(replay)).resolves.toBe(chunks.join(""));
+  });
+
+  it("uses one total deadline across heartbeat chunks", async () => {
+    vi.useFakeTimers();
+    try {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(": ping\n\n"));
+          setTimeout(() => controller.enqueue(encoder.encode(": ping\n\n")), 40);
+          setTimeout(() => controller.enqueue(encoder.encode(": ping\n\n")), 80);
+        },
+      });
+      const pending = preflightTransformedStream(stream, FORMATS.CLAUDE, {
+        timeoutMs: 100,
+        maxBytes: 65536,
+      });
+      const assertion = expect(pending).rejects.toEqual(expect.objectContaining({
+        code: "stream_preflight_timeout",
+        status: 504,
+      }));
+      await vi.advanceTimersByTimeAsync(110);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("exports a typed preflight error", () => {
+    expect(new StreamPreflightError("x")).toMatchObject({ status: 502, code: "stream_preflight_failed" });
+  });
+});

--- a/tests/unit/stream-success-boundary.test.js
+++ b/tests/unit/stream-success-boundary.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}),
+  saveRequestUsage: vi.fn(async () => {}),
+}));
+
+const { buildOnStreamComplete } = await import("../../open-sse/handlers/chatCore/streamingHandler.js");
+
+function build(onRequestSuccess) {
+  return buildOnStreamComplete({
+    provider: "anthropic",
+    model: "claude-test",
+    connectionId: "connection-test",
+    apiKey: null,
+    requestStartTime: Date.now(),
+    body: { messages: [{ role: "user", content: "hi" }] },
+    stream: true,
+    clientRawRequest: { endpoint: "/v1/messages" },
+    onRequestSuccess,
+  }).onStreamComplete;
+}
+
+describe("stream success boundary", () => {
+  it("does not clear account on incomplete/synthetic-error terminal", async () => {
+    const onRequestSuccess = vi.fn(async () => {});
+    build(onRequestSuccess)({ content: "partial" }, null, Date.now(), {
+      genuineTerminal: false,
+    });
+    await Promise.resolve();
+    expect(onRequestSuccess).not.toHaveBeenCalled();
+  });
+
+  it("clears account exactly once after genuine terminal completion", async () => {
+    const onRequestSuccess = vi.fn(async () => {});
+    build(onRequestSuccess)({ content: "done" }, null, Date.now(), {
+      genuineTerminal: true,
+    });
+    await Promise.resolve();
+    expect(onRequestSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows synchronous account-clear failures", () => {
+    const onRequestSuccess = vi.fn(() => { throw new Error("db unavailable"); });
+    expect(() => build(onRequestSuccess)({}, null, Date.now(), {
+      genuineTerminal: true,
+    })).not.toThrow();
+  });
+});

--- a/tests/unit/stream-timeouts.test.js
+++ b/tests/unit/stream-timeouts.test.js
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  appendRequestLog: vi.fn(async () => {}),
+  trackPendingRequest: vi.fn(),
+}));
+
+const { pipeWithDisconnect } = await import("../../open-sse/utils/streamHandler.js");
+
+const encoder = new TextEncoder();
+
+function passthroughTransform() {
+  return new TransformStream({
+    transform(chunk, controller) { controller.enqueue(chunk); },
+  });
+}
+
+function controller() {
+  let connected = true;
+  const ctl = {
+    signal: new AbortController().signal,
+    startTime: Date.now(),
+    isConnected: () => connected,
+    handleComplete: vi.fn(() => { connected = false; }),
+    handleError: vi.fn(() => { connected = false; }),
+    handleDisconnect: vi.fn(() => { connected = false; }),
+    abort: vi.fn(() => { connected = false; }),
+  };
+  return ctl;
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe("stream timeout phases", () => {
+  it("uses first-chunk timeout before any upstream byte", async () => {
+    vi.useFakeTimers();
+    const ctl = controller();
+    const upstream = new Response(new ReadableStream({ start() {} }));
+    const output = pipeWithDisconnect(upstream, passthroughTransform(), ctl, null, {
+      firstChunkTimeoutMs: 50,
+      stallTimeoutMs: 500,
+    });
+    const reader = output.getReader();
+    const pending = reader.read();
+
+    await vi.advanceTimersByTimeAsync(60);
+    await Promise.resolve();
+
+    expect(ctl.handleError).toHaveBeenCalledWith(expect.objectContaining({
+      message: "stream first chunk timeout",
+    }));
+    expect(ctl.abort).toHaveBeenCalledTimes(1);
+    reader.cancel().catch(() => {});
+    pending.catch(() => {});
+  });
+
+  it("clears first-chunk timeout after first byte and uses stall timeout", async () => {
+    vi.useFakeTimers();
+    const ctl = controller();
+    let upstreamController;
+    const upstream = new Response(new ReadableStream({
+      start(controller) { upstreamController = controller; },
+    }));
+    const output = pipeWithDisconnect(upstream, passthroughTransform(), ctl, null, {
+      firstChunkTimeoutMs: 50,
+      stallTimeoutMs: 100,
+    });
+    const reader = output.getReader();
+    const firstRead = reader.read();
+    upstreamController.enqueue(encoder.encode("first"));
+    await expect(firstRead).resolves.toEqual(expect.objectContaining({ done: false }));
+
+    await vi.advanceTimersByTimeAsync(60);
+    expect(ctl.handleError).not.toHaveBeenCalled();
+
+    const pending = reader.read();
+    await vi.advanceTimersByTimeAsync(50);
+    await Promise.resolve();
+    expect(ctl.handleError).toHaveBeenCalledWith(expect.objectContaining({
+      message: "stream stall timeout",
+    }));
+    expect(ctl.abort).toHaveBeenCalledTimes(1);
+    reader.cancel().catch(() => {});
+    pending.catch(() => {});
+  });
+});

--- a/update-9router.sh
+++ b/update-9router.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# =============================================================
+# Cập nhật upstream 9Router nhưng giữ patch local độc lập.
+# Workflow: local/stream-hardening --rebase--> origin/master
+# Chạy trong WSL: chmod +x update-9router.sh && ./update-9router.sh
+# =============================================================
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+step() { echo -e "\n${CYAN}==> $1${NC}"; }
+warn() { echo -e "${YELLOW}$1${NC}"; }
+err()  { echo -e "${RED}$1${NC}"; }
+
+# Resolve from this script, not $HOME, so the script can never update a different checkout.
+ROUTER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DB_DIR="$HOME/.9router"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+DB_BACKUP_DIR="$HOME/.9router.backup-$STAMP"
+PATCH_BACKUP_DIR="$HOME/.9router-patches/$STAMP"
+PATCH_BRANCH="local/stream-hardening"
+UPSTREAM_REF="origin/master"
+
+if ! git -C "$ROUTER_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    err "Không tìm thấy Git checkout 9Router tại $ROUTER_DIR."
+    exit 1
+fi
+
+cd "$ROUTER_DIR"
+CURRENT_BRANCH="$(git branch --show-current)"
+if [ "$CURRENT_BRANCH" != "$PATCH_BRANCH" ]; then
+    err "Đang ở branch '$CURRENT_BRANCH'; update chỉ được chạy trên '$PATCH_BRANCH'."
+    err "Chuyển branch: git switch $PATCH_BRANCH"
+    exit 1
+fi
+
+# Never auto-stash: untracked files may contain local secrets. A dirty tree means
+# patch has not been captured in a durable commit yet, so stop before touching refs.
+if [ -n "$(git status --porcelain)" ]; then
+    err "Working tree đang có thay đổi chưa commit; dừng update để không mất patch."
+    err "Kiểm tra: git status --short"
+    err "Sau khi test xong, commit patch trên '$PATCH_BRANCH' rồi chạy lại script."
+    exit 1
+fi
+
+OLD_VERSION="$(git rev-parse --short HEAD)"
+OLD_UPSTREAM="$(git rev-parse --short "$UPSTREAM_REF" 2>/dev/null || echo unknown)"
+echo "Patch branch: $PATCH_BRANCH"
+echo "Commit hiện tại: $OLD_VERSION"
+echo "Upstream cache hiện tại: $OLD_UPSTREAM"
+
+# --- Bước 1: Backup database + local patch commits trước update ---
+step "Backup database và patch local"
+if [ -d "$DB_DIR" ]; then
+    cp -r "$DB_DIR" "$DB_BACKUP_DIR"
+    echo "Database backup: $DB_BACKUP_DIR"
+else
+    warn "Không tìm thấy $DB_DIR — bỏ qua database backup."
+fi
+
+mkdir -p "$PATCH_BACKUP_DIR"
+LOCAL_COMMIT_COUNT="$(git rev-list --count "$UPSTREAM_REF..HEAD")"
+if [ "$LOCAL_COMMIT_COUNT" -gt 0 ]; then
+    git format-patch --quiet --output-directory "$PATCH_BACKUP_DIR" "$UPSTREAM_REF..HEAD"
+    git bundle create "$PATCH_BACKUP_DIR/local-stream-hardening.bundle" "$PATCH_BRANCH"
+    echo "Patch backup ($LOCAL_COMMIT_COUNT commit): $PATCH_BACKUP_DIR"
+else
+    warn "Branch chưa có commit local phía trên $UPSTREAM_REF; không có patch commit để backup."
+fi
+
+# --- Bước 2: Fetch upstream rồi replay patch local lên upstream mới ---
+step "Fetch origin và rebase patch local lên origin/master"
+git fetch --prune origin
+NEW_UPSTREAM="$(git rev-parse --short "$UPSTREAM_REF")"
+
+if ! git rebase "$UPSTREAM_REF"; then
+    err "Rebase conflict. Patch KHÔNG bị mất; Git đang giữ conflict để xử lý."
+    err "Xem conflict: git status"
+    err "Tiếp tục: git add <files> && git rebase --continue"
+    err "Hủy update: git rebase --abort"
+    exit 1
+fi
+
+NEW_VERSION="$(git rev-parse --short HEAD)"
+if [ "$OLD_UPSTREAM" = "$NEW_UPSTREAM" ]; then
+    warn "Upstream không có commit mới; vẫn build lại để xác minh patch."
+else
+    echo "Upstream: $OLD_UPSTREAM -> $NEW_UPSTREAM"
+fi
+
+# --- Bước 3: Dependencies + build ---
+step "Cài dependencies"
+npm install
+
+step "Build production"
+npm run build
+
+# postbuild already copies standalone assets. Keep an explicit sanity check rather
+# than deleting/copying source-adjacent directories a second time.
+if [ ! -f "$ROUTER_DIR/.next/standalone/server.js" ]; then
+    err "Build thiếu .next/standalone/server.js; không restart service."
+    exit 1
+fi
+
+# --- Bước 4: Restart + health ---
+step "Restart 9Router qua PM2"
+pm2 restart 9router
+pm2 save
+
+step "Kiểm tra health sau restart"
+sleep 3
+HEALTH="$(curl --fail --silent --show-error http://localhost:20128/api/health 2>/dev/null || echo FAILED)"
+MODELS_STATUS="$(curl --output /dev/null --silent --write-out '%{http_code}' http://localhost:20128/v1/models || echo 000)"
+
+if [[ "$HEALTH" == *'"ok":true'* ]] && [[ "$MODELS_STATUS" =~ ^2 ]]; then
+    echo -e "${GREEN}=====================================================${NC}"
+    echo -e "${GREEN} CẬP NHẬT THÀNH CÔNG${NC}"
+    echo -e "${GREEN} Patch branch: $PATCH_BRANCH${NC}"
+    echo -e "${GREEN} Commit: $OLD_VERSION -> $NEW_VERSION${NC}"
+    echo -e "${GREEN} Upstream: $OLD_UPSTREAM -> $NEW_UPSTREAM${NC}"
+    echo -e "${GREEN} /api/health: $HEALTH${NC}"
+    echo -e "${GREEN} /v1/models: HTTP $MODELS_STATUS${NC}"
+    echo -e "${GREEN} DB backup: $DB_BACKUP_DIR${NC}"
+    echo -e "${GREEN} Patch backup: $PATCH_BACKUP_DIR${NC}"
+    echo -e "${GREEN}=====================================================${NC}"
+else
+    echo -e "${RED}=====================================================${NC}"
+    echo -e "${RED} CẢNH BÁO: post-update smoke check thất bại${NC}"
+    echo -e "${RED} /api/health: $HEALTH${NC}"
+    echo -e "${RED} /v1/models: HTTP $MODELS_STATUS${NC}"
+    echo -e "${RED} Log: pm2 logs 9router --lines 100 --nostream${NC}"
+    echo -e "${RED} Code rollback: git reset --hard $OLD_VERSION (chỉ sau khi đã xác nhận patch backup)${NC}"
+    echo -e "${RED} DB backup: $DB_BACKUP_DIR${NC}"
+    echo -e "${RED}=====================================================${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Problem

Users occasionally hit: `API Error: API returned an empty or malformed response (HTTP 200) — check for a proxy or gateway intercepting the request`.

Root cause: `handleStreamingResponse` committed HTTP 200 as soon as the provider's SSE pipe was built — before any byte of the stream was validated. If the upstream stream turned out empty, malformed, or closed mid-flight without a `message_stop`, the client had already received a 200 it could not recover from, and `onRequestSuccess` (which clears account error state) could fire before the stream had actually completed.

## Fix

- **Preflight before commit**: read up to the first valid transformed output event (Claude `message_start`, or first non-empty chunk for other formats) *before* returning HTTP 200. Buffered bytes are replayed byte-for-byte, so a valid stream passes through unchanged. An empty/malformed stream fails pre-commit (`streamStarted:false`), letting combo/account fallback try the next model/account instead of the client receiving a broken 200.
- **Success boundary**: `onRequestSuccess` (clears account error) now only fires from `onStreamComplete` once a genuine success terminal is observed (`message_stop` / `[DONE]` / `response.completed` / `finish_reason`) — never at pipe-build time, and never on stall/abort/preflight-fail/error-terminal.
- **Anthropic terminal on incomplete close**: a Claude stream that closes without `message_stop` now emits `event: error` (never a synthesized `message_stop`, never `[DONE]`).
- **Timeout separation**: first-chunk timeout (waiting for the first upstream byte) is now distinct from the stall timeout (gap between chunks once flowing); the preflight timeout never shortens a provider's existing first-chunk budget.
- **Scoped fallback for request-level errors**: added an error-scope classifier (`request` / `account` / `transport`) with `lockAccount` / `accountFallback` / `comboFallback` policy. Kiro's `CONTENT_LENGTH_EXCEEDS_THRESHOLD` / "input is too long" is now request-scoped — it does not lock the account, but a combo can still advance to another model.
- **Context guard**: trims history against a model's declared context window only when explicit metadata exists (no-op for small requests); preserves an assistant `tool_use` + `tool_result` pair as one atomic unit, failing open (returns the original body) if a `tool_result` has no matching preceding `tool_use`.

## Testing

- 32 new unit tests covering: split-stream byte-exact replay, empty-200 pre-commit failure, malformed/first-error-event rejection, leading `ping` heartbeat tolerance, combo fallback after an empty-200 first model, Anthropic abort terminal, the `onRequestSuccess` success-boundary gate, independent first-chunk/stall timeouts, Kiro request-scoped error (no lock) vs 429 (lock), and context-guard tool-call bridging.
- Full suite compared 1:1 against a clean `origin/master` checkout: **0 regressions** (113 pre-existing failures identical on both, all new tests passing).
- `npm run build` passes.
- Verified end-to-end against a live deployment (direct 9Router and via an upstream smart-router proxy): valid streams complete with `message_start → … → message_stop`; a real-world case (an Antigravity/Gemini account returning a deprecated-model notice and closing without a terminal) now correctly surfaces `event:error` instead of a silently truncated 200.

## Companion patch

A matching preflight was also applied to [smart-router-9router](https://github.com/sathanh91/smart-router-9router) (the optional tiered-routing proxy some users run in front of 9Router), for users who terminate the Anthropic SSE contract at that layer instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)