### PR TITLE
fix(console-log): stop dragging the reader back to the newest line

### DIFF
--- a/src/app/(dashboard)/dashboard/console-log/ConsoleLogClient.js
+++ b/src/app/(dashboard)/dashboard/console-log/ConsoleLogClient.js
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { Card, Button } from "@/shared/components";
 import { CONSOLE_LOG_CONFIG } from "@/shared/constants/config";
+import { isPinnedToBottom } from "@/shared/utils/scrollFollow";
 
 const LOG_LEVEL_COLORS = {
   LOG: "text-green-400",
@@ -62,9 +63,18 @@ export default function ConsoleLogClient() {
     return () => es.close();
   }, []);
 
-  // Auto-scroll to bottom on new logs
+  // Follow the tail only while the reader is already at it. Recorded on
+  // scroll rather than read in the effect: by the time the effect runs the
+  // new lines are laid out, so the element no longer reports where the
+  // reader was before they arrived.
+  const followTailRef = useRef(true);
+
+  const handleLogScroll = () => {
+    followTailRef.current = isPinnedToBottom(logRef.current);
+  };
+
   useEffect(() => {
-    if (!logRef.current) return;
+    if (!logRef.current || !followTailRef.current) return;
     logRef.current.scrollTop = logRef.current.scrollHeight;
   }, [logs]);
 
@@ -78,6 +88,7 @@ export default function ConsoleLogClient() {
         </div>
         <div
           ref={logRef}
+          onScroll={handleLogScroll}
           className="bg-black rounded-b-lg p-4 text-xs font-mono h-[calc(100vh-220px)] overflow-y-auto"
         >
           {logs.length === 0 ? (

--- a/src/shared/utils/scrollFollow.js
+++ b/src/shared/utils/scrollFollow.js
@@ -1,0 +1,38 @@
+// Should a scrolling log keep following its own tail?
+//
+// The console log wrote `scrollTop = scrollHeight` on every append, so a reader
+// looking at an older line was dragged back to the bottom by the next entry.
+// Something is always appending — a fan-out to several models, a background
+// token refresh — which is what turns an awkward behaviour into an unreadable
+// one (#3838).
+//
+// Follow mode is therefore a property of where the reader already is: at the
+// bottom means "keep me there", anywhere else means "leave me alone".
+
+/**
+ * How far from the bottom still counts as "at the bottom", in CSS pixels.
+ *
+ * Not zero. `scrollHeight` and `clientHeight` are integers while `scrollTop` is
+ * fractional under a non-integer device pixel ratio, so an element pinned to
+ * its bottom routinely reports a residue of a pixel or two. An exact comparison
+ * would drop the reader out of follow mode without them having scrolled.
+ */
+export const SCROLL_FOLLOW_SLACK_PX = 8;
+
+/**
+ * True when `el` is scrolled to (or within `slack` of) its bottom.
+ *
+ * A missing element answers true: nothing has been painted yet, and the first
+ * paint of a log should land at the newest line.
+ */
+export function isPinnedToBottom(el, slack = SCROLL_FOLLOW_SLACK_PX) {
+  if (!el) return true;
+  const { scrollTop, scrollHeight, clientHeight } = el;
+  const measured = [scrollTop, scrollHeight, clientHeight];
+  if (!measured.every((n) => typeof n === "number" && Number.isFinite(n))) {
+    // A detached or unmeasured node reports nothing useful; following is the
+    // behaviour that was there before, so keep it rather than freezing the log.
+    return true;
+  }
+  return scrollHeight - scrollTop - clientHeight <= slack;
+}

--- a/tests/unit/scroll-follow.test.js
+++ b/tests/unit/scroll-follow.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { isPinnedToBottom, SCROLL_FOLLOW_SLACK_PX } from "../../src/shared/utils/scrollFollow.js";
+
+// A scroll box, measured the way the DOM measures one.
+const box = ({ scrollTop, scrollHeight = 1000, clientHeight = 400 }) => ({
+  scrollTop,
+  scrollHeight,
+  clientHeight,
+});
+
+describe("isPinnedToBottom", () => {
+  it("is true at the exact bottom", () => {
+    expect(isPinnedToBottom(box({ scrollTop: 600 }))).toBe(true);
+  });
+
+  it("is false while the reader is looking at older lines", () => {
+    // This is the case #3838 is about: the log kept yanking them back here.
+    expect(isPinnedToBottom(box({ scrollTop: 0 }))).toBe(false);
+    expect(isPinnedToBottom(box({ scrollTop: 300 }))).toBe(false);
+  });
+
+  it("tolerates the sub-pixel residue a pinned element reports", () => {
+    // scrollHeight/clientHeight are integers while scrollTop is fractional, so
+    // an element that is at the bottom can be a pixel or two short of it.
+    expect(isPinnedToBottom(box({ scrollTop: 600 - 1.5 }))).toBe(true);
+    expect(isPinnedToBottom(box({ scrollTop: 600 - SCROLL_FOLLOW_SLACK_PX }))).toBe(true);
+  });
+
+  it("stops following once past the slack", () => {
+    expect(isPinnedToBottom(box({ scrollTop: 600 - SCROLL_FOLLOW_SLACK_PX - 1 }))).toBe(false);
+  });
+
+  it("follows a log short enough not to scroll at all", () => {
+    // scrollHeight === clientHeight: there is no 'older' to read.
+    expect(isPinnedToBottom(box({ scrollTop: 0, scrollHeight: 400, clientHeight: 400 }))).toBe(true);
+  });
+
+  it("follows when there is no element or no measurement yet", () => {
+    // First paint, or a detached node: the previous behaviour was to scroll, and
+    // freezing the log would be worse than scrolling it.
+    expect(isPinnedToBottom(null)).toBe(true);
+    expect(isPinnedToBottom(undefined)).toBe(true);
+    expect(isPinnedToBottom({})).toBe(true);
+    expect(isPinnedToBottom(box({ scrollTop: NaN }))).toBe(true);
+  });
+
+  it("honours an explicit slack", () => {
+    expect(isPinnedToBottom(box({ scrollTop: 590 }), 0)).toBe(false);
+    expect(isPinnedToBottom(box({ scrollTop: 590 }), 20)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #3838.

The console log scrolled to the bottom on **every** append:

```js
useEffect(() => {
  if (!logRef.current) return;
  logRef.current.scrollTop = logRef.current.scrollHeight;
}, [logs]);
```

So scrolling up to read an older line lasted until the next entry arrived. And something is always appending — a combo fanning out to several models, a background token refresh — which is what makes it unreadable rather than merely awkward. The reporter could not see which member of a fusion had failed.

## The change

Following the tail becomes a property of **where the reader already is**: at the bottom means keep me there, anywhere else means leave me alone.

Two details that are not obvious:

- **The position is recorded on scroll, not read inside the effect.** By the time the effect runs, the new lines are already laid out, so the element no longer reports where the reader was *before* they arrived.
- **The comparison carries a few pixels of slack rather than testing equality.** `scrollHeight` and `clientHeight` are integers while `scrollTop` is fractional under a non-integer device pixel ratio, so an element sitting at its bottom routinely reports a residue of a pixel or two. An exact test drops the reader out of follow mode without them having scrolled.

The decision lives in a plain function (`src/shared/utils/scrollFollow.js`) because `tests/vitest.config.js` runs with `environment: "node"` and there is no React testing setup — a component test could not have run at all, and I would rather have a real test of the rule than none.

## Verification

`tests/unit/scroll-follow.test.js` — **7 passed**. Each claim checked by reverting it:

| reverted | fails |
|---|---|
| slack removed (exact comparison) | the sub-pixel case, and the explicit-slack case |
| always follow (the old behaviour) | the older-lines case, and two others |

`npx next build` — ✓ compiled successfully.

## Not changed

`EndpointPageClient.js` has the same unconditional scroll for the Tailscale install log. Left alone deliberately: it runs for the length of one install and has nothing older to read. The helper is there if you want it applied.
