### PR TITLE
fix(combo): report one model's status with that same model's message

### DIFF
--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -348,14 +348,20 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
         await new Promise(r => setTimeout(r, cooldownMs));
       }
 
-      // Fallback to next model
+      // Fallback to next model. Status and message are recorded together: the
+      // status used to keep the FIRST failure while the message kept the LAST,
+      // so a combo that ran out of models answered with one model's status and
+      // another model's text -- e.g. 403 from a Console model carrying a 429
+      // body from the model tried after it. That reads as a single provider
+      // returning a nonsensical pair, which is why #3729 looked like fallback
+      // had not run at all.
       lastError = errorText || String(result.status);
-      if (!lastStatus) lastStatus = result.status;
+      lastStatus = result.status;
       log.warn("COMBO", `Model ${modelStr} failed, trying next`, { status: result.status });
     } catch (error) {
       // Catch unexpected exceptions to ensure fallback continues
       lastError = error.message || String(error);
-      if (!lastStatus) lastStatus = 500;
+      lastStatus = 500;
       log.warn("COMBO", `Model ${modelStr} threw error, trying next`, { error: lastError });
     }
   }

--- a/tests/unit/combo-failure-pairing.test.js
+++ b/tests/unit/combo-failure-pairing.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { handleComboChat } from "../../open-sse/services/combo.js";
+
+// When every model in a combo fails, the response the client sees must describe
+// ONE of those failures. It used to describe two: the status was pinned to the
+// first failure and the message to the last, so a combo answered with e.g. a 403
+// from model 1 carrying model 2's 429 text. That pair reads as one provider
+// behaving incoherently, which is how #3729 was reported -- as fallback not
+// running, when it had run and simply exhausted the list.
+
+const log = { info() {}, warn() {}, error() {}, debug() {} };
+
+const failure = (status, message) =>
+  new Response(JSON.stringify({ error: { type: "server_error", message } }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const success = () => new Response(JSON.stringify({ ok: true }), { status: 200 });
+
+async function runCombo(models, responder, comboName) {
+  const tried = [];
+  const res = await handleComboChat({
+    body: { messages: [] },
+    models,
+    handleSingleModel: async (_body, modelStr) => {
+      tried.push(modelStr);
+      return responder(modelStr);
+    },
+    log,
+    comboName,
+    comboStrategy: "priority",
+  });
+  let body = null;
+  try {
+    body = await res.clone().json();
+  } catch {
+    /* non-JSON body */
+  }
+  return { tried, status: res.status, message: body?.error?.message ?? null };
+}
+
+describe("combo failure reporting", () => {
+  it("pairs the reported status with the message from the same model", async () => {
+    const { status, message } = await runCombo(
+      ["a", "b", "c"],
+      (m) =>
+        m === "a"
+          ? failure(403, "console said 403")
+          : m === "b"
+            ? failure(429, "quota said 429")
+            : failure(500, "last one said 500"),
+      "pairing"
+    );
+    expect({ status, message }).toEqual({ status: 500, message: "last one said 500" });
+  });
+
+  it("still reports a single failure unchanged", async () => {
+    const { status, message } = await runCombo(["solo"], () => failure(418, "only failure"), "solo");
+    expect({ status, message }).toEqual({ status: 418, message: "only failure" });
+  });
+
+  it("keeps falling through a Console 403 to a model that works", async () => {
+    // The behaviour #3729 asked for, which already worked: proving it here means
+    // a future change to the fallback rules cannot quietly remove it.
+    const { tried, status } = await runCombo(
+      ["cl/z-ai/glm-5.3-flash", "oc/big-pickle"],
+      (m) =>
+        m === "cl/z-ai/glm-5.3-flash"
+          ? failure(403, "Error from provider (Console): Upstream request failed: Model is unavailable.")
+          : success(),
+      "console-403"
+    );
+    expect(tried).toEqual(["cl/z-ai/glm-5.3-flash", "oc/big-pickle"]);
+    expect(status).toBe(200);
+  });
+
+  it("pairs a thrown error with the 500 it is reported as", async () => {
+    const { status, message } = await runCombo(
+      ["a", "b"],
+      (m) => {
+        if (m === "a") return failure(403, "console said 403");
+        throw new Error("adapter exploded");
+      },
+      "threw"
+    );
+    expect({ status, message }).toEqual({ status: 500, message: "adapter exploded" });
+  });
+});


### PR DESCRIPTION
Addresses #3729.

## The report's diagnosis does not hold

#3729 suggests the Console error is "not recognized by the fallback heuristic in `open-sse/services/accountFallback.js`" and asks for the phrase to be added. But `checkFallbackError` returns `shouldFallback: true` on **every** path, including its default:

```js
// Default: transient cooldown for any unmatched error
return { shouldFallback: true, cooldownMs: TRANSIENT_COOLDOWN_MS };
```

Driving `handleComboChat` with the exact reported failure confirms it — the combo advances:

```
TRIED: [ 'cl/z-ai/glm-5.3-flash', 'oc/big-pickle' ]   STATUS: 200
```

Adding `"Model is unavailable"` to a match list would have changed nothing.

## What is actually wrong

When the list *is* exhausted, the reply mixes two different attempts:

```js
lastError = errorText || String(result.status);   // the LAST failure
if (!lastStatus) lastStatus = result.status;      // the FIRST failure
```

Same probe, three models, all failing:

```
FINAL STATUS: 403      FINAL MSG: "second model says 429"
```

A 403 from the model tried first, carrying the text of a 429 from a later one. That reads as a single provider returning a nonsensical pair — which is exactly the `HTTP 403: [400]: {...}` shape in the report, and why it looked like fallback had never run.

## The change

Status and message are recorded together, so the client sees the failure that actually ended the combo. The thrown-exception branch is paired the same way — it reports 500 and now carries the message that went with it.

## Verification

`tests/unit/combo-failure-pairing.test.js` — **4 passed**. Restoring `if (!lastStatus)` fails exactly the pairing test.

One of those four pins that a Console 403 still falls through to a working model. That behaviour already works; the test is there so a later change to the fallback rules cannot quietly remove it.

**Pre-existing, untouched:** `combo-autoswitch.test.js` fails 4 of 22 on `master` (`detectRequiredCapabilities > web_search tool -> search`, `reorderByCapabilities > keeps order when no model matches`) — same test names with this change stashed, checked rather than assumed.

This does not close #3729 by itself if the reporter's three models were all genuinely unavailable; it makes the failure legible so that case can be told apart from a broken fallback.
