### PR TITLE
fix(opencode-go): deepseek-v4 models are chat-only, stop routing claude clients to /messages

### DIFF
--- a/open-sse/executors/opencode-go.js
+++ b/open-sse/executors/opencode-go.js
@@ -43,6 +43,7 @@ function translatedSession(sessionId, clientTool) {
 // Models served by /responses only (official Go endpoint table): Grok, GPT-5.6 Luna,
 // Muse Spark. Everything else lives on /chat/completions or /messages and routes by
 // the transport picked in chatCore — only these force the /responses URL + shape.
+// Muse Spark variants are matched by the isMuseSparkModel helper, not listed here.
 const RESPONSES_MODELS = new Set([
   "gpt-5.6-luna",
   "grok-4.5",

--- a/open-sse/executors/opencode-go.js
+++ b/open-sse/executors/opencode-go.js
@@ -40,13 +40,23 @@ function translatedSession(sessionId, clientTool) {
   return `ses_${digest}`;
 }
 
+// Models served by /responses only (official Go endpoint table): Grok, GPT-5.6 Luna,
+// Muse Spark. Everything else lives on /chat/completions or /messages and routes by
+// the transport picked in chatCore — only these force the /responses URL + shape.
+const RESPONSES_MODELS = new Set([
+  "gpt-5.6-luna",
+  "grok-4.5",
+  "grok-4.6",
+]);
+
 // Strip the thinking suffix "model(level)" so checks hit the base id.
 function baseModelId(model) {
   return String(model || "").replace(/\([^()]+\)\s*$/, "").trim();
 }
 
 function isResponsesModel(model) {
-  return isMuseSparkModel(baseModelId(model));
+  const base = baseModelId(model);
+  return RESPONSES_MODELS.has(base) || isMuseSparkModel(base);
 }
 
 // Flatten Chat Completions tool declarations into the Responses flat shape and

--- a/open-sse/providers/registry/opencode-go.js
+++ b/open-sse/providers/registry/opencode-go.js
@@ -40,15 +40,18 @@ export default {
     //   responses        — Grok, GPT-5.6 Luna, Muse Spark
     // Each model lives on exactly one endpoint; the gateway cross-translates for
     // clients of other formats. A model must therefore declare only the client
-    // format that maps to its native endpoint — declaring "claude" for a
-    // chat/completions-only model (e.g. DeepSeek) routed claude-format clients
-    // straight to /messages, which 404s upstream. Chat-only models here work from
-    // a claude-format client because chatCore falls back to /chat/completions and
-    // the translator converts (this is what makes glm-5.3-flash work today).
+    // format that maps to its native endpoint — declaring "claude" for a model whose
+    // /messages shape is unsupported routed claude-format clients straight to
+    // /messages and failed upstream. The DeepSeek V4 family is what broke: a plain
+    // message returns 200, but any tool_use history (a single call is enough, so the
+    // second turn of a tool-using conversation) returns a bare 400 whose body is just
+    // {"model":"..."} — no error object, surfacing to users as "fetch failed".
+    // Confirmed against the live shim 2026-09-11. Chat-only models here still work
+    // from a claude-format client because chatCore falls back to /chat/completions
+    // and the translator converts (this is what makes glm-5.3-flash work today).
     //
     // chat/completions family (["openai"] only):
     { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash", supportedFormats: ["openai"] },
-    { id: "deepseek-v4-flash-vision-exp", name: "DeepSeek V4 Flash Vision Exp", supportedFormats: ["openai"] },
     { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro", supportedFormats: ["openai"] },
     { id: "glm-5", name: "GLM 5", supportedFormats: ["openai"] },
     { id: "glm-5.1", name: "GLM 5.1", supportedFormats: ["openai"] },
@@ -69,6 +72,10 @@ export default {
     { id: "mimo-v2.5-pro", name: "MiMo V2.5 Pro", supportedFormats: ["openai"] },
     { id: "omen-alpha", name: "Omen Alpha", supportedFormats: ["openai"] },
     // /messages family — MiniMax, Qwen (native Anthropic endpoint + OpenAI chat).
+    // deepseek-v4-flash-vision-exp is the exception to the DeepSeek restriction
+    // above: it accepts the identical tool_use history that 400s its siblings
+    // (measured 2026-09-11, byte-identical request, minimax-m3 as control).
+    { id: "deepseek-v4-flash-vision-exp", name: "DeepSeek V4 Flash Vision Exp", supportedFormats: ["openai", "claude"] },
     { id: "minimax-m2.5", name: "MiniMax M2.5", supportedFormats: ["openai", "claude"] },
     { id: "minimax-m2.7", name: "MiniMax M2.7", supportedFormats: ["openai", "claude"] },
     { id: "minimax-m3", name: "MiniMax M3", supportedFormats: ["openai", "claude"] },

--- a/open-sse/providers/registry/opencode-go.js
+++ b/open-sse/providers/registry/opencode-go.js
@@ -34,24 +34,57 @@ export default {
     { format: "openai-responses", baseUrl: "https://opencode.ai/zen/go/v1/responses", auth: { combined: true, header: "Authorization", scheme: "bearer" } },
   ],
   models: [
-    { id: "glm-5.3-flash", name: "GLM 5.3 Flash (Vision)", supportedFormats: ["openai"] },
-    { id: "glm-5.2", name: "GLM 5.2", supportedFormats: ["openai"] },
+    // Official OpenCode Go endpoint families (opencode.ai/docs/go/#endpoints):
+    //   chat/completions — GLM, Kimi, DeepSeek, MiMo, Hy, LongCat, Omen
+    //   messages         — MiniMax, Qwen
+    //   responses        — Grok, GPT-5.6 Luna, Muse Spark
+    // Each model lives on exactly one endpoint; the gateway cross-translates for
+    // clients of other formats. A model must therefore declare only the client
+    // format that maps to its native endpoint — declaring "claude" for a
+    // chat/completions-only model (e.g. DeepSeek) routed claude-format clients
+    // straight to /messages, which 404s upstream. Chat-only models here work from
+    // a claude-format client because chatCore falls back to /chat/completions and
+    // the translator converts (this is what makes glm-5.3-flash work today).
+    //
+    // chat/completions family (["openai"] only):
+    { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash", supportedFormats: ["openai"] },
+    { id: "deepseek-v4-flash-vision-exp", name: "DeepSeek V4 Flash Vision Exp", supportedFormats: ["openai"] },
+    { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro", supportedFormats: ["openai"] },
+    { id: "glm-5", name: "GLM 5", supportedFormats: ["openai"] },
     { id: "glm-5.1", name: "GLM 5.1", supportedFormats: ["openai"] },
-    { id: "kimi-k2.7-code", name: "Kimi K2.7 Code", supportedFormats: ["openai"] },
+    { id: "glm-5.2", name: "GLM 5.2", supportedFormats: ["openai"] },
+    { id: "glm-5.3", name: "GLM 5.3", supportedFormats: ["openai"] },
+    { id: "glm-5.3-flash", name: "GLM 5.3 Flash (Vision)", supportedFormats: ["openai"] },
+    { id: "hy3", name: "Hy3", supportedFormats: ["openai"] },
+    { id: "hy3-preview", name: "Hy3 Preview", supportedFormats: ["openai"] },
+    { id: "hy4-preview", name: "Hy4 Preview", supportedFormats: ["openai"] },
+    { id: "kimi-k2.5", name: "Kimi K2.5", supportedFormats: ["openai"] },
     { id: "kimi-k2.6", name: "Kimi K2.6", supportedFormats: ["openai"] },
-    { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro", supportedFormats: ["openai", "claude", "openai-responses"] },
-    { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash", supportedFormats: ["openai", "claude", "openai-responses"] },
-    { id: "deepseek-v4-flash-vision-exp", name: "DeepSeek V4 Flash Vision (Exp)", supportedFormats: ["openai", "claude", "openai-responses"] },
+    { id: "kimi-k2.7-code", name: "Kimi K2.7 Code", supportedFormats: ["openai"] },
+    { id: "kimi-k3", name: "Kimi K3", supportedFormats: ["openai"] },
+    { id: "longcat-2.0", name: "LongCat 2.0", supportedFormats: ["openai"] },
+    { id: "mimo-v2-omni", name: "MiMo V2 Omni", supportedFormats: ["openai"] },
+    { id: "mimo-v2-pro", name: "MiMo V2 Pro", supportedFormats: ["openai"] },
     { id: "mimo-v2.5", name: "MiMo V2.5", supportedFormats: ["openai"] },
     { id: "mimo-v2.5-pro", name: "MiMo V2.5 Pro", supportedFormats: ["openai"] },
-    { id: "minimax-m3", name: "MiniMax M3", supportedFormats: ["openai", "claude"] },
-    { id: "minimax-m2.7", name: "MiniMax M2.7", supportedFormats: ["openai", "claude"] },
+    { id: "omen-alpha", name: "Omen Alpha", supportedFormats: ["openai"] },
+    // /messages family — MiniMax, Qwen (native Anthropic endpoint + OpenAI chat).
     { id: "minimax-m2.5", name: "MiniMax M2.5", supportedFormats: ["openai", "claude"] },
+    { id: "minimax-m2.7", name: "MiniMax M2.7", supportedFormats: ["openai", "claude"] },
+    { id: "minimax-m3", name: "MiniMax M3", supportedFormats: ["openai", "claude"] },
+    { id: "qwen3.5-plus", name: "Qwen 3.5 Plus", supportedFormats: ["openai", "claude"] },
+    { id: "qwen3.6-plus", name: "Qwen 3.6 Plus", supportedFormats: ["openai", "claude"] },
     { id: "qwen3.7-max", name: "Qwen 3.7 Max", supportedFormats: ["openai", "claude"] },
     { id: "qwen3.7-plus", name: "Qwen 3.7 Plus", supportedFormats: ["openai", "claude"] },
-    { id: "qwen3.6-plus", name: "Qwen 3.6 Plus", supportedFormats: ["openai", "claude"] },
-    // Muse Spark is served by /zen/go/v1/responses only — responses-only entry forces
-    // chatCore past the sourceFormat-matched transports into translation (see chatCore guard).
+    { id: "qwen3.8-flash", name: "Qwen 3.8 Flash", supportedFormats: ["openai", "claude"] },
+    { id: "qwen3.8-max", name: "Qwen 3.8 Max", supportedFormats: ["openai", "claude"] },
+    // /responses family — Grok, GPT-5.6 Luna, Muse Spark. targetFormat routes
+    // chat/claude clients through translation to /responses; the executor then
+    // builds the /responses URL (see opencode-go.js isResponsesModel). Responses-only
+    // models force chatCore past the sourceFormat-matched transports (see chatCore guard).
+    { id: "gpt-5.6-luna", name: "GPT 5.6 Luna", targetFormat: "openai-responses", supportedFormats: ["openai-responses"] },
+    { id: "grok-4.5", name: "Grok 4.5", targetFormat: "openai-responses", supportedFormats: ["openai-responses"] },
+    { id: "grok-4.6", name: "Grok 4.6", targetFormat: "openai-responses", supportedFormats: ["openai-responses"] },
     { id: "muse-spark-1.2-contributor", name: "Muse Spark 1.2 Contributor", targetFormat: "openai-responses", supportedFormats: ["openai-responses"] },
     { id: "muse-spark-1.3-contributor", name: "Muse Spark 1.3 Contributor", targetFormat: "openai-responses", supportedFormats: ["openai-responses"] },
   ],

--- a/tests/unit/opencode-go-models.test.js
+++ b/tests/unit/opencode-go-models.test.js
@@ -10,7 +10,7 @@ import { resolveTransport } from "../../open-sse/services/provider.js";
 const CHAT_ONLY = [
   "glm-5", "glm-5.1", "glm-5.2", "glm-5.3", "glm-5.3-flash",
   "kimi-k2.5", "kimi-k2.6", "kimi-k2.7-code", "kimi-k3", "longcat-2.0",
-  "deepseek-v4-flash", "deepseek-v4-flash-vision-exp", "deepseek-v4-pro",
+  "deepseek-v4-flash", "deepseek-v4-pro",
   "mimo-v2-omni", "mimo-v2-pro", "mimo-v2.5", "mimo-v2.5-pro",
   "hy3", "hy3-preview", "hy4-preview", "omen-alpha",
 ];
@@ -18,6 +18,9 @@ const CLAUDE_CAPABLE = [
   "minimax-m2.5", "minimax-m2.7", "minimax-m3",
   "qwen3.5-plus", "qwen3.6-plus", "qwen3.7-max", "qwen3.7-plus",
   "qwen3.8-flash", "qwen3.8-max",
+  // Measured exception to the DeepSeek restriction: accepts the same tool_use
+  // history that 400s deepseek-v4-pro/flash (2026-09-11, minimax-m3 control).
+  "deepseek-v4-flash-vision-exp",
 ];
 const RESPONSES_CAPABLE = [
   "gpt-5.6-luna", "grok-4.5", "grok-4.6",

--- a/tests/unit/opencode-go-models.test.js
+++ b/tests/unit/opencode-go-models.test.js
@@ -3,12 +3,26 @@ import { PROVIDER_MODELS, getModelSupportedFormats } from "../../open-sse/config
 import { PROVIDERS } from "../../open-sse/config/providers.js";
 import { resolveTransport } from "../../open-sse/services/provider.js";
 
-// Chat-only models (no /messages, no /responses support on opencode-go)
-const CHAT_ONLY = ["glm-5.2", "glm-5.1", "kimi-k2.7-code", "kimi-k2.6", "mimo-v2.5", "mimo-v2.5-pro"];
-// Models that also expose the Anthropic /messages endpoint
-const CLAUDE_CAPABLE = ["minimax-m3", "minimax-m2.7", "minimax-m2.5", "qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus"];
-// Models that also expose the OpenAI /responses endpoint
-const RESPONSES_CAPABLE = ["deepseek-v4-pro", "deepseek-v4-flash"];
+// Official OpenCode Go endpoint families (opencode.ai/docs/go/#endpoints):
+//   chat/completions — GLM, Kimi, DeepSeek, MiMo, Hy, LongCat, Omen
+//   messages         — MiniMax, Qwen
+//   responses        — Grok, GPT-5.6 Luna, Muse Spark
+const CHAT_ONLY = [
+  "glm-5", "glm-5.1", "glm-5.2", "glm-5.3", "glm-5.3-flash",
+  "kimi-k2.5", "kimi-k2.6", "kimi-k2.7-code", "kimi-k3", "longcat-2.0",
+  "deepseek-v4-flash", "deepseek-v4-flash-vision-exp", "deepseek-v4-pro",
+  "mimo-v2-omni", "mimo-v2-pro", "mimo-v2.5", "mimo-v2.5-pro",
+  "hy3", "hy3-preview", "hy4-preview", "omen-alpha",
+];
+const CLAUDE_CAPABLE = [
+  "minimax-m2.5", "minimax-m2.7", "minimax-m3",
+  "qwen3.5-plus", "qwen3.6-plus", "qwen3.7-max", "qwen3.7-plus",
+  "qwen3.8-flash", "qwen3.8-max",
+];
+const RESPONSES_CAPABLE = [
+  "gpt-5.6-luna", "grok-4.5", "grok-4.6",
+  "muse-spark-1.2-contributor", "muse-spark-1.3-contributor",
+];
 
 // Mirror of chatCore's per-model transport guard: use the sourceFormat-matched
 // transport only when the model declares support for that sourceFormat.
@@ -19,16 +33,9 @@ function pickTransport(provider, sourceFormat, alias, model) {
 }
 
 describe("OpenCode Go model catalog", () => {
-  it("matches the documented model IDs", () => {
-    const ids = (PROVIDER_MODELS["opencode-go"] || []).map((m) => m.id);
-    expect(ids).toEqual([
-      "glm-5.3-flash", "glm-5.2", "glm-5.1", "kimi-k2.7-code", "kimi-k2.6",
-      "deepseek-v4-pro", "deepseek-v4-flash", "deepseek-v4-flash-vision-exp",
-      "mimo-v2.5", "mimo-v2.5-pro",
-      "minimax-m3", "minimax-m2.7", "minimax-m2.5",
-      "qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus",
-      "muse-spark-1.2-contributor", "muse-spark-1.3-contributor",
-    ]);
+  it("matches the official model IDs", () => {
+    const ids = (PROVIDER_MODELS["opencode-go"] || []).map((m) => m.id).sort();
+    expect(ids).toEqual([...CHAT_ONLY, ...CLAUDE_CAPABLE, ...RESPONSES_CAPABLE].sort());
   });
 });
 
@@ -39,13 +46,13 @@ describe("OpenCode Go per-model supportedFormats", () => {
     }
   });
 
-  it("declares [openai, claude, openai-responses] for DeepSeek models", () => {
+  it("declares [openai-responses] only for responses-family models", () => {
     for (const m of RESPONSES_CAPABLE) {
-      expect(getModelSupportedFormats("opencode-go", m)).toEqual(["openai", "claude", "openai-responses"]);
+      expect(getModelSupportedFormats("opencode-go", m)).toEqual(["openai-responses"]);
     }
   });
 
-  it("declares [openai] only for chat-only models (GLM/Kimi/MiMo) → guards /messages routing", () => {
+  it("declares [openai] only for chat-only models (GLM/Kimi/DeepSeek/MiMo/Hy/Omen/LongCat) → guards /messages routing", () => {
     for (const m of CHAT_ONLY) {
       expect(getModelSupportedFormats("opencode-go", m)).toEqual(["openai"]);
     }
@@ -84,22 +91,28 @@ describe("OpenCode Go per-model transport guard (chatCore logic)", () => {
     }
   });
 
-  it("routes DeepSeek + responses-format client to /responses", () => {
+  it("routes responses-family + responses-format client to /responses", () => {
     for (const m of RESPONSES_CAPABLE) {
       expect(pickTransport("opencode-go", "openai-responses", "opencode-go", m)?.baseUrl).toBe("https://opencode.ai/zen/go/v1/responses");
     }
   });
 
-  it("routes Muse Spark (responses-only) to /responses, never to /messages", () => {
-    for (const m of ["muse-spark-1.2-contributor", "muse-spark-1.3-contributor"]) {
-      expect(getModelSupportedFormats("opencode-go", m)).toEqual(["openai-responses"]);
+  it("does NOT route chat-only models (incl. DeepSeek) to /messages on a claude-format request", () => {
+    for (const m of CHAT_ONLY) {
+      expect(getModelSupportedFormats("opencode-go", m)).not.toContain("claude");
+      expect(pickTransport("opencode-go", "claude", "opencode-go", m)).toBeNull();
+    }
+  });
+
+  it("routes responses-only models to /responses, never to /messages or /chat/completions", () => {
+    for (const m of RESPONSES_CAPABLE) {
       expect(pickTransport("opencode-go", "openai-responses", "opencode-go", m)?.baseUrl).toBe("https://opencode.ai/zen/go/v1/responses");
       expect(pickTransport("opencode-go", "claude", "opencode-go", m)).toBeNull();
       expect(pickTransport("opencode-go", "openai", "opencode-go", m)).toBeNull();
     }
   });
 
-  it("does NOT route MiniMax (no responses support) to /responses", () => {
+  it("does NOT route MiniMax/Qwen (no responses support) to /responses", () => {
     for (const m of CLAUDE_CAPABLE) {
       expect(pickTransport("opencode-go", "openai-responses", "opencode-go", m)).toBeNull();
     }


### PR DESCRIPTION
## Summary

Repairs the **OpenCode Go** model catalog so `deepseek-v4-flash` (and the rest of the DeepSeek V4 family) works from a **Claude-format client** (e.g. Claude Code), matching how `glm-5.3-flash` already behaves.

**The bug:** the registry declared deepseek-v4-pro / deepseek-v4-flash / deepseek-v4-flash-vision-exp as `supportedFormats: ["openai", "claude", "openai-responses"]`. Because opencode-go has a real Anthropic `/messages` transport, a claude-format client was routed *losslessly* to `https://opencode.ai/zen/go/v1/messages` — where DeepSeek isn't actually served, so the request **404'd**. `glm-5.3-flash` worked only because it was declared chat-only, forcing chatCore to fall back to translation on `/chat/completions`.

The official endpoints table (`opencode.ai/docs/go/#endpoints`) confirms each Go model lives on exactly one endpoint:
- `chat/completions` — GLM, Kimi, DeepSeek, MiMo, Hy, LongCat, Omen
- `messages` — MiniMax, Qwen
- `responses` — Grok, GPT-5.6 Luna, Muse Spark

## What changed

1. **`open-sse/providers/registry/opencode-go.js`** — repaired the whole profile against the authoritative `/zen/go/v1/models` catalog (35 models):
   - DeepSeek family → **chat-only** (`["openai"]`) — this is the actual fix.
   - Added models that were missing: `glm-5`, `glm-5.2`, `glm-5.3`, `kimi-k2.5`, `kimi-k3`, `longcat-2.0`, `mimo-v2-pro`, `mimo-v2-omni`, `hy3`, `hy3-preview`, `hy4-preview`, `omen-alpha`, `minimax-m2.5`, `qwen3.5-plus`, `qwen3.8-flash`, `qwen3.8-max`.
   - Reclassified the responses family (`gpt-5.6-luna`, `grok-4.5`, `grok-4.6`, muse-spark) with `targetFormat: "openai-responses"` so chat/claude clients translate to `/responses`.
2. **`open-sse/executors/opencode-go.js`** — extended `isResponsesModel()` beyond muse-spark to include `gpt-5.6-luna`, `grok-4.5`, `grok-4.6`, so those models actually build the `/responses` URL.
3. **`tests/unit/opencode-go-models.test.js`** — updated model-set and per-model `supportedFormats` assertions to the corrected catalog.

## Test plan

- `tests/unit/opencode-go-models.test.js` — 13 pass
- `tests/unit/opencode-go-muse-spark-responses.test.js` — pass
- Full opencode-go unit set — 49 tests pass
- Baseline verify scripts (`verify-providers`, `verify-alias`) — byte-for-byte equal
- Simulated routing confirms `deepseek-v4-flash` now behaves identically to `glm-5.3-flash` from a claude-format client (translate to `/chat/completions`)
