### PR TITLE
fix(translator): six format-conversion defects (#3243, #3247, #3254, #3369, #3492, replaces 6 PRs)

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -175,7 +175,11 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     translatedBody = { ...body, model: stripThinkingSuffix(upstreamModel) };
     if (provider === "codex") {
       const suffixThinking = {};
-      applyThinking(sourceFormat, upstreamModel, suffixThinking, provider);
+      // Pinned to OPENAI on purpose: this branch reads the flat reasoning_effort key
+      // off the scratch object and nests it itself, so applyThinking must not nest.
+      // Passing sourceFormat here would hand back {reasoning:{effort}} for a Responses
+      // client and the suffix would silently stop applying.
+      applyThinking(FORMATS.OPENAI, upstreamModel, suffixThinking, provider);
       if (suffixThinking.reasoning_effort) {
         const reasoning = translatedBody.reasoning;
         translatedBody.reasoning = {

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -16,6 +16,7 @@ import { getExecutor } from "../executors/index.js";
 import { supportsGrokCliReasoningEffort } from "../config/grokCli.js";
 import { buildRequestDetail, extractRequestConfig } from "./chatCore/requestDetail.js";
 import { handleForcedSSEToJson } from "./chatCore/sseToJsonHandler.js";
+import { clientRequestedStreaming as requestedStreaming } from "./chatCore/streamMode.js";
 import { handleNonStreamingResponse } from "./chatCore/nonStreamingHandler.js";
 import { handleStreamingResponse, buildOnStreamComplete } from "./chatCore/streamingHandler.js";
 import { detectClientTool, isNativePassthrough } from "../utils/clientDetector.js";
@@ -115,9 +116,9 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     }
   }
 
-  const clientRequestedStreaming = body.stream === true || sourceFormat === FORMATS.ANTIGRAVITY || sourceFormat === FORMATS.GEMINI || sourceFormat === FORMATS.GEMINI_CLI;
+  const clientRequestedStreaming = requestedStreaming(body, sourceFormat);
   const providerRequiresStreaming = PROVIDERS[provider]?.forceStream === true;
-  let stream = providerRequiresStreaming ? true : (body.stream !== false);
+  let stream = providerRequiresStreaming ? true : clientRequestedStreaming;
 
   // Image generation models require non-streaming (Google v1internal:generateContent)
   const modelType = getModelType(alias, model);

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -141,17 +141,17 @@ function openAICompletionToResponses(responseBody, customToolNames = null) {
 /**
  * Translate non-streaming response body from provider format → OpenAI format.
  */
+// Provider responded in OpenAI Chat Completions shape — hand the client whatever
+// dialect it speaks, or the body unchanged when that dialect is OpenAI itself.
+function fromOpenAICompletion(responseBody, sourceFormat, customToolNames) {
+  if (sourceFormat === FORMATS.OPENAI_RESPONSES) return openAICompletionToResponses(responseBody, customToolNames);
+  if (sourceFormat === FORMATS.CLAUDE) return openAICompletionToClaudeMessage(responseBody);
+  return responseBody;
+}
+
 export function translateNonStreamingResponse(responseBody, targetFormat, sourceFormat, customToolNames = null) {
   if (targetFormat === sourceFormat) return responseBody;
-  // Provider responded in OpenAI Chat Completions shape but the client speaks
-  // Responses API — convert so tool_calls/text surface as Responses `output`.
-  if (targetFormat === FORMATS.OPENAI && sourceFormat === FORMATS.OPENAI_RESPONSES) {
-    return openAICompletionToResponses(responseBody, customToolNames);
-  }
-  if (targetFormat === FORMATS.OPENAI && sourceFormat === FORMATS.CLAUDE) {
-    return openAICompletionToClaudeMessage(responseBody);
-  }
-  if (targetFormat === FORMATS.OPENAI) return responseBody;
+  if (targetFormat === FORMATS.OPENAI) return fromOpenAICompletion(responseBody, sourceFormat, customToolNames);
 
   // Gemini / Antigravity
   if (targetFormat === FORMATS.GEMINI || targetFormat === FORMATS.ANTIGRAVITY || targetFormat === FORMATS.GEMINI_CLI || targetFormat === FORMATS.VERTEX) {
@@ -273,6 +273,10 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
   // Ollama
   if (targetFormat === FORMATS.OLLAMA) {
     return ollamaBodyToOpenAI(responseBody);
+  }
+
+  if (Array.isArray(responseBody?.choices)) {
+    return fromOpenAICompletion(responseBody, sourceFormat, customToolNames);
   }
 
   return responseBody;

--- a/open-sse/handlers/chatCore/streamMode.js
+++ b/open-sse/handlers/chatCore/streamMode.js
@@ -1,0 +1,24 @@
+import { FORMATS } from "../../translator/formats.js";
+
+/**
+ * Whether the client asked for an SSE-framed response.
+ *
+ * The OpenAI API defines `stream` with a default of **false**, so a body that
+ * omits the key is a non-streaming request. Reading an absent key as "stream"
+ * frames a plain `chat.completion` object as SSE: wrong content-type, plus a
+ * `data: [DONE]` glued onto valid JSON, which strict parsers reject (#3492).
+ *
+ * The Gemini and Antigravity surfaces are the exception. Their endpoints carry
+ * the mode in the path rather than the body, and this router only routes their
+ * streaming ones, so those formats always mean SSE.
+ */
+export function clientRequestedStreaming(body, sourceFormat) {
+  if (
+    sourceFormat === FORMATS.ANTIGRAVITY ||
+    sourceFormat === FORMATS.GEMINI ||
+    sourceFormat === FORMATS.GEMINI_CLI
+  ) {
+    return true;
+  }
+  return body?.stream === true;
+}

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -5,6 +5,7 @@
 import { getCapabilitiesForModel } from "../../providers/capabilities.js";
 import { getThinkingLevels } from "../../providers/thinkingLevels.js";
 import { PROVIDERS } from "../../providers/index.js";
+import { FORMATS } from "../formats.js";
 import { LEVEL_TO_BUDGET, budgetToLevel, effortToBudget, effortToThinkingLevel } from "./thinking.js";
 
 // Map a target wire-format to its native thinking format (when capability has none).
@@ -20,6 +21,8 @@ const FORMAT_TO_NATIVE = {
   antigravity: "gemini-budget",
   kiro: "kiro",
 };
+
+const RESPONSES_TARGETS = new Set([FORMATS.OPENAI_RESPONSES, FORMATS.OPENAI_RESPONSE]);
 
 // Strip a trailing thinking suffix "model(value)" → "model" (no-op when absent).
 export function stripThinkingSuffix(model) {
@@ -361,7 +364,17 @@ export function applyThinking(targetFormat, model, body, provider = null, intent
 
   const fmt = resolveFormat(targetFormat, cleanModel, provider);
   const supportedLevels = getThinkingLevels(provider, cleanModel);
+  const prior = body.reasoning;
+  const priorReasoning = prior && typeof prior === "object" ? prior : null;
   stripAll(body);
   applyFormat(fmt, body, cfg, caps, supportedLevels);
+  if (RESPONSES_TARGETS.has(targetFormat)) nestReasoningEffort(body, priorReasoning);
   return body;
+}
+
+function nestReasoningEffort(body, priorReasoning) {
+  if (typeof body.reasoning_effort !== "string") return;
+  const effort = body.reasoning_effort;
+  delete body.reasoning_effort;
+  body.reasoning = { ...priorReasoning, effort };
 }

--- a/open-sse/translator/concerns/toolCall.js
+++ b/open-sse/translator/concerns/toolCall.js
@@ -21,9 +21,37 @@ function sanitizeToolId(id) {
   return sanitized.length > 0 ? sanitized : null;
 }
 
+// Resolve the id a tool result should carry.
+//
+// A missing id cannot be sanitized into existence, and Anthropic rejects the
+// whole request when one is absent ("tool_result.tool_use_id: Field required").
+// Pair it instead with the oldest tool call from the preceding assistant turn
+// that nothing has answered yet — that is the id upstream is expecting, and
+// OpenAI-format clients that drop tool_call_id on a turn are the reason this
+// path exists (#3362). Only if there is nothing to pair with do we generate an
+// id, which at least keeps the request well-formed.
+function resolveToolResultId(rawId, unanswered, makeFallbackId) {
+  const usable =
+    typeof rawId === "string" && rawId
+      ? (TOOL_ID_PATTERN.test(rawId) ? rawId : sanitizeToolId(rawId))
+      : null;
+
+  if (usable) {
+    const at = unanswered.indexOf(usable);
+    if (at >= 0) unanswered.splice(at, 1);
+    return usable;
+  }
+
+  return unanswered.shift() || makeFallbackId();
+}
+
 // Ensure all tool_calls have valid id field and arguments is string (some providers require it)
 export function ensureToolCallIds(body) {
   if (!body.messages || !Array.isArray(body.messages)) return body;
+
+  // Tool call ids from the most recent assistant turn that no result has
+  // claimed yet, oldest first.
+  let unanswered = [];
 
   for (let i = 0; i < body.messages.length; i++) {
     const msg = body.messages[i];
@@ -45,13 +73,8 @@ export function ensureToolCallIds(body) {
       }
     }
 
-    // Validate tool_call_id in tool messages (role: "tool")
-    if (msg.role === "tool" && msg.tool_call_id && !TOOL_ID_PATTERN.test(msg.tool_call_id)) {
-      const sanitized = sanitizeToolId(msg.tool_call_id);
-      msg.tool_call_id = sanitized || generateToolCallId(i, 0);
-    }
-
-    // Also validate tool_use blocks in content (Claude format)
+    // Validate tool_use blocks in content (Claude format) before the ids are
+    // read back out below.
     if (Array.isArray(msg.content)) {
       for (let k = 0; k < msg.content.length; k++) {
         const block = msg.content[k];
@@ -59,10 +82,27 @@ export function ensureToolCallIds(body) {
           const sanitized = sanitizeToolId(block.id);
           block.id = sanitized || generateToolCallId(i, k, block.name);
         }
-        // Validate tool_use_id in tool_result blocks
-        if (block.type === "tool_result" && block.tool_use_id && !TOOL_ID_PATTERN.test(block.tool_use_id)) {
-          const sanitized = sanitizeToolId(block.tool_use_id);
-          block.tool_use_id = sanitized || generateToolCallId(i, k);
+      }
+    }
+
+    // An assistant turn opens a new set of tool calls waiting for results, and
+    // ends whatever the previous one left open.
+    if (msg.role === "assistant") {
+      unanswered = getToolCallIds(msg);
+      continue;
+    }
+
+    // Tool result, OpenAI shape (role: "tool")
+    if (msg.role === "tool") {
+      msg.tool_call_id = resolveToolResultId(msg.tool_call_id, unanswered, () => generateToolCallId(i, 0));
+    }
+
+    // Tool result, Claude shape (tool_result block in user content)
+    if (Array.isArray(msg.content)) {
+      for (let k = 0; k < msg.content.length; k++) {
+        const block = msg.content[k];
+        if (block.type === "tool_result") {
+          block.tool_use_id = resolveToolResultId(block.tool_use_id, unanswered, () => generateToolCallId(i, k));
         }
       }
     }

--- a/open-sse/translator/formats/openai.js
+++ b/open-sse/translator/formats/openai.js
@@ -23,8 +23,8 @@ export function filterToOpenAIFormat(body, opts = {}) {
     // Keep tool messages as-is (OpenAI format)
     if (msg.role === ROLE.TOOL) return msg;
 
-    // Keep assistant messages with tool_calls as-is
-    if (msg.role === ROLE.ASSISTANT && msg.tool_calls) return msg;
+    // Keep assistant messages with tool_calls as-is (an empty array carries none)
+    if (msg.role === ROLE.ASSISTANT && msg.tool_calls?.length) return msg;
 
     // Handle string content
     if (typeof msg.content === "string") return msg;
@@ -64,8 +64,8 @@ export function filterToOpenAIFormat(body, opts = {}) {
   body.messages = body.messages.filter(msg => {
     // Always keep tool messages
     if (msg.role === ROLE.TOOL) return true;
-    // Always keep assistant messages with tool_calls
-    if (msg.role === ROLE.ASSISTANT && msg.tool_calls) return true;
+    // Always keep assistant messages with tool_calls (an empty array carries none)
+    if (msg.role === ROLE.ASSISTANT && msg.tool_calls?.length) return true;
     
     if (typeof msg.content === "string") return msg.content.trim() !== "";
     if (Array.isArray(msg.content)) {

--- a/open-sse/translator/response/commandcode-to-openai.js
+++ b/open-sse/translator/response/commandcode-to-openai.js
@@ -168,7 +168,17 @@ export function commandCodeToOpenAIResponse(chunk, state) {
       state.finishReason = OPENAI_FINISH.STOP;
       const errVal = event.error ?? event.message ?? "unknown";
       const errStr = typeof errVal === "string" ? errVal : JSON.stringify(errVal);
-      out.push(makeChunk(state, { content: `\n\n[CommandCode error: ${errStr}]` }));
+      // Same first-delta contract as every other content branch here. An upstream
+      // error is frequently the FIRST event (a 503 before any token), and this was
+      // the one branch that emitted content without the opening `role` and without
+      // advancing chunkIndex -- so the error chunk carried no role, and any text
+      // arriving after it still thought it was chunk zero and sent a second one.
+      const errText = `\n\n[CommandCode error: ${errStr}]`;
+      const delta = state.chunkIndex === 0
+        ? { role: ROLE.ASSISTANT, content: errText }
+        : { content: errText };
+      state.chunkIndex++;
+      out.push(makeChunk(state, delta));
       out.push(makeChunk(state, {}, OPENAI_FINISH.STOP));
       break;
     }

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -220,11 +220,13 @@ describe("applyThinking per provider format", () => {
     ["gpt-5.6-luna", "ultra", "max"],
   ])("normalizes Codex %s effort %s to %s", (model, effort, expected) => {
     const out = apply("openai-responses", model, { reasoning: { effort } }, "codex");
-    expect(out.reasoning_effort).toBe(expected);
+    expect(out.reasoning_effort).toBeUndefined();
+    expect(out.reasoning.effort).toBe(expected);
   });
   it("applies a supported Codex Ultra suffix", () => {
     const out = apply("openai-responses", "gpt-5.6-sol(ultra)", {}, "codex");
-    expect(out.reasoning_effort).toBe("ultra");
+    expect(out.reasoning_effort).toBeUndefined();
+    expect(out.reasoning.effort).toBe("ultra");
   });
   it("keeps Codex-only GPT-5.6 levels out of Kiro translation", () => {
     const out = apply("openai", "gpt-5.6-sol", { reasoning_effort: "max" }, "kiro");

--- a/tests/unit/commandcode-to-openai.test.js
+++ b/tests/unit/commandcode-to-openai.test.js
@@ -124,4 +124,37 @@ describe("commandcode-to-openai — error event", () => {
     expect(text).toContain("Boom");
     expect(text).not.toContain("[object Object]");
   });
+
+  // An upstream error is routinely the FIRST event on the stream -- a 503 arrives
+  // before any token. Every other content branch opens with `role: "assistant"`;
+  // this one did not, so the only delta a client received for a failed turn had no
+  // role on it.
+  it("opens with the assistant role when the error is the first event", () => {
+    const { chunks } = feed([
+      { type: "error", error: { type: "server_error", message: "Service temporarily unavailable", statusCode: 503 } },
+    ]);
+    expect(chunks[0].choices[0].delta.role).toBe("assistant");
+    expect(chunks[0].choices[0].delta.content).toContain("Service temporarily unavailable");
+  });
+
+  it("does not open with a role when content already went out", () => {
+    const { chunks } = feed([
+      { type: "text-delta", text: "Hello" },
+      { type: "error", error: "boom" },
+    ]);
+    expect(chunks[0].choices[0].delta.role).toBe("assistant");
+    expect(chunks[1].choices[0].delta.role).toBeUndefined();
+  });
+
+  // The branch used to leave chunkIndex at 0, so text arriving after the error still
+  // believed it was the opening chunk and sent a second role delta.
+  it("sends the role exactly once when text follows the error", () => {
+    const { chunks } = feed([
+      { type: "error", error: "boom" },
+      { type: "text-delta", text: "recovered" },
+    ]);
+    const withRole = chunks.filter((c) => c.choices[0].delta.role === "assistant");
+    expect(withRole).toHaveLength(1);
+    expect(chunks[0].choices[0].delta.role).toBe("assistant");
+  });
 });

--- a/tests/unit/nonstream-binary-transport-source-format-3199.test.js
+++ b/tests/unit/nonstream-binary-transport-source-format-3199.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}),
+  saveRequestUsage: vi.fn(async () => {})
+}));
+
+const { FORMATS } = await import("../../open-sse/translator/formats.js");
+const { translateNonStreamingResponse } = await import("../../open-sse/handlers/chatCore/nonStreamingHandler.js");
+
+// The kiro executor decodes its EventStream frames into a chat.completion body
+// before chatCore ever sees them, so translateNonStreamingResponse is handed
+// OpenAI shape under targetFormat "kiro".
+const KIRO_DECODED_BODY = {
+  id: "chatcmpl-1786352438097",
+  object: "chat.completion",
+  created: 1786352438,
+  model: "claude-haiku-4.5",
+  choices: [{
+    index: 0,
+    message: { role: "assistant", content: "Hey there." },
+    finish_reason: "stop",
+  }],
+  usage: { prompt_tokens: 10, completion_tokens: 8 },
+};
+
+const KIRO_TOOL_BODY = {
+  id: "chatcmpl-tool",
+  object: "chat.completion",
+  model: "claude-haiku-4.5",
+  choices: [{
+    index: 0,
+    message: {
+      role: "assistant",
+      content: null,
+      tool_calls: [{ id: "toolu_1", type: "function", function: { name: "Read", arguments: '{"path":"a.txt"}' } }],
+    },
+    finish_reason: "tool_calls",
+  }],
+  usage: {},
+};
+
+describe("#3199 non-streaming responses from binary-transport targets", () => {
+  it("returns an Anthropic message to a Claude client", () => {
+    const out = translateNonStreamingResponse(KIRO_DECODED_BODY, FORMATS.KIRO, FORMATS.CLAUDE);
+
+    expect(out.type).toBe("message");
+    expect(out.role).toBe("assistant");
+    expect(out.content).toEqual([{ type: "text", text: "Hey there." }]);
+    expect(out.stop_reason).toBe("end_turn");
+    expect(out.usage).toEqual({ input_tokens: 10, output_tokens: 8 });
+    expect(out.choices).toBeUndefined();
+  });
+
+  it("maps tool calls to tool_use blocks for a Claude client", () => {
+    const out = translateNonStreamingResponse(KIRO_TOOL_BODY, FORMATS.KIRO, FORMATS.CLAUDE);
+
+    expect(out.content).toEqual([
+      { type: "tool_use", id: "toolu_1", name: "Read", input: { path: "a.txt" } },
+    ]);
+    expect(out.stop_reason).toBe("tool_use");
+  });
+
+  it("returns a Responses body to a Responses client", () => {
+    const out = translateNonStreamingResponse(KIRO_DECODED_BODY, FORMATS.KIRO, FORMATS.OPENAI_RESPONSES);
+
+    expect(out.object).toBe("response");
+    expect(out.output).toEqual([{
+      type: "message",
+      role: "assistant",
+      content: [{ type: "output_text", text: "Hey there.", annotations: [] }],
+    }]);
+  });
+
+  it("leaves an OpenAI client's body untouched", () => {
+    const out = translateNonStreamingResponse(KIRO_DECODED_BODY, FORMATS.KIRO, FORMATS.OPENAI);
+
+    expect(out).toBe(KIRO_DECODED_BODY);
+  });
+
+  it("does not touch a body that has no choices array", () => {
+    const raw = { some: "proprietary shape" };
+    const out = translateNonStreamingResponse(raw, FORMATS.KIRO, FORMATS.CLAUDE);
+
+    expect(out).toBe(raw);
+  });
+});

--- a/tests/unit/openai-format-empty-tool-calls.test.js
+++ b/tests/unit/openai-format-empty-tool-calls.test.js
@@ -1,0 +1,67 @@
+// filterToOpenAIFormat treated `tool_calls: []` as "this message carries tool calls",
+// because an empty array is truthy. Two shortcuts keyed off that check, so an assistant
+// message with an empty tool_calls array skipped content normalisation and survived the
+// empty-message filter. Upstreams that reject Claude-only blocks or empty assistant turns
+// then rejected the whole request.
+import { describe, it, expect } from "vitest";
+import { filterToOpenAIFormat } from "../../open-sse/translator/formats/openai.js";
+
+describe("filterToOpenAIFormat with an empty tool_calls array", () => {
+  it("still strips Claude-only blocks from the assistant turn", () => {
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [],
+          content: [
+            { type: "thinking", thinking: "internal reasoning" },
+            { type: "text", text: "visible answer" },
+          ],
+        },
+      ],
+    };
+
+    const out = filterToOpenAIFormat(body);
+    const types = out.messages[0].content.map((b) => b.type);
+
+    expect(types).not.toContain("thinking");
+    expect(types).toEqual(["text"]);
+  });
+
+  it("still drops an assistant turn left with no usable content", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", tool_calls: [], content: "   " },
+      ],
+    };
+
+    const out = filterToOpenAIFormat(body);
+
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0].role).toBe("user");
+  });
+
+  it("leaves a message with real tool calls untouched", () => {
+    const toolCall = {
+      id: "call_1",
+      type: "function",
+      function: { name: "get_weather", arguments: "{}" },
+    };
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [toolCall],
+          content: [{ type: "thinking", thinking: "keep me" }],
+        },
+      ],
+    };
+
+    const out = filterToOpenAIFormat(body);
+
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0].tool_calls).toEqual([toolCall]);
+    expect(out.messages[0].content).toEqual([{ type: "thinking", thinking: "keep me" }]);
+  });
+});

--- a/tests/unit/stream-mode-default-3492.test.js
+++ b/tests/unit/stream-mode-default-3492.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { clientRequestedStreaming } from "../../open-sse/handlers/chatCore/streamMode.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+/**
+ * chatCore resolved the response framing with `body.stream !== false`, which
+ * reads an absent `stream` key as "stream". The OpenAI API defines `stream`
+ * with a default of false, so a body without the key is a non-streaming
+ * request — and the response came back as `text/event-stream` with a
+ * `data: [DONE]` appended to a plain `chat.completion` object, which strict
+ * JSON clients cannot parse (#3492).
+ *
+ * chatCore now reads the mode from here:
+ *   let stream = providerRequiresStreaming ? true : clientRequestedStreaming;
+ */
+const chat = (extra = {}) => ({
+  model: "deepseek-chat",
+  messages: [{ role: "user", content: "say OK" }],
+  ...extra,
+});
+
+describe("clientRequestedStreaming", () => {
+  it("reads a body with no stream key as non-streaming", () => {
+    expect(clientRequestedStreaming(chat(), FORMATS.OPENAI)).toBe(false);
+  });
+
+  it("reads an explicit stream:false as non-streaming", () => {
+    expect(clientRequestedStreaming(chat({ stream: false }), FORMATS.OPENAI)).toBe(false);
+  });
+
+  it("reads an explicit stream:true as streaming", () => {
+    expect(clientRequestedStreaming(chat({ stream: true }), FORMATS.OPENAI)).toBe(true);
+  });
+
+  it("does not treat a truthy non-boolean as a request to stream", () => {
+    for (const value of ["true", 1, {}]) {
+      expect(clientRequestedStreaming(chat({ stream: value }), FORMATS.OPENAI)).toBe(false);
+    }
+  });
+
+  it("keeps the Gemini and Antigravity surfaces on SSE regardless of the body", () => {
+    for (const format of [FORMATS.GEMINI, FORMATS.GEMINI_CLI, FORMATS.ANTIGRAVITY]) {
+      expect(clientRequestedStreaming(chat(), format)).toBe(true);
+      expect(clientRequestedStreaming(chat({ stream: false }), format)).toBe(true);
+    }
+  });
+
+  it("treats the Claude surface like OpenAI", () => {
+    expect(clientRequestedStreaming(chat(), FORMATS.CLAUDE)).toBe(false);
+    expect(clientRequestedStreaming(chat({ stream: true }), FORMATS.CLAUDE)).toBe(true);
+  });
+
+  it("survives a missing body", () => {
+    expect(clientRequestedStreaming(undefined, FORMATS.OPENAI)).toBe(false);
+  });
+});

--- a/tests/unit/stream-mode-default-3492.test.js
+++ b/tests/unit/stream-mode-default-3492.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
 
 import { clientRequestedStreaming } from "../../open-sse/handlers/chatCore/streamMode.js";
 import { FORMATS } from "../../open-sse/translator/formats.js";
@@ -53,5 +54,36 @@ describe("clientRequestedStreaming", () => {
 
   it("survives a missing body", () => {
     expect(clientRequestedStreaming(undefined, FORMATS.OPENAI)).toBe(false);
+  });
+});
+
+// The tests above exercise clientRequestedStreaming in isolation. They all keep
+// passing if chatCore.js goes back to its own `body.stream !== false`, because
+// nothing here observes the call site — reverting the wiring alone left this
+// file green, which is exactly the shape of bug this PR is about. handleChatCore
+// takes ~30 collaborators and cannot be driven from a unit test, so pin the
+// wiring at the source level instead.
+describe("chatCore reads the stream mode from streamMode.js (#3492)", () => {
+  const source = readFileSync(
+    new URL("../../open-sse/handlers/chatCore.js", import.meta.url),
+    "utf8",
+  );
+
+  it("imports the helper", () => {
+    expect(source).toMatch(
+      /import\s*\{\s*clientRequestedStreaming[^}]*\}\s*from\s*["']\.\/chatCore\/streamMode\.js["']/,
+    );
+  });
+
+  it("derives the streaming decision from it", () => {
+    expect(source).toMatch(/const\s+clientRequestedStreaming\s*=\s*requestedStreaming\(\s*body\s*,\s*sourceFormat\s*\)/);
+    expect(source).toMatch(/let\s+stream\s*=\s*providerRequiresStreaming\s*\?\s*true\s*:\s*clientRequestedStreaming/);
+  });
+
+  it("no longer decides the response framing with `body.stream !== false`", () => {
+    // The Accept-header branch still reads `body.stream !== true`; only the
+    // `!== false` spelling, which is what treated an absent key as streaming,
+    // must be gone.
+    expect(source).not.toMatch(/body\.stream\s*!==\s*false/);
   });
 });

--- a/tests/unit/thinking-responses-nested-3154.test.js
+++ b/tests/unit/thinking-responses-nested-3154.test.js
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+const { applyThinking } = await import("../../open-sse/translator/concerns/thinkingUnified.js");
+const { translateRequest } = await import("../../open-sse/translator/index.js");
+const { FORMATS } = await import("../../open-sse/translator/formats.js");
+
+describe("#3154 reasoning effort nesting for Responses targets", () => {
+  it("nests effort under reasoning for a gpt-5.6 model on an openai-responses target", () => {
+    const body = { model: "gpt-5.6-luna", reasoning_effort: "high" };
+    applyThinking(FORMATS.OPENAI_RESPONSES, "gpt-5.6-luna", body, "openai-compatible-responses-abc");
+
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.reasoning).toMatchObject({ effort: "high" });
+  });
+
+  it("keeps the flat key for chat completions targets", () => {
+    const body = { model: "gpt-5.6-luna", reasoning_effort: "high" };
+    applyThinking(FORMATS.OPENAI, "gpt-5.6-luna", body, "openai-compatible-chat-abc");
+
+    expect(body.reasoning_effort).toBe("high");
+    expect(body.reasoning).toBeUndefined();
+  });
+
+  it("nests a disabled effort too", () => {
+    const body = { model: "gpt-5.6-luna", reasoning_effort: "none" };
+    applyThinking(FORMATS.OPENAI_RESPONSES, "gpt-5.6-luna", body, "openai-compatible-responses-abc");
+
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.reasoning).toMatchObject({ effort: "none" });
+  });
+
+  it("preserves sibling reasoning keys set by the caller", () => {
+    const body = { model: "gpt-5.6-luna", reasoning: { effort: "low", mode: "pro", summary: "detailed" } };
+    applyThinking(FORMATS.OPENAI_RESPONSES, "gpt-5.6-luna(high)", body, "openai-compatible-responses-abc");
+
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.reasoning).toEqual({ effort: "high", mode: "pro", summary: "detailed" });
+  });
+
+  // FORMAT_TO_NATIVE carries both spellings and usageTracking/modality dispatch on the
+  // singular one, so a fix keyed to "openai-responses" alone still ships the flat key here.
+  it("nests for the singular openai-response target too", () => {
+    const body = { model: "gpt-5.6-luna", reasoning_effort: "high" };
+    applyThinking(FORMATS.OPENAI_RESPONSE, "gpt-5.6-luna", body, "openai-compatible-responses-abc");
+
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.reasoning).toMatchObject({ effort: "high" });
+  });
+
+  it("leaves a native Responses request nested rather than flattening it", () => {
+    const out = translateRequest(
+      FORMATS.OPENAI_RESPONSES,
+      FORMATS.OPENAI_RESPONSES,
+      "gpt-5.6-luna",
+      { model: "gpt-5.6-luna", input: "hi", reasoning: { effort: "high", mode: "pro" } },
+      true,
+      {},
+      "openai-compatible-responses-abc",
+    );
+
+    expect(out.reasoning_effort).toBeUndefined();
+    expect(out.reasoning).toMatchObject({ effort: "high", mode: "pro" });
+  });
+
+  it("leaves non-reasoning models untouched", () => {
+    const body = { model: "gpt-4o-mini", reasoning_effort: "high" };
+    applyThinking(FORMATS.OPENAI_RESPONSES, "gpt-4o-mini", body, "openai-compatible-responses-abc");
+
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.reasoning).toBeUndefined();
+  });
+
+  it("produces a Responses body with no flat reasoning_effort end to end", () => {
+    const out = translateRequest(
+      FORMATS.OPENAI,
+      FORMATS.OPENAI_RESPONSES,
+      "gpt-5.6-luna",
+      { model: "gpt-5.6-luna", messages: [{ role: "user", content: "hi" }], reasoning_effort: "high" },
+      true,
+      {},
+      "openai-compatible-responses-abc",
+    );
+
+    expect(out.reasoning_effort).toBeUndefined();
+    expect(out.reasoning).toMatchObject({ effort: "high", summary: "auto" });
+  });
+});

--- a/tests/unit/tool-result-missing-id-3362.test.js
+++ b/tests/unit/tool-result-missing-id-3362.test.js
@@ -1,0 +1,174 @@
+// #3362 — Claude tool-result requests intermittently failed with
+// "messages.N.content.0.tool_result.tool_use_id: Field required".
+//
+// ensureToolCallIds repaired an assistant tool_call whose id was missing, but
+// both tool-result branches were guarded on the id being truthy, so a result
+// arriving without one passed through untouched and openai-to-claude emitted
+// `tool_use_id: undefined`. Anthropic rejects the whole request.
+import { describe, it, expect } from "vitest";
+import { ensureToolCallIds } from "../../open-sse/translator/concerns/toolCall.js";
+import { fixMissingToolResponses } from "../../open-sse/translator/concerns/toolCall.js";
+import { openaiToClaudeRequest } from "../../open-sse/translator/request/openai-to-claude.js";
+
+const TOOL_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+function assistantCall(...ids) {
+  return {
+    role: "assistant",
+    content: null,
+    tool_calls: ids.map((id) => ({ id, type: "function", function: { name: "read_file", arguments: "{}" } })),
+  };
+}
+
+describe("tool_result id repair (#3362)", () => {
+  it("pairs a result that arrived without an id with the open tool call", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "read it" },
+        assistantCall("call_abc123"),
+        { role: "tool", content: "file contents" },
+      ],
+    };
+
+    ensureToolCallIds(body);
+
+    expect(body.messages[2].tool_call_id).toBe("call_abc123");
+  });
+
+  it("pairs parallel results in order", () => {
+    const body = {
+      messages: [
+        assistantCall("call_one", "call_two"),
+        { role: "tool", content: "first" },
+        { role: "tool", content: "second" },
+      ],
+    };
+
+    ensureToolCallIds(body);
+
+    expect(body.messages.slice(1).map((m) => m.tool_call_id)).toEqual(["call_one", "call_two"]);
+  });
+
+  // An id already claimed by an explicit result must not be handed out again,
+  // whichever order the results arrive in.
+  it("does not hand the same id to two results", () => {
+    const inOrder = {
+      messages: [
+        assistantCall("call_one", "call_two"),
+        { role: "tool", tool_call_id: "call_one", content: "first" },
+        { role: "tool", content: "second, id dropped" },
+      ],
+    };
+
+    ensureToolCallIds(inOrder);
+
+    expect(inOrder.messages.slice(1).map((m) => m.tool_call_id)).toEqual(["call_one", "call_two"]);
+
+    const outOfOrder = {
+      messages: [
+        assistantCall("call_one", "call_two"),
+        { role: "tool", tool_call_id: "call_two", content: "second arrived first" },
+        { role: "tool", content: "the other one" },
+      ],
+    };
+
+    ensureToolCallIds(outOfOrder);
+
+    expect(outOfOrder.messages.slice(1).map((m) => m.tool_call_id)).toEqual(["call_two", "call_one"]);
+  });
+
+  it("repairs the Claude shape too (tool_result block in user content)", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: [{ type: "tool_use", id: "call_xyz", name: "read_file", input: {} }] },
+        { role: "user", content: [{ type: "tool_result", content: "ok" }] },
+      ],
+    };
+
+    ensureToolCallIds(body);
+
+    expect(body.messages[1].content[0].tool_use_id).toBe("call_xyz");
+  });
+
+  it("leaves a valid id alone", () => {
+    const body = {
+      messages: [assistantCall("call_abc"), { role: "tool", tool_call_id: "call_abc", content: "ok" }],
+    };
+
+    ensureToolCallIds(body);
+
+    expect(body.messages[1].tool_call_id).toBe("call_abc");
+  });
+
+  it("still sanitizes an id that breaks Anthropic's pattern", () => {
+    const body = {
+      messages: [
+        assistantCall("call:abc/1"),
+        { role: "tool", tool_call_id: "call:abc/1", content: "ok" },
+      ],
+    };
+
+    ensureToolCallIds(body);
+
+    const id = body.messages[0].tool_calls[0].id;
+    expect(id).toBe("callabc1");
+    expect(body.messages[1].tool_call_id).toBe(id);
+  });
+
+  // Nothing to pair with is still not a reason to emit an absent field: a
+  // well-formed id keeps the request shape valid instead of guaranteeing a 400.
+  it("never leaves the id empty when there is no open call", () => {
+    const body = { messages: [{ role: "tool", content: "orphan" }] };
+
+    ensureToolCallIds(body);
+
+    expect(body.messages[0].tool_call_id).toBeTruthy();
+    expect(body.messages[0].tool_call_id).toMatch(TOOL_ID_PATTERN);
+  });
+
+  it("does not reuse ids across assistant turns", () => {
+    const body = {
+      messages: [
+        assistantCall("call_first"),
+        { role: "tool", tool_call_id: "call_first", content: "a" },
+        assistantCall("call_second"),
+        { role: "tool", content: "b" },
+      ],
+    };
+
+    ensureToolCallIds(body);
+
+    expect(body.messages[3].tool_call_id).toBe("call_second");
+  });
+
+  // hasToolResults() matches on the id, so before the repair a result with no
+  // id looked absent and fixMissingToolResponses spliced in an empty duplicate.
+  it("stops a duplicate empty result being inserted after it", () => {
+    const body = {
+      messages: [assistantCall("call_abc"), { role: "tool", content: "real output" }],
+    };
+
+    fixMissingToolResponses(ensureToolCallIds(body));
+
+    const results = body.messages.filter((m) => m.role === "tool");
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe("real output");
+  });
+
+  it("reaches Anthropic with a tool_use_id, end to end", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "read it" },
+        assistantCall("call_abc123"),
+        { role: "tool", content: "file contents" },
+      ],
+    };
+
+    const claude = openaiToClaudeRequest("claude-sonnet-5", ensureToolCallIds(body), false);
+
+    const blocks = claude.messages.flatMap((m) => (Array.isArray(m.content) ? m.content : []));
+    const results = blocks.filter((b) => b.type === "tool_result");
+    expect(results).toHaveLength(1);
+    expect(results[0].tool_use_id).toBe("call_abc123");
+  });
+});


### PR DESCRIPTION
Six translator/handler fixes that were sitting in separate PRs (#3243, #3247, #3254, #3369, #3492/#3528, #3549), rebased onto current `master` and sent as one review. Each is an independent commit, so any one of them can be dropped without touching the others.

All six are format-conversion defects: a request or response crossed a format boundary and lost a field that the target API requires.

| commit | defect |
|---|---|
| `1b042a1c` | `reasoning.effort` was sent flat to `openai-responses` targets, which nest it |
| `0f23a482` | a non-streaming binary-transport reply was returned in the upstream's format, not the client's |
| `8805156e` | `tool_calls: []` was treated as "has tool calls", producing an empty `tool_use` block |
| `74658a51` | a tool result arriving without an id emitted `tool_use_id: undefined`; Anthropic rejects the whole request |
| `65339392` | a request with no stream key defaulted to streaming, so non-streaming clients got SSE |
| `d43850f6` | the CommandCode error chunk opened without a role, so clients that key on the first delta dropped it |

## Verification

```
npx vitest@3 run --config tests/vitest.config.js \
  tests/unit/{commandcode-to-openai,nonstream-binary-transport-source-format-3199,openai-format-empty-tool-calls,stream-mode-default-3492,thinking-responses-nested-3154,tool-result-missing-id-3362}.test.js \
  tests/translator/thinking-unified.test.js
→ 7 files, 107 passed
```

Two notes on running these, because both cost me time:

- The alias `@/` only resolves with `--config tests/vitest.config.js`; without it collection dies on `Failed to load url @/lib/dataDir.js`.
- **vitest 2.x cannot run any test that reaches `open-sse/translator/index.js`.** It fails with `TypeError: register is not a function` at the top-level `register(...)` calls. That is not a defect in this repo: `index.js` deliberately relies on function-declaration hoisting to survive the import cycle (the comment above `var requestRegistry` says so), and Vite 5's SSR transform turns the named import into a call-time property access that is not yet populated. I confirmed the same failure on clean `master`, on `master` as of 15 Aug, and on this repo's own `tests/translator/bugs-antigravity.test.js` — so it predates these changes and is not caused by them. vitest 3 runs them correctly.

Each claim was checked by reverting it and confirming which test dies; no test passes for a reason other than the fix.

One of the six did not survive that check as it stood. Reverting the call site in `chatCore.js` for `#3492` left `stream-mode-default-3492.test.js` **green**: the tests exercised `clientRequestedStreaming` in isolation and nothing observed the wiring — the same shape of bug the fix is about. `handleChatCore` takes ~30 collaborators and cannot be driven from a unit test, so `18e67517` pins the call site at the source level instead. Reverting `chatCore.js` now fails 3 of that file's 10 cases.
