### PR TITLE
fix(stream): expired model lock masks account lock, and dropped generated images (#3516, #3521)

### DIFF
--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -118,10 +118,20 @@ export function getModelLockKey(model) {
  * Reads flat field `modelLock_${model}` (or `modelLock___all` when model=null).
  */
 export function isModelLockActive(connection, model) {
-  const key = getModelLockKey(model);
-  const expiry = connection[key] || connection[MODEL_LOCK_ALL];
-  if (!expiry) return false;
-  return new Date(expiry).getTime() > Date.now();
+  const now = Date.now();
+  const stillLocked = (value) => {
+    if (!value) return false;
+    const until = new Date(value).getTime();
+    return Number.isFinite(until) && until > now;
+  };
+  // Each key is judged on its own expiry. `a || b` picked the per-model key on the
+  // truthiness of the string, so a stale one hid a still-active account-wide lock:
+  // the connection then read as free for exactly the model that had just failed,
+  // while still reading as locked for every other model. Nothing clears the stale
+  // key either -- the lazy cleanup runs only after a successful request, and an
+  // account under an `__all` lock never gets one. Same rule the sibling
+  // `getEarliestModelLockUntil` already applies when it skips expired entries.
+  return stillLocked(connection[getModelLockKey(model)]) || stillLocked(connection[MODEL_LOCK_ALL]);
 }
 
 /**

--- a/open-sse/utils/streamHelpers.js
+++ b/open-sse/utils/streamHelpers.js
@@ -41,6 +41,11 @@ export function hasValuableContent(chunk, format) {
     return delta.content && delta.content !== "" ||
            delta.reasoning_content && delta.reasoning_content !== "" ||
            delta.tool_calls && delta.tool_calls.length > 0 ||
+           // Generated images arrive on their own chunk with nothing else in the
+           // delta, so leaving `images` out of this list dropped every one of them.
+           // The translator emits exactly this shape (gemini-to-openai.js:105) and
+           // the golden snapshot for "inlineData -> delta.images" locks it.
+           delta.images && delta.images.length > 0 ||
            chunk.choices[0].finish_reason ||
            delta.role;
   }

--- a/tests/unit/model-lock-precedence.test.js
+++ b/tests/unit/model-lock-precedence.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MODEL_LOCK_ALL,
+  getEarliestModelLockUntil,
+  getModelLockKey,
+  isModelLockActive,
+} from "../../open-sse/services/accountFallback.js";
+
+const MODEL = "claude-fable-5";
+const past = () => new Date(Date.now() - 60_000).toISOString();
+const future = () => new Date(Date.now() + 7 * 24 * 3600_000).toISOString();
+
+describe("isModelLockActive precedence", () => {
+  it("does not let an expired per-model lock mask an active account-wide lock", () => {
+    // The shape a GitHub account reaches after a plain 402 (two-minute per-model
+    // lock) followed by monthly exhaustion (account-wide lock until next month).
+    const connection = {
+      [getModelLockKey(MODEL)]: past(),
+      [MODEL_LOCK_ALL]: future(),
+    };
+
+    expect(isModelLockActive(connection, MODEL)).toBe(true);
+    // The asymmetry is what made this visible: the account read as locked for a
+    // model it had no history with, and free for the one that had just failed.
+    expect(isModelLockActive(connection, "some-other-model")).toBe(true);
+    // The UI badge already skipped expired entries, so routing and the dashboard
+    // disagreed about the same connection.
+    expect(getEarliestModelLockUntil(connection)).not.toBeNull();
+  });
+
+  it("keeps an active per-model lock", () => {
+    const connection = { [getModelLockKey(MODEL)]: future() };
+    expect(isModelLockActive(connection, MODEL)).toBe(true);
+    expect(isModelLockActive(connection, "other")).toBe(false);
+  });
+
+  it("releases a connection once both locks have expired", () => {
+    const connection = {
+      [getModelLockKey(MODEL)]: past(),
+      [MODEL_LOCK_ALL]: past(),
+    };
+    expect(isModelLockActive(connection, MODEL)).toBe(false);
+    expect(isModelLockActive(connection, "other")).toBe(false);
+  });
+
+  it("treats an unparseable timestamp as no lock rather than a permanent one", () => {
+    const connection = { [getModelLockKey(MODEL)]: "not-a-date" };
+    expect(isModelLockActive(connection, MODEL)).toBe(false);
+  });
+
+  it("returns false when the connection carries no lock at all", () => {
+    expect(isModelLockActive({}, MODEL)).toBe(false);
+  });
+});

--- a/tests/unit/stream-keeps-generated-images.test.js
+++ b/tests/unit/stream-keeps-generated-images.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { hasValuableContent } from "../../open-sse/utils/streamHelpers.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+/**
+ * `hasValuableContent` gates every chunk on the streaming path
+ * (open-sse/utils/stream.js:315). A generated image arrives on its own chunk with
+ * nothing else in the delta, so leaving `images` out of the check dropped it — and
+ * the client received a well-formed but empty assistant message.
+ *
+ * The shape below is the one the translator emits at
+ * open-sse/translator/response/gemini-to-openai.js:105, and the one the repo's own
+ * golden snapshot locks for "image output (inlineData → delta.images)".
+ */
+const imageChunk = () => ({
+  choices: [
+    {
+      index: 0,
+      delta: {
+        images: [
+          {
+            type: "image_url",
+            image_url: { url: "data:image/png;base64,iVBORw0KGgo=" },
+          },
+        ],
+      },
+      finish_reason: null,
+    },
+  ],
+});
+
+describe("hasValuableContent — OpenAI format", () => {
+  it("keeps a chunk carrying only a generated image", () => {
+    expect(hasValuableContent(imageChunk(), FORMATS.OPENAI)).toBeTruthy();
+  });
+
+  it("still drops a chunk whose delta is genuinely empty", () => {
+    const empty = { choices: [{ index: 0, delta: {}, finish_reason: null }] };
+    expect(hasValuableContent(empty, FORMATS.OPENAI)).toBeFalsy();
+  });
+
+  it("drops an empty images array rather than treating it as content", () => {
+    const chunk = imageChunk();
+    chunk.choices[0].delta.images = [];
+    expect(hasValuableContent(chunk, FORMATS.OPENAI)).toBeFalsy();
+  });
+
+  it("keeps the shapes it already kept", () => {
+    const text = { choices: [{ delta: { content: "hi" } }] };
+    const reasoning = { choices: [{ delta: { reasoning_content: "why" } }] };
+    const tools = { choices: [{ delta: { tool_calls: [{ index: 0 }] } }] };
+    const role = { choices: [{ delta: { role: "assistant" } }] };
+    const finish = { choices: [{ delta: {}, finish_reason: "stop" }] };
+    for (const chunk of [text, reasoning, tools, role, finish]) {
+      expect(hasValuableContent(chunk, FORMATS.OPENAI)).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
Two stream-path fixes that were sitting in separate PRs (#3516, #3521), rebased onto current `master`. Independent commits; either can be dropped.

**`fix(fallback)` (#3516)** — an expired per-model lock masked an active account lock. The per-model entry was checked first and, once its TTL had passed, the code returned "not locked" without consulting the account-level lock that was still live, so requests were sent to an account the router had already taken out of rotation.

**`fix(stream)` (#3521)** — generated images were dropped from OpenAI-format streams. The delta handler forwarded `content` and reasoning fields and ignored the image parts, so a model that returned an image mid-stream produced text-only output with no error.

## Not included: #3542

I tried to bundle #3542 (record the turn when a client hangs up mid-stream) and it no longer applies. `master` has since grown its own `finalizeStream()` in `open-sse/utils/stream.js`, called from `transform` on terminal events and from `flush`, which overlaps that PR's `finishStream()`. The remaining gap is real — there is still no `cancel` callback on the transformer, so a client that disconnects *before* any terminal event still records nothing — but closing it now means rewriting against the new structure rather than replaying the old patch. I will send that separately rather than force a stale diff through here.

## Verification

Run with **vitest 3** and the repo config — both parts matter:

```
npx vitest@3 run --config tests/vitest.config.js <files>
```

Without `--config` the `@/` alias does not resolve (`Failed to load url @/lib/dataDir.js`). And vitest 2.x cannot run anything that reaches `open-sse/translator/index.js`: it throws `TypeError: register is not a function` at the top-level `register(...)` calls, because `index.js` deliberately relies on function-declaration hoisting to survive the import cycle while Vite 5's SSR transform turns the named import into a call-time property access. I confirmed that failure on clean `master` and on `master` as of 15 Aug, so it is not caused by these changes.

Every fix was checked by reverting it and confirming which test dies. No claim here rests on a test that passes for another reason.
