### PR TITLE
fix(models): four provider-catalog and connection defects (#3262, #3115, #3486, #3467)

### DIFF
--- a/open-sse/providers/registry/ollama-local.js
+++ b/open-sse/providers/registry/ollama-local.js
@@ -11,6 +11,11 @@ export default {
     website: "https://ollama.com",
   },
   category: "apikey",
+  // The connection's own endpoint, stored as providerSpecificData.baseUrl.
+  baseUrlField: {
+    label: "Ollama Host URL",
+    placeholder: "http://localhost:11434",
+  },
   transport: {
     baseUrl: "http://localhost:11434/api/chat",
     format: "ollama",

--- a/open-sse/providers/registry/selfhosted-embedding.js
+++ b/open-sse/providers/registry/selfhosted-embedding.js
@@ -40,6 +40,12 @@ export default {
     website: "https://github.com/ggml-org/llama.cpp",
   },
   category: "apikey",
+  // Same gap as the TTS and STT entries.
+  baseUrlField: {
+    label: "Base URL",
+    placeholder: "http://localhost:8080/v1",
+    help: "OpenAI base URL — /embeddings is appended.",
+  },
   auth: {
     apiKey: {
       // Note the /v1: the adapter appends "/embeddings" to whatever it is given,

--- a/open-sse/providers/registry/selfhosted-stt.js
+++ b/open-sse/providers/registry/selfhosted-stt.js
@@ -28,6 +28,13 @@ export default {
     website: "https://github.com/ggml-org/whisper.cpp",
   },
   category: "apikey",
+  // See the TTS entry: without this the dashboard cannot point the connection
+  // at a separately hosted server.
+  baseUrlField: {
+    label: "Base URL",
+    placeholder: "http://localhost:8080/v1/audio/transcriptions",
+    help: "Full transcriptions endpoint.",
+  },
   auth: {
     apiKey: {
       text: "Set providerSpecificData.baseUrl to the full transcriptions URL, e.g. http://host:8080/v1/audio/transcriptions. The API key is not checked by local servers; any value works.",

--- a/open-sse/providers/registry/selfhosted-tts.js
+++ b/open-sse/providers/registry/selfhosted-tts.js
@@ -22,6 +22,14 @@ export default {
     website: "https://github.com/remsky/Kokoro-FastAPI",
   },
   category: "apikey",
+  // Without this the dashboard saves no baseUrl and the connection silently
+  // falls back to the localhost default below, which in Docker points at the
+  // 9router container itself.
+  baseUrlField: {
+    label: "Base URL",
+    placeholder: "http://localhost:8880",
+    help: "Server root — /v1/audio/speech is appended.",
+  },
   auth: {
     apiKey: {
       text: "Set providerSpecificData.baseUrl to the server root, e.g. http://host:8080 — /v1/audio/speech is appended. The API key is not checked by local servers; any value works.",

--- a/open-sse/services/comboLimits.js
+++ b/open-sse/services/comboLimits.js
@@ -1,0 +1,38 @@
+/**
+ * Token limits a combo pool can honour.
+ *
+ * A request routed to a combo may land on any member, so the pool can only
+ * promise what its *smallest* member accepts. Anything larger is a limit some
+ * member will reject.
+ *
+ * `capsFor` receives one member reference ("alias/model-id") and returns that
+ * model's capabilities; passing it in keeps this pure and lets the caller own
+ * the alias-to-provider mapping.
+ *
+ * Members whose capabilities carry no usable number are skipped rather than
+ * treated as zero. When no member reports one, the field comes back undefined
+ * and the caller omits it - an absent field lets a client fall back, a wrong
+ * one does not.
+ */
+export function comboTokenLimits(members, capsFor) {
+  const lowest = { contextWindow: undefined, maxOutput: undefined };
+  if (!Array.isArray(members)) return lowest;
+
+  for (const ref of members) {
+    if (typeof ref !== "string" || ref.trim() === "") continue;
+    const caps = capsFor(ref) || {};
+    for (const field of ["contextWindow", "maxOutput"]) {
+      const value = caps[field];
+      if (!Number.isFinite(value) || value <= 0) continue;
+      lowest[field] = lowest[field] === undefined ? value : Math.min(lowest[field], value);
+    }
+  }
+  return lowest;
+}
+
+/** Split a combo member reference into its provider alias and model id. */
+export function splitModelRef(ref) {
+  const slash = ref.indexOf("/");
+  if (slash === -1) return { alias: "", modelId: ref };
+  return { alias: ref.slice(0, slash), modelId: ref.slice(slash + 1) };
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import { Button, Badge, Input, Modal, Select } from "@/shared/components";
 import { AI_PROVIDERS } from "@/shared/constants/providers";
 import { planBulkAdd } from "@/shared/utils/bulkAdd";
+import { buildProviderSpecificData as buildSpecificData } from "@/shared/utils/providerSpecificData";
 
 const BULK_PLACEHOLDER = `name1|sk-key1\nname2|sk-key2\nsk-key-only-auto-named`;
 
@@ -18,6 +19,9 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
     ? (provider === "grok-web" ? "sso=xxxxx... or just the raw value" : "eyJhbGciOi...")
     : (isXaiApiKey ? "xai-..." : provider === "qoder" ? "pt-..." : "");
 
+  // Providers whose endpoint is per-connection declare it in the registry.
+  const baseUrlField = AI_PROVIDERS?.[provider]?.baseUrlField || null;
+
   const isAzure = provider === "azure";
   const isCloudflareAi = provider === "cloudflare-ai";
   const providerRegions = AI_PROVIDERS?.[provider]?.regions || null;
@@ -29,7 +33,7 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
     defaultModel: "",
     priority: 1,
     proxyPoolId: NONE_PROXY_POOL_VALUE,
-    ollamaHostUrl: "",
+    baseUrl: "",
   });
   const [azureData, setAzureData] = useState({
     azureEndpoint: "",
@@ -52,26 +56,17 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
   const [bulkText, setBulkText] = useState("");
   const [bulkResult, setBulkResult] = useState(null); // { success, failed }
 
-  const buildProviderSpecificData = () => {
-    if (isOllamaLocal && formData.ollamaHostUrl.trim()) {
-      return { baseUrl: formData.ollamaHostUrl.trim() };
-    }
-    if (isAzure) {
-      return {
-        azureEndpoint: azureData.azureEndpoint,
-        apiVersion: azureData.apiVersion,
-        deployment: azureData.deployment,
-        organization: azureData.organization,
-      };
-    }
-    if (isCloudflareAi) {
-      return { accountId: cloudflareData.accountId };
-    }
-    if (providerRegions && region) {
-      return { region };
-    }
-    return undefined;
-  };
+  const buildProviderSpecificData = () =>
+    buildSpecificData({
+      hasBaseUrlField: Boolean(baseUrlField),
+      baseUrl: formData.baseUrl,
+      isAzure,
+      azureData,
+      isCloudflareAi,
+      cloudflareData,
+      region,
+      hasRegions: Boolean(providerRegions),
+    });
 
   const handleValidate = async () => {
     setValidating(true);
@@ -233,13 +228,14 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
           onChange={(e) => setFormData({ ...formData, name: e.target.value })}
           placeholder={isOllamaLocal ? "Ollama Local" : "Production Key"}
         />
-        {isOllamaLocal && (
+        {baseUrlField && (
           <div className="flex gap-2">
             <Input
-              label="Ollama Host URL"
-              value={formData.ollamaHostUrl}
-              onChange={(e) => setFormData({ ...formData, ollamaHostUrl: e.target.value })}
-              placeholder="http://localhost:11434"
+              label={baseUrlField.label}
+              value={formData.baseUrl}
+              onChange={(e) => setFormData({ ...formData, baseUrl: e.target.value })}
+              placeholder={baseUrlField.placeholder}
+              hint={baseUrlField.help}
               className="flex-1"
             />
             <div className="pt-6">

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -18,6 +18,7 @@ import { resolveZedModels } from "open-sse/shared/zedAuth.js";
 import { updateProviderCredentials } from "@/sse/services/tokenRefresh";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { capabilitiesFromServiceKind, getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { comboTokenLimits, splitModelRef } from "open-sse/services/comboLimits.js";
 
 // Per-provider live model resolvers. Each receives a connection record and
 // returns { models: [{ id, name? }, ...] } | null on failure.
@@ -292,6 +293,14 @@ export async function buildModelsList(kindFilter, options = {}) {
 
   const models = [];
 
+  const aliasToProviderId = Object.fromEntries(
+    Object.entries(PROVIDER_ID_TO_ALIAS).map(([id, alias]) => [alias, id])
+  );
+  const capsForModelRef = (ref) => {
+    const { alias, modelId } = splitModelRef(ref);
+    return getCapabilitiesForModel(aliasToProviderId[alias] || alias, modelId);
+  };
+
   // Combos first (filtered by kind). Web combos expose `kind` so AI knows search vs fetch.
   for (const combo of combos) {
     if (!comboMatchesKinds(combo, kindFilter)) continue;
@@ -302,15 +311,20 @@ export async function buildModelsList(kindFilter, options = {}) {
     };
     if (combo.kind === "webSearch" || combo.kind === "webFetch") {
       entry.kind = combo.kind;
+    } else {
+      // Same snake_case token limits individual models carry, so a client
+      // sizing its context window off /v1/models does not fall back to
+      // guessing from the name. A combo can route to any member, so the pool
+      // can only promise what its smallest member accepts.
+      const { contextWindow, maxOutput } = comboTokenLimits(combo.models, capsForModelRef);
+      if (Number.isFinite(contextWindow)) entry.context_length = contextWindow;
+      if (Number.isFinite(maxOutput)) entry.max_completion_tokens = maxOutput;
     }
     models.push(entry);
   }
 
   if (connections.length === 0) {
     // DB unavailable -> return static models, filtered by per-model kind
-    const aliasToProviderId = Object.fromEntries(
-      Object.entries(PROVIDER_ID_TO_ALIAS).map(([id, alias]) => [alias, id])
-    );
     for (const [alias, providerModels] of Object.entries(PROVIDER_MODELS)) {
       const providerId = aliasToProviderId[alias] || alias;
       if (!providerMatchesKinds(providerId, kindFilter)) continue;

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -375,7 +375,25 @@ export async function buildModelsList(kindFilter, options = {}) {
           )
         : providerModels.map((model) => model.id);
 
-      if (isCompatibleProvider && rawModelIds.length === 0 && !skipDynamicFetch) {
+      const customModelKindById = new Map();
+      const customModelIds = customModels
+        .filter((m) => {
+          if (!m?.id) return false;
+          const kind = getModelKind(m) || LLM_KIND;
+          // imageToText custom models are vision-capable chat models: expose them
+          // both in the default LLM list and in /v1/models/image-to-text.
+          if (!kindFilter.includes(kind) && !(kind === "imageToText" && kindFilter.includes(LLM_KIND))) return false;
+          const alias = m.providerAlias;
+          return alias === staticAlias || alias === outputAlias || alias === providerId;
+        })
+        .map((m) => {
+          const modelId = String(m.id).trim();
+          if (modelId) customModelKindById.set(modelId, getModelKind(m) || LLM_KIND);
+          return modelId;
+        })
+        .filter((modelId) => modelId !== "");
+
+      if (isCompatibleProvider && rawModelIds.length === 0 && customModelIds.length === 0 && !skipDynamicFetch) {
         rawModelIds = await fetchCompatibleModelIds(conn);
       }
 
@@ -418,24 +436,6 @@ export async function buildModelsList(kindFilter, options = {}) {
           return modelId;
         })
         .filter((modelId) => typeof modelId === "string" && modelId.trim() !== "");
-
-      const customModelKindById = new Map();
-      const customModelIds = customModels
-        .filter((m) => {
-          if (!m?.id) return false;
-          const kind = getModelKind(m) || LLM_KIND;
-          // imageToText custom models are vision-capable chat models: expose them
-          // both in the default LLM list and in /v1/models/image-to-text.
-          if (!kindFilter.includes(kind) && !(kind === "imageToText" && kindFilter.includes(LLM_KIND))) return false;
-          const alias = m.providerAlias;
-          return alias === staticAlias || alias === outputAlias || alias === providerId;
-        })
-        .map((m) => {
-          const modelId = String(m.id).trim();
-          if (modelId) customModelKindById.set(modelId, getModelKind(m) || LLM_KIND);
-          return modelId;
-        })
-        .filter((modelId) => modelId !== "");
 
       const aliasModelIds = Object.values(modelAliases || {})
         .filter((fullModel) => {

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -29,6 +29,7 @@ function buildProviderEntry(r) {
     ...(r.thinkingConfig ? { thinkingConfig: r.thinkingConfig } : {}),
     ...(r.regions ? { regions: r.regions, defaultRegion: r.defaultRegion } : {}),
     ...(r.hasProviderSpecificData ? { hasProviderSpecificData: true } : {}),
+    ...(r.baseUrlField ? { baseUrlField: r.baseUrlField } : {}),
     ...(r.noAuth ? { noAuth: true } : {}),
     ...(r.passthroughModels ? { passthroughModels: true } : {}),
     ...(r.hasOAuth ? { hasOAuth: true } : {}),

--- a/src/shared/utils/providerSpecificData.js
+++ b/src/shared/utils/providerSpecificData.js
@@ -1,0 +1,42 @@
+/**
+ * Build the `providerSpecificData` a new connection is saved with.
+ *
+ * Kept out of the modal so the shape can be tested without rendering: the
+ * saved value is what the executors read, and a connection saved without it
+ * silently falls back to a built-in default — which is how self-hosted TTS and
+ * STT connections ended up pointing at the 9router container itself (#3467).
+ *
+ * `baseUrl` is included for any provider whose registry entry declares a
+ * `baseUrlField`, and only when the user actually typed something: an empty
+ * box means "keep the provider's default", not "save an empty endpoint".
+ */
+export function buildProviderSpecificData({
+  hasBaseUrlField = false,
+  baseUrl = "",
+  isAzure = false,
+  azureData = null,
+  isCloudflareAi = false,
+  cloudflareData = null,
+  region = "",
+  hasRegions = false,
+} = {}) {
+  if (hasBaseUrlField) {
+    const trimmed = String(baseUrl || "").trim();
+    return trimmed ? { baseUrl: trimmed } : undefined;
+  }
+  if (isAzure) {
+    return {
+      azureEndpoint: azureData?.azureEndpoint,
+      apiVersion: azureData?.apiVersion,
+      deployment: azureData?.deployment,
+      organization: azureData?.organization,
+    };
+  }
+  if (isCloudflareAi) {
+    return { accountId: cloudflareData?.accountId };
+  }
+  if (hasRegions && region) {
+    return { region };
+  }
+  return undefined;
+}

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -56,6 +56,12 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
       const resolvedProxy = await resolveConnectionProxyConfig({ proxyPoolId: pickedId || "" });
       return {
         id: "noauth",
+        // Executors key their upstream session id on connectionId. Without it
+        // deriveSessionId() falls through to a fresh random id on every call, so
+        // each turn of one conversation reaches the provider as a new session and
+        // burns a free-tier slot. "noauth" is the sentinel markAccountUnavailable
+        // and clearAccountError already test for.
+        connectionId: "noauth",
         connectionName: "Public",
         isActive: true,
         accessToken: "public",

--- a/tests/unit/combo-token-limits-3486.test.js
+++ b/tests/unit/combo-token-limits-3486.test.js
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { comboTokenLimits, splitModelRef } from "../../open-sse/services/comboLimits.js";
+import { getCapabilitiesForModel } from "../../open-sse/providers/capabilities.js";
+
+/**
+ * Combo entries in /v1/models carried no token metadata, so a client sizing its
+ * context window off the endpoint fell back to guessing from the model name —
+ * a 1M pool read as a 128k one, compacting at ~96k (#3486).
+ *
+ * A request routed to a combo can land on any member, so the pool can only
+ * promise what its smallest member accepts.
+ */
+const capsFor = (ref) => {
+  const { alias, modelId } = splitModelRef(ref);
+  return getCapabilitiesForModel(alias, modelId);
+};
+
+describe("splitModelRef", () => {
+  it("splits on the first slash only", () => {
+    expect(splitModelRef("openrouter/deepseek/deepseek-chat")).toEqual({
+      alias: "openrouter",
+      modelId: "deepseek/deepseek-chat",
+    });
+  });
+
+  it("treats a bare id as having no alias", () => {
+    expect(splitModelRef("gpt-5")).toEqual({ alias: "", modelId: "gpt-5" });
+  });
+});
+
+describe("comboTokenLimits", () => {
+  const caps = {
+    "a/wide": { contextWindow: 1_000_000, maxOutput: 128_000 },
+    "a/narrow": { contextWindow: 128_000, maxOutput: 64_000 },
+    "a/silent": {},
+  };
+  const stub = (ref) => caps[ref];
+
+  it("reports the smallest window in the pool", () => {
+    expect(comboTokenLimits(["a/wide", "a/narrow"], stub)).toEqual({
+      contextWindow: 128_000,
+      maxOutput: 64_000,
+    });
+  });
+
+  it("is order independent", () => {
+    expect(comboTokenLimits(["a/narrow", "a/wide"], stub)).toEqual(
+      comboTokenLimits(["a/wide", "a/narrow"], stub),
+    );
+  });
+
+  it("ignores a member that reports no limits rather than reading it as zero", () => {
+    expect(comboTokenLimits(["a/wide", "a/silent"], stub)).toEqual({
+      contextWindow: 1_000_000,
+      maxOutput: 128_000,
+    });
+  });
+
+  it("returns nothing to emit when no member reports a limit", () => {
+    expect(comboTokenLimits(["a/silent"], stub)).toEqual({
+      contextWindow: undefined,
+      maxOutput: undefined,
+    });
+  });
+
+  it("survives an empty, absent or malformed model list", () => {
+    const empty = { contextWindow: undefined, maxOutput: undefined };
+    expect(comboTokenLimits([], stub)).toEqual(empty);
+    expect(comboTokenLimits(undefined, stub)).toEqual(empty);
+    expect(comboTokenLimits([null, "", "  ", 7], stub)).toEqual(empty);
+  });
+
+  it("mixes a 1M model with a 128k one down to 128k using the real catalog", () => {
+    const limits = comboTokenLimits(
+      ["anthropic/claude-opus-4.7", "deepseek/deepseek-chat"],
+      capsFor,
+    );
+    expect(limits.contextWindow).toBe(128_000);
+  });
+
+  it("keeps the full window when every member is wide", () => {
+    const limits = comboTokenLimits(
+      ["anthropic/claude-opus-4.7", "anthropic/claude-opus-4.7"],
+      capsFor,
+    );
+    expect(limits.contextWindow).toBe(1_000_000);
+  });
+});

--- a/tests/unit/custom-provider-model-list-3115.test.js
+++ b/tests/unit/custom-provider-model-list-3115.test.js
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { connectionsMock, customModelsMock, fetchMock } = vi.hoisted(() => ({
+  connectionsMock: vi.fn(),
+  customModelsMock: vi.fn(),
+  fetchMock: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: connectionsMock,
+  getCombos: vi.fn(async () => []),
+  getCustomModels: customModelsMock,
+  getModelAliases: vi.fn(async () => ({})),
+}));
+
+vi.mock("@/lib/disabledModelsDb", () => ({
+  getDisabledModels: vi.fn(async () => ({})),
+}));
+
+vi.mock("@/sse/services/tokenRefresh", () => ({
+  updateProviderCredentials: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/network/connectionProxy", () => ({
+  resolveConnectionProxyConfig: vi.fn(() => null),
+}));
+
+const { buildModelsList } = await import("../../src/app/api/v1/models/route.js");
+
+const PROVIDER_ID = "openai-compatible-chat-11111111";
+
+const connection = {
+  provider: PROVIDER_ID,
+  isActive: true,
+  apiKey: "sk-test",
+  providerSpecificData: { prefix: "hn", apiType: "chat", baseUrl: "https://api.example.com/v1" },
+};
+
+// The upstream catalog the provider's own /models endpoint advertises.
+const UPSTREAM = ["keep-me", "drop-me-1", "drop-me-2"];
+
+function idsFor(models) {
+  return models.filter(m => m.id.startsWith("hn/")).map(m => m.id.slice(3));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = fetchMock;
+  connectionsMock.mockResolvedValue([connection]);
+  fetchMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({ data: UPSTREAM.map(id => ({ id })) }),
+  });
+});
+
+describe("#3115 curated custom-provider model list wins over the live upstream catalog", () => {
+  it("lists only the curated models and never hits the upstream /models endpoint", async () => {
+    customModelsMock.mockResolvedValue([{ providerAlias: "hn", id: "keep-me", type: "llm" }]);
+
+    const data = await buildModelsList(["llm"]);
+
+    expect(idsFor(data)).toEqual(["keep-me"]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("still falls back to the live catalog when nothing is curated", async () => {
+    customModelsMock.mockResolvedValue([]);
+
+    const data = await buildModelsList(["llm"]);
+
+    expect(idsFor(data).sort()).toEqual([...UPSTREAM].sort());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores curated models belonging to a different provider", async () => {
+    customModelsMock.mockResolvedValue([{ providerAlias: "other", id: "not-mine", type: "llm" }]);
+
+    const data = await buildModelsList(["llm"]);
+
+    expect(idsFor(data).sort()).toEqual([...UPSTREAM].sort());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps honouring skipDynamicFetch", async () => {
+    customModelsMock.mockResolvedValue([]);
+
+    const data = await buildModelsList(["llm"], { skipDynamicFetch: true });
+
+    expect(idsFor(data)).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/noauth-session-id-3262.test.js
+++ b/tests/unit/noauth-session-id-3262.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: vi.fn(async () => []),
+  validateApiKey: vi.fn(),
+  updateProviderConnection: vi.fn(),
+  getSettings: vi.fn(async () => ({})),
+  getProxyPools: vi.fn(async () => []),
+}));
+
+vi.mock("@/lib/network/connectionProxy", () => ({
+  resolveConnectionProxyConfig: vi.fn(async () => ({
+    connectionProxyEnabled: false,
+    connectionProxyUrl: "",
+    connectionNoProxy: "",
+    proxyPoolId: null,
+    vercelRelayUrl: "",
+  })),
+  pickProxyPoolId: vi.fn(() => null),
+}));
+
+const { getProviderCredentials } = await import("../../src/sse/services/auth.js");
+const { OpenCodeExecutor } = await import("../../open-sse/executors/opencode.js");
+
+// Turn 1: nothing but the user prompt.
+const userOnly = {
+  model: "oc/deepseek-v4-flash-free",
+  messages: [{ role: "user", content: "List the files in this repo." }],
+};
+
+// Turn 2 — the first tool call. The assistant item carries a tool_call and no
+// prose, so the assistant-text heuristic cannot identify the conversation and
+// the connection-level fallback is what has to hold the session together.
+const afterFirstToolCall = {
+  model: "oc/deepseek-v4-flash-free",
+  messages: [
+    { role: "user", content: "List the files in this repo." },
+    {
+      role: "assistant",
+      content: "",
+      tool_calls: [{ id: "call_1", type: "function", function: { name: "ls", arguments: "{}" } }],
+    },
+    { role: "tool", tool_call_id: "call_1", content: "README.md" },
+  ],
+};
+
+function sessionFor(body, credentials) {
+  const ex = new OpenCodeExecutor();
+  ex.transformRequest("oc/deepseek-v4-flash-free", body, true, credentials);
+  return ex.buildHeaders(credentials, true)["x-opencode-session"];
+}
+
+describe("#3262 no-auth free providers keep one upstream session", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("gives the virtual no-auth connection the sentinel connectionId", async () => {
+    const creds = await getProviderCredentials("opencode");
+    expect(creds.connectionId).toBe("noauth");
+    // The value markAccountUnavailable / clearAccountError already test for, so a
+    // free provider is never cooled down as if it were a real account.
+    expect(creds.id).toBe("noauth");
+  });
+
+  it("holds the session across the first tool call", () => {
+    const creds = { rawHeaders: {}, connectionId: "noauth" };
+    expect(sessionFor(afterFirstToolCall, creds)).toBe(sessionFor(userOnly, creds));
+  });
+
+  it("keeps the session reproducible for repeats of the same turn", () => {
+    const creds = { rawHeaders: {}, connectionId: "noauth" };
+    expect(sessionFor(userOnly, creds)).toBe(sessionFor(userOnly, creds));
+  });
+
+  // Without the field every call minted a new ses_, which is what burned the
+  // free-tier quota on the second request of a conversation.
+  it("mints a new session per call when connectionId is missing", () => {
+    const creds = () => ({ rawHeaders: {} });
+    expect(sessionFor(userOnly, creds())).not.toBe(sessionFor(userOnly, creds()));
+  });
+
+  it("still honours a client-supplied session id", () => {
+    const creds = { rawHeaders: { "x-opencode-session": "ses_from_client" }, connectionId: "noauth" };
+    expect(sessionFor(userOnly, creds)).toBe("ses_from_client");
+  });
+});

--- a/tests/unit/provider-base-url-field-3467.test.js
+++ b/tests/unit/provider-base-url-field-3467.test.js
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { buildProviderSpecificData } from "../../src/shared/utils/providerSpecificData.js";
+import REGISTRY from "../../open-sse/providers/registry/index.js";
+
+/**
+ * Self-hosted TTS/STT/embedding connections read their endpoint from
+ * `providerSpecificData.baseUrl`, and their registry entries tell the user to
+ * set it — but the dashboard rendered no field for it, so every connection
+ * created through the UI was saved without one and fell back to a localhost
+ * default. In Docker that default is the 9router container itself (#3467).
+ *
+ * The field is now declared in the registry and read from there, so a provider
+ * that needs a per-connection endpoint cannot be added without one again.
+ */
+const entry = (id) => REGISTRY.find((r) => r.id === id);
+
+describe("registry: providers with a per-connection endpoint declare it", () => {
+  it.each([
+    "selfhosted-tts",
+    "selfhosted-stt",
+    "selfhosted-embedding",
+    "ollama-local",
+  ])("%s declares a baseUrlField", (id) => {
+    const field = entry(id)?.baseUrlField;
+    expect(field, `${id} must declare baseUrlField`).toBeTruthy();
+    expect(typeof field.label).toBe("string");
+    expect(field.label.length).toBeGreaterThan(0);
+    expect(typeof field.placeholder).toBe("string");
+  });
+
+  it("each placeholder matches the default that provider actually falls back to", () => {
+    expect(entry("selfhosted-tts").baseUrlField.placeholder).toBe(
+      entry("selfhosted-tts").ttsConfig.baseUrl,
+    );
+    expect(entry("selfhosted-stt").baseUrlField.placeholder).toBe(
+      entry("selfhosted-stt").sttConfig.baseUrl,
+    );
+  });
+
+  it("providers with a fixed endpoint do not declare one", () => {
+    for (const id of ["openai", "anthropic", "gemini"]) {
+      const e = entry(id);
+      if (e) expect(e.baseUrlField, `${id}`).toBeUndefined();
+    }
+  });
+});
+
+describe("buildProviderSpecificData", () => {
+  it("saves a trimmed baseUrl when the provider declares the field", () => {
+    expect(
+      buildProviderSpecificData({ hasBaseUrlField: true, baseUrl: "  http://tts:8880 " }),
+    ).toEqual({ baseUrl: "http://tts:8880" });
+  });
+
+  it("saves nothing when the box is left empty, so the default still applies", () => {
+    for (const value of ["", "   ", undefined, null]) {
+      expect(buildProviderSpecificData({ hasBaseUrlField: true, baseUrl: value })).toBeUndefined();
+    }
+  });
+
+  it("ignores a typed baseUrl for a provider that does not declare the field", () => {
+    expect(
+      buildProviderSpecificData({ hasBaseUrlField: false, baseUrl: "http://nope" }),
+    ).toBeUndefined();
+  });
+
+  it("still builds the Azure shape", () => {
+    expect(
+      buildProviderSpecificData({
+        isAzure: true,
+        azureData: {
+          azureEndpoint: "https://x.openai.azure.com",
+          apiVersion: "2024-10-01-preview",
+          deployment: "gpt-4o",
+          organization: "org",
+        },
+      }),
+    ).toEqual({
+      azureEndpoint: "https://x.openai.azure.com",
+      apiVersion: "2024-10-01-preview",
+      deployment: "gpt-4o",
+      organization: "org",
+    });
+  });
+
+  it("still builds the Cloudflare and region shapes", () => {
+    expect(
+      buildProviderSpecificData({ isCloudflareAi: true, cloudflareData: { accountId: "acc" } }),
+    ).toEqual({ accountId: "acc" });
+    expect(buildProviderSpecificData({ hasRegions: true, region: "eu" })).toEqual({ region: "eu" });
+    expect(buildProviderSpecificData({ hasRegions: true, region: "" })).toBeUndefined();
+  });
+
+  it("returns nothing for an ordinary provider", () => {
+    expect(buildProviderSpecificData()).toBeUndefined();
+    expect(buildProviderSpecificData({})).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Four provider/model-catalog fixes that were sitting in separate PRs (#3330, #3252, #3529, #3539), rebased onto current `master`. Independent commits.

| commit | defect |
|---|---|
| `fix(auth)` (#3262) | no-auth free providers got a fresh upstream session id per request, so providers that key state on the session saw every call as a new conversation |
| `fix(models)` (#3115) | a curated custom-model list did not suppress the live `/models` fetch, so the catalog came back with the provider's full list instead of the operator's selection |
| `feat(models)` (#3486) | combo entries in `/v1/models` reported no token limits, so clients sizing a request against a combo had nothing to read |
| `fix(providers)` (#3467) | self-hosted TTS/STT/embedding connections had no Base URL field, so they could not point at anything but the default host |

The `#3115` commit reads as larger than it is: most of it is one block moved earlier in `buildModelsList` so that `customModelIds` exists before the dynamic-fetch decision. The behavioural change is the added `&& customModelIds.length === 0` on that condition.

## Verification

Run with **vitest 3** and the repo config — both parts matter:

```
npx vitest@3 run --config tests/vitest.config.js <files>
```

Without `--config` the `@/` alias does not resolve (`Failed to load url @/lib/dataDir.js`). And vitest 2.x cannot run anything that reaches `open-sse/translator/index.js`: it throws `TypeError: register is not a function` at the top-level `register(...)` calls, because `index.js` deliberately relies on function-declaration hoisting to survive the import cycle while Vite 5's SSR transform turns the named import into a call-time property access. I confirmed that failure on clean `master` and on `master` as of 15 Aug, so it is not caused by these changes.

Every fix was checked by reverting it and confirming which test dies. No claim here rests on a test that passes for another reason.
