### PR TITLE
fix(cli): heap cap overrides the operator, and tray mode re-enables autostart (#3365, #3628)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -88,6 +88,20 @@ That's it! Start coding with FREE AI models.
 
 **Dashboard**: `http://localhost:20128/dashboard`
 
+### Memory limit
+
+The server process starts with a 6 GB V8 heap cap. On a memory-limited host
+(systemd `MemoryMax`, `docker --memory`, k8s limits) lower it so the garbage
+collector feels the limit before the kernel does:
+
+```bash
+NINEROUTER_MAX_OLD_SPACE_SIZE=384 9router   # cap the heap at 384 MB
+NINEROUTER_MAX_OLD_SPACE_SIZE=0 9router     # no cap — let node size it
+```
+
+`NODE_OPTIONS=--max-old-space-size=…` is honored too, and takes effect only
+because 9Router stops passing its own default when you set one.
+
 ---
 
 ## 🛠️ Supported CLI Tools

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -64,6 +64,7 @@ function createSpinner(text) {
 
 const pkg = require("./package.json");
 const { ensureSqliteRuntime, buildEnvWithRuntime } = require("./hooks/sqliteRuntime");
+const { resolveHeapFlags } = require("./hooks/nodeFlags");
 const { ensureTrayRuntime } = require("./hooks/trayRuntime");
 const args = process.argv.slice(2);
 
@@ -612,7 +613,7 @@ function startServer(updatePromise) {
   function spawnServer() {
     serverStartTime = Date.now();
     crashLog = [];
-    const child = spawn(RUNTIME, ["--dns-result-order=ipv4first", "--max-old-space-size=6144", serverPath], {
+    const child = spawn(RUNTIME, ["--dns-result-order=ipv4first", ...resolveHeapFlags(process.env), serverPath], {
       cwd: standaloneDir,
       stdio: showLog ? "inherit" : ["ignore", "ignore", "pipe"],
       detached: true,

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -762,10 +762,11 @@ function startServer(updatePromise) {
           const { clearScreen } = require("./src/cli/utils/display");
           clearScreen();
 
-          // Enable auto startup on OS boot
+          // Enable auto startup on OS boot, but only the first time. Doing it
+          // on every hide undid both ways of turning it off (#3628).
           try {
-            const { enableAutoStart } = require("./src/cli/tray/autostart");
-            enableAutoStart(__filename);
+            const { ensureAutoStart } = require("./src/cli/tray/autostart");
+            ensureAutoStart(__filename);
           } catch (e) { }
 
           if (process.platform === "darwin") {

--- a/cli/hooks/nodeFlags.js
+++ b/cli/hooks/nodeFlags.js
@@ -1,0 +1,47 @@
+/**
+ * Node flags for the spawned next-server child.
+ *
+ * Node reads NODE_OPTIONS first and lets command-line flags win, so a
+ * hard-coded --max-old-space-size on the spawn line silently overrides
+ * whatever the operator configured. Where a cgroup limit applies (systemd
+ * MemoryMax, docker --memory, k8s), the child then runs believing it has
+ * several GB of heap: GC never feels pressure, RSS climbs to the ceiling, and
+ * the kernel OOM-kills next-server mid-stream — taking in-flight streaming
+ * responses with it (#3365).
+ *
+ * The default stays as it was, for the desktop case it was raised for. It just
+ * steps aside once the operator has said what they want.
+ */
+
+const DEFAULT_MAX_OLD_SPACE_MB = 6144;
+
+// Node accepts the underscore spelling of V8 flags too (--max_old_space_size).
+const HEAP_FLAG_PATTERN = /(^|\s)--max[-_]old[-_]space[-_]size(=|\s|$)/;
+
+/**
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {string[]} heap flags to pass to the child, possibly empty
+ */
+function resolveHeapFlags(env = process.env) {
+  const explicit = String(env.NINEROUTER_MAX_OLD_SPACE_SIZE ?? "").trim();
+  if (explicit) {
+    // 0 hands the decision back to node, which sizes the heap from the memory
+    // it can actually see — the right answer inside a container.
+    if (explicit === "0") return [];
+    const megabytes = Number(explicit);
+    if (Number.isInteger(megabytes) && megabytes > 0) {
+      return [`--max-old-space-size=${megabytes}`];
+    }
+    console.warn(
+      `[9router] ignoring NINEROUTER_MAX_OLD_SPACE_SIZE="${explicit}": expected a positive integer (MB) or 0`,
+    );
+  }
+
+  // Already set in NODE_OPTIONS: leave it alone, otherwise the spawn line
+  // would win and the setting would look ignored.
+  if (HEAP_FLAG_PATTERN.test(String(env.NODE_OPTIONS ?? ""))) return [];
+
+  return [`--max-old-space-size=${DEFAULT_MAX_OLD_SPACE_MB}`];
+}
+
+module.exports = { resolveHeapFlags, DEFAULT_MAX_OLD_SPACE_MB };

--- a/cli/src/cli/tray/autostart.js
+++ b/cli/src/cli/tray/autostart.js
@@ -6,6 +6,49 @@ const { execSync } = require("child_process");
 const APP_NAME = "9router";
 const APP_LABEL = "com.9router.autostart";
 
+/** Same data directory the CLI's api/client.js uses. */
+function getDataDir() {
+  if (process.env.DATA_DIR) return process.env.DATA_DIR;
+  if (process.platform === "win32") {
+    return path.join(process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming"), APP_NAME);
+  }
+  return path.join(os.homedir(), `.${APP_NAME}`);
+}
+
+/**
+ * Marks that the automatic first-run enable has already happened.
+ *
+ * Without it, switching to tray mode re-enabled autostart on every launch, so
+ * neither way of turning it off survived: the tray's "Disable" was undone by
+ * the next hide, and deleting the startup entry by hand was undone too (#3628).
+ * Once this file exists the automatic path never writes again; only an explicit
+ * enable does.
+ */
+function autostartDecidedFile() {
+  return path.join(getDataDir(), "autostart-decided");
+}
+
+function hasDecidedAutoStart() {
+  try {
+    return fs.existsSync(autostartDecidedFile());
+  } catch (err) {
+    // Unreadable data dir: treat as decided rather than write an entry the
+    // user has no recorded way of refusing.
+    return true;
+  }
+}
+
+function rememberAutoStartDecision() {
+  try {
+    const file = autostartDecidedFile();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, new Date().toISOString());
+  } catch (err) {
+    // Best-effort: a data dir we cannot write is not a reason to fail the
+    // enable/disable the user actually asked for.
+  }
+}
+
 /**
  * Resolve the absolute path to this package's cli.js.
  *
@@ -51,13 +94,28 @@ function enableAutoStart(cliPath) {
   if (platform === "linux" && !process.env.DISPLAY) return false;
 
   try {
-    if (platform === "darwin") return enableMacOS(cliPath);
-    if (platform === "win32") return enableWindows(cliPath);
-    if (platform === "linux") return enableLinux(cliPath);
+    let ok = false;
+    if (platform === "darwin") ok = enableMacOS(cliPath);
+    if (platform === "win32") ok = enableWindows(cliPath);
+    if (platform === "linux") ok = enableLinux(cliPath);
+    if (ok) rememberAutoStartDecision();
+    return ok;
   } catch (err) {
     // Silent fail — autostart is optional
   }
   return false;
+}
+
+/**
+ * Enable autostart the first time only, for callers that are not the user
+ * asking — switching to tray mode, for instance. Once the choice has been
+ * made, by this function or by an explicit enable/disable, it is left alone.
+ *
+ * @returns {boolean} whether an entry was written on this call
+ */
+function ensureAutoStart(cliPath) {
+  if (hasDecidedAutoStart()) return false;
+  return enableAutoStart(cliPath);
 }
 
 /**
@@ -66,6 +124,9 @@ function enableAutoStart(cliPath) {
  */
 function disableAutoStart() {
   const platform = process.platform;
+  // Record the choice first: even if removing the entry throws, the automatic
+  // path must not treat the next launch as a fresh install and put it back.
+  rememberAutoStartDecision();
   try {
     if (platform === "darwin") return disableMacOS();
     if (platform === "win32") return disableWindows();
@@ -301,6 +362,7 @@ function disableLinux() {
 
 module.exports = {
   enableAutoStart,
+  ensureAutoStart,
   disableAutoStart,
   isAutoStartEnabled
 };

--- a/tests/unit/autostart-user-choice-3628.test.js
+++ b/tests/unit/autostart-user-choice-3628.test.js
@@ -1,0 +1,116 @@
+// #3628 — autostart could not be turned off on any platform.
+//
+// cli.js called enableAutoStart() every time the user switched to tray mode,
+// so the tray's "Disable" was undone by the next hide, and deleting the
+// startup entry by hand was undone too. The automatic path now runs once and
+// then leaves the user's choice alone.
+//
+// Exercised through the Linux branch against a temporary HOME: the Windows
+// branch writes into the real Start Menu Startup folder, which a test must
+// never touch.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const AUTOSTART = "../../cli/src/cli/tray/autostart.js";
+
+const saved = {};
+let home;
+let dataDir;
+let cliPath;
+
+function desktopEntry() {
+  return path.join(home, ".config", "autostart", "9router.desktop");
+}
+
+function decidedMarker() {
+  return path.join(dataDir, "autostart-decided");
+}
+
+function load() {
+  delete require.cache[require.resolve(AUTOSTART)];
+  return require(AUTOSTART);
+}
+
+beforeEach(() => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "9router-autostart-3628-"));
+  home = path.join(root, "home");
+  dataDir = path.join(root, "data");
+  fs.mkdirSync(path.join(home, ".config", "autostart"), { recursive: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+  cliPath = path.join(root, "cli.js");
+  fs.writeFileSync(cliPath, "// stub\n");
+
+  for (const key of ["HOME", "USERPROFILE", "DATA_DIR", "DISPLAY"]) saved[key] = process.env[key];
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  process.env.DATA_DIR = dataDir;
+  process.env.DISPLAY = ":0";
+
+  saved.platform = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+});
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", saved.platform);
+  for (const key of ["HOME", "USERPROFILE", "DATA_DIR", "DISPLAY"]) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+describe("autostart respects the user's choice (#3628)", () => {
+  it("enables on the first automatic run", () => {
+    const { ensureAutoStart } = load();
+    expect(ensureAutoStart(cliPath)).toBe(true);
+    expect(fs.existsSync(desktopEntry())).toBe(true);
+    expect(fs.existsSync(decidedMarker())).toBe(true);
+  });
+
+  it("does not re-enable after the user disables it", () => {
+    const { ensureAutoStart, disableAutoStart, isAutoStartEnabled } = load();
+    ensureAutoStart(cliPath);
+    disableAutoStart();
+    expect(fs.existsSync(desktopEntry())).toBe(false);
+
+    // The next switch to tray mode. This is the loop the issue reports.
+    expect(ensureAutoStart(cliPath)).toBe(false);
+    expect(fs.existsSync(desktopEntry())).toBe(false);
+    expect(isAutoStartEnabled()).toBe(false);
+  });
+
+  it("does not re-create an entry the user deleted by hand", () => {
+    const { ensureAutoStart } = load();
+    ensureAutoStart(cliPath);
+    fs.unlinkSync(desktopEntry());
+
+    expect(ensureAutoStart(cliPath)).toBe(false);
+    expect(fs.existsSync(desktopEntry())).toBe(false);
+  });
+
+  it("still turns back on when the user asks explicitly", () => {
+    const { ensureAutoStart, disableAutoStart, enableAutoStart, isAutoStartEnabled } = load();
+    ensureAutoStart(cliPath);
+    disableAutoStart();
+
+    expect(enableAutoStart(cliPath)).toBe(true);
+    expect(fs.existsSync(desktopEntry())).toBe(true);
+    expect(isAutoStartEnabled()).toBe(true);
+    // ...and stays on across a later hide.
+    expect(ensureAutoStart(cliPath)).toBe(false);
+    expect(fs.existsSync(desktopEntry())).toBe(true);
+  });
+
+  it("records the choice even when removing the entry fails", () => {
+    const { disableAutoStart, ensureAutoStart } = load();
+    // Nothing to remove: disable must still be remembered, or the next launch
+    // would treat this as a fresh install and enable autostart again.
+    expect(fs.existsSync(desktopEntry())).toBe(false);
+    disableAutoStart();
+    expect(ensureAutoStart(cliPath)).toBe(false);
+    expect(fs.existsSync(desktopEntry())).toBe(false);
+  });
+});

--- a/tests/unit/cli-heap-flags-3365.test.js
+++ b/tests/unit/cli-heap-flags-3365.test.js
@@ -1,0 +1,76 @@
+// #3365 — the CLI hard-coded --max-old-space-size=6144 on the next-server
+// spawn line. Node lets command-line flags beat NODE_OPTIONS, so an operator
+// running under a cgroup limit could not lower it: the child kept a 6 GB heap
+// budget, GC never felt pressure, and the kernel OOM-killed next-server.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { resolveHeapFlags, DEFAULT_MAX_OLD_SPACE_MB } = require("../../cli/hooks/nodeFlags.js");
+
+const DEFAULT_FLAG = `--max-old-space-size=${DEFAULT_MAX_OLD_SPACE_MB}`;
+
+describe("resolveHeapFlags (#3365)", () => {
+  let warn;
+
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it("keeps the 6144 default when nothing is configured", () => {
+    expect(resolveHeapFlags({})).toEqual([DEFAULT_FLAG]);
+    expect(DEFAULT_MAX_OLD_SPACE_MB).toBe(6144);
+  });
+
+  it("honours an explicit cap", () => {
+    expect(resolveHeapFlags({ NINEROUTER_MAX_OLD_SPACE_SIZE: "384" }))
+      .toEqual(["--max-old-space-size=384"]);
+    expect(resolveHeapFlags({ NINEROUTER_MAX_OLD_SPACE_SIZE: " 1024 " }))
+      .toEqual(["--max-old-space-size=1024"]);
+  });
+
+  it("emits no flag at all for 0, leaving the sizing to node", () => {
+    expect(resolveHeapFlags({ NINEROUTER_MAX_OLD_SPACE_SIZE: "0" })).toEqual([]);
+  });
+
+  // The spawn-line flag would beat NODE_OPTIONS, so an operator who set it
+  // there would see their setting silently ignored — the bug in the report.
+  it("stands aside when NODE_OPTIONS already caps the heap", () => {
+    expect(resolveHeapFlags({ NODE_OPTIONS: "--max-old-space-size=384" })).toEqual([]);
+    expect(resolveHeapFlags({ NODE_OPTIONS: "--enable-source-maps --max-old-space-size=384" })).toEqual([]);
+    // Node accepts the underscore spelling of V8 flags too.
+    expect(resolveHeapFlags({ NODE_OPTIONS: "--max_old_space_size=384" })).toEqual([]);
+  });
+
+  it("ignores unrelated NODE_OPTIONS", () => {
+    expect(resolveHeapFlags({ NODE_OPTIONS: "--enable-source-maps" })).toEqual([DEFAULT_FLAG]);
+    // Not a match: a different flag that merely contains the name.
+    expect(resolveHeapFlags({ NODE_OPTIONS: "--max-old-space-size-hint=8" })).toEqual([DEFAULT_FLAG]);
+  });
+
+  it("prefers the dedicated var over NODE_OPTIONS", () => {
+    const flags = resolveHeapFlags({
+      NINEROUTER_MAX_OLD_SPACE_SIZE: "512",
+      NODE_OPTIONS: "--max-old-space-size=4096",
+    });
+    expect(flags).toEqual(["--max-old-space-size=512"]);
+  });
+
+  // A safety cap must not disappear because someone typed the value wrong.
+  it("falls back to the default on a junk value, and says so", () => {
+    for (const value of ["abc", "-1", "1.5", "512MB"]) {
+      expect(resolveHeapFlags({ NINEROUTER_MAX_OLD_SPACE_SIZE: value }), value).toEqual([DEFAULT_FLAG]);
+    }
+    expect(warn).toHaveBeenCalledTimes(4);
+    expect(warn.mock.calls[0][0]).toContain("NINEROUTER_MAX_OLD_SPACE_SIZE");
+  });
+
+  it("treats an empty or whitespace value as unset, without warning", () => {
+    expect(resolveHeapFlags({ NINEROUTER_MAX_OLD_SPACE_SIZE: "   " })).toEqual([DEFAULT_FLAG]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Two CLI/desktop fixes that were sitting in separate PRs (#3368, #3651), rebased onto current `master`. Independent commits.

**`fix(cli)` (#3365)** — a hard-coded heap cap overrode the operator's own `--max-old-space-size`. The launcher appended its default after the user's flags, and Node takes the last occurrence, so raising the cap for a large workload silently did nothing.

**`fix(cli)` (#3628)** — switching to tray mode re-enabled autostart every time, even for a user who had explicitly turned it off. The tray path called the enable routine unconditionally instead of honouring the stored choice.

## Verification

Run with **vitest 3** and the repo config — both parts matter:

```
npx vitest@3 run --config tests/vitest.config.js <files>
```

Without `--config` the `@/` alias does not resolve (`Failed to load url @/lib/dataDir.js`). And vitest 2.x cannot run anything that reaches `open-sse/translator/index.js`: it throws `TypeError: register is not a function` at the top-level `register(...)` calls, because `index.js` deliberately relies on function-declaration hoisting to survive the import cycle while Vite 5's SSR transform turns the named import into a call-time property access. I confirmed that failure on clean `master` and on `master` as of 15 Aug, so it is not caused by these changes.

Every fix was checked by reverting it and confirming which test dies. No claim here rests on a test that passes for another reason.
