### PR TITLE
fix(usage): key-mask collision, double countdown timer, and OpenCode Go quota (#3640, #3470, #3334)

### DIFF
--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -24,6 +24,7 @@ import {
   getOllamaUsage,
   getVercelAiGatewayUsage,
   getQoderUsage,
+  getOpencodeGoUsage,
 } from "./usage/misc.js";
 
 /**
@@ -60,6 +61,7 @@ const USAGE_HANDLERS = {
   deepseek: (c) => getDeepseekUsage(c.apiKey, c.proxyOptions),
   groq: (c) => getGroqUsage(c.apiKey, c.proxyOptions),
   zed: (c) => getZedUsage(c.accessToken, c.providerSpecificData, c.proxyOptions),
+  "opencode-go": (c) => getOpencodeGoUsage(c.apiKey, c.proxyOptions),
 };
 
 export async function getUsageForProvider(connection, proxyOptions = null, options = {}) {

--- a/open-sse/services/usage/misc.js
+++ b/open-sse/services/usage/misc.js
@@ -1,9 +1,9 @@
 /**
- * Misc usage handlers (iFlow, Ollama, GLM, Vercel AI Gateway, Qoder)
+ * Misc usage handlers (iFlow, Ollama, GLM, Vercel AI Gateway, Qoder, OpenCode Go)
  */
 
 import { proxyAwareFetch } from "../../utils/proxyFetch.js";
-import { U } from "./shared.js";
+import { U, parseResetTime } from "./shared.js";
 
 export { getGlmUsage } from "./glm.js";
 
@@ -252,5 +252,111 @@ export async function getQoderUsage(accessToken, proxyOptions = null) {
     };
   } catch (error) {
     return { message: `Qoder connected. Unable to fetch usage: ${error.message}` };
+  }
+}
+
+// OpenCode Go reports each window as a percentage consumed, not absolute counts,
+// so used is the percent and total is 100.
+//
+// Labels carry no duration on purpose: only the rolling window is a fixed span
+// (and its length is server-side plan config, absent from the payload). Weekly
+// resets on a calendar week boundary and monthly on the subscription
+// anniversary, so "7d"/"30d" would be wrong. Each row renders its own countdown
+// from resetAt anyway.
+const OPENCODE_GO_WINDOWS = [
+  { key: "rolling", label: "Rolling" },
+  { key: "weekly", label: "Weekly" },
+  { key: "monthly", label: "Monthly" },
+];
+
+// Errors come back as {type:"error", error:{type, message}} — surface the
+// message rather than echoing the raw JSON envelope at the user.
+async function readOpencodeGoError(response) {
+  const text = await response.text().catch(() => "");
+  if (!text) return "";
+  try {
+    const message = JSON.parse(text)?.error?.message;
+    if (typeof message === "string" && message.trim()) return message.trim();
+  } catch {
+    // not JSON — fall through to the raw text
+  }
+  return text.slice(0, 200);
+}
+
+/**
+ * OpenCode Go Usage
+ */
+export async function getOpencodeGoUsage(apiKey, proxyOptions = null) {
+  if (!apiKey) {
+    return { message: "OpenCode Go API key not available." };
+  }
+
+  const url = U("opencode-go").url;
+  if (!url) {
+    return { message: "OpenCode Go usage endpoint is not configured." };
+  }
+
+  try {
+    const response = await proxyAwareFetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+      },
+    }, proxyOptions);
+
+    if (response.status === 401) {
+      return { message: "OpenCode Go API key invalid or expired." };
+    }
+
+    // 403 is an entitlement error, not an auth error: upstream answers it when
+    // the key authenticates but the account carries no Go subscription. Calling
+    // that an invalid key would send the user off to reissue a working one.
+    if (response.status === 403) {
+      const detail = await readOpencodeGoError(response);
+      return {
+        plan: "OpenCode Go",
+        message: detail || "OpenCode Go subscription required for this account.",
+      };
+    }
+
+    if (!response.ok) {
+      const detail = await readOpencodeGoError(response);
+      return { message: `OpenCode Go usage API error (${response.status})${detail ? `: ${detail}` : ""}` };
+    }
+
+    const data = await response.json().catch(() => null);
+    if (!data || typeof data !== "object") {
+      return { message: "OpenCode Go usage response was not JSON." };
+    }
+
+    const usage = data?.usage || {};
+    const quotas = {};
+
+    for (const { key, label } of OPENCODE_GO_WINDOWS) {
+      const window = usage[key];
+      // Upstream emits all three windows today, but the payload shape has moved
+      // once already. Skip anything unrecognised instead of emitting a 0% bar
+      // that would read as "quota untouched".
+      if (!window || typeof window !== "object") continue;
+      const percent = Number(window.percent);
+      if (!Number.isFinite(percent)) continue;
+      const used = Math.min(100, Math.max(0, percent));
+      quotas[label] = {
+        used,
+        total: 100,
+        remainingPercentage: 100 - used,
+        resetAt: parseResetTime(window.resetsAt),
+        unlimited: false,
+      };
+    }
+
+    if (Object.keys(quotas).length === 0) {
+      return { plan: "OpenCode Go", message: "OpenCode Go connected. No quota windows reported.", quotas: {} };
+    }
+
+    return { plan: "OpenCode Go", quotas };
+  } catch (error) {
+    return { message: `OpenCode Go connected. Unable to fetch usage: ${error.message}` };
   }
 }

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -29,6 +29,7 @@ import {
   setQuotaCache,
   QUOTA_CACHE_KEY,
   REFRESH_INTERVAL_MS,
+  COUNTDOWN_SECONDS,
   CLAUDE_REFRESH_INTERVAL_MS,
   DEPLETED_QUOTA_THRESHOLD,
   AUTO_REFRESH_STORAGE_KEY,
@@ -38,6 +39,7 @@ import {
   ACCOUNT_FILTER_OPTIONS,
   QUOTA_SORT_OPTIONS,
 } from "./utils";
+import { createRefreshTimers, nextCountdown } from "./refreshTimers";
 import Card from "@/shared/components/Card";
 import { ConfirmModal, EditConnectionModal } from "@/shared/components";
 import { USAGE_SUPPORTED_PROVIDERS } from "@/shared/constants/providers";
@@ -135,7 +137,7 @@ export default function ProviderLimits() {
   const [lastUpdated, setLastUpdated] = useState(null);
   const [hasHydratedAutoRefresh, setHasHydratedAutoRefresh] = useState(false);
   const [refreshingAll, setRefreshingAll] = useState(false);
-  const [countdown, setCountdown] = useState(60);
+  const [countdown, setCountdown] = useState(COUNTDOWN_SECONDS);
   const [connectionsLoading, setConnectionsLoading] = useState(true);
   const [deletingId, setDeletingId] = useState(null);
   const [togglingId, setTogglingId] = useState(null);
@@ -169,8 +171,6 @@ export default function ProviderLimits() {
     providerFilteredConnections: 0,
   });
 
-  const intervalRef = useRef(null);
-  const countdownRef = useRef(null);
   const tickCountRef = useRef(0);
 
   const fetchConnections = useCallback(
@@ -467,7 +467,7 @@ export default function ProviderLimits() {
     if (refreshingAll) return;
 
     setRefreshingAll(true);
-    setCountdown(60);
+    setCountdown(COUNTDOWN_SECONDS);
 
     // Throttle Claude: poll its quota every Nth auto-tick (manual force bypasses)
     const tick = (tickCountRef.current += 1);
@@ -646,65 +646,54 @@ export default function ProviderLimits() {
     updateQuotaVisibility(next, previous);
   }, [quotaVisibility, updateQuotaVisibility]);
 
-  // Auto-refresh interval
+  // One owner for both intervals. `refreshAll` is read through a ref so a new
+  // identity does not tear the timers down and restart the 60s window.
+  const refreshAllRef = useRef(refreshAll);
   useEffect(() => {
-    if (!hasHydratedAutoRefresh || !autoRefresh) {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-      if (countdownRef.current) {
-        clearInterval(countdownRef.current);
-        countdownRef.current = null;
-      }
+    refreshAllRef.current = refreshAll;
+  }, [refreshAll]);
+
+  const timers = useMemo(
+    () =>
+      createRefreshTimers({
+        onRefresh: () => refreshAllRef.current(),
+        onTick: () => setCountdown((prev) => nextCountdown(prev, COUNTDOWN_SECONDS)),
+        refreshIntervalMs: REFRESH_INTERVAL_MS,
+      }),
+    []
+  );
+
+  // Auto-refresh interval. Nothing starts while the tab is hidden — the
+  // visibilitychange handler below owns the resume.
+  useEffect(() => {
+    if (!hasHydratedAutoRefresh || !autoRefresh || document.hidden) {
+      timers.stop();
       return;
     }
-
-    // Main refresh interval
-    intervalRef.current = setInterval(() => {
-      refreshAll();
-    }, REFRESH_INTERVAL_MS);
-
-    // Countdown interval
-    countdownRef.current = setInterval(() => {
-      setCountdown((prev) => {
-        if (prev <= 1) return 60;
-        return prev - 1;
-      });
-    }, 1000);
-
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-      if (countdownRef.current) clearInterval(countdownRef.current);
-    };
-  }, [autoRefresh, refreshAll, hasHydratedAutoRefresh]);
+    timers.start();
+    return () => timers.stop();
+  }, [autoRefresh, hasHydratedAutoRefresh, timers]);
 
   // Pause auto-refresh when tab is hidden (Page Visibility API)
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (document.hidden) {
-        if (intervalRef.current) {
-          clearInterval(intervalRef.current);
-          intervalRef.current = null;
-        }
-        if (countdownRef.current) {
-          clearInterval(countdownRef.current);
-          countdownRef.current = null;
-        }
+        timers.stop();
       } else if (autoRefresh && hasHydratedAutoRefresh) {
-        // Resume auto-refresh when tab becomes visible
-        intervalRef.current = setInterval(() => refreshAll(), REFRESH_INTERVAL_MS);
-        countdownRef.current = setInterval(() => {
-          setCountdown((prev) => (prev <= 1 ? 60 : prev - 1));
-        }, 1000);
+        // `start` clears first, so repeated visible events cannot stack.
+        timers.start();
       }
     };
 
     document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
+      // A tab hidden at mount takes the effect above through its early return,
+      // which leaves no cleanup behind — so unmounting after a resume would
+      // otherwise leave both intervals running.
+      timers.stop();
     };
-  }, [autoRefresh, refreshAll, hasHydratedAutoRefresh]);
+  }, [autoRefresh, hasHydratedAutoRefresh, timers]);
 
   const sortedConnections = useMemo(
     () =>

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/refreshTimers.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/refreshTimers.js
@@ -1,0 +1,49 @@
+/**
+ * Ownership of the quota tracker's auto-refresh timers.
+ *
+ * Two places used to create these intervals — the auto-refresh effect and the
+ * `visibilitychange` handler — and each only cleared what its own ref happened
+ * to point at. A hidden→visible transition that raced with the effect re-running
+ * left one pair orphaned and ticking forever, so the countdown dropped two
+ * seconds per second (#3470).
+ *
+ * `start()` always stops first, so calling it twice replaces the timers instead
+ * of doubling them, and there is exactly one owner no matter who calls.
+ */
+export function createRefreshTimers({
+  onRefresh,
+  onTick,
+  refreshIntervalMs,
+  tickMs = 1000,
+}) {
+  let refreshId = null;
+  let tickId = null;
+
+  const stop = () => {
+    if (refreshId !== null) {
+      clearInterval(refreshId);
+      refreshId = null;
+    }
+    if (tickId !== null) {
+      clearInterval(tickId);
+      tickId = null;
+    }
+  };
+
+  const start = () => {
+    stop();
+    refreshId = setInterval(() => onRefresh(), refreshIntervalMs);
+    tickId = setInterval(() => onTick(), tickMs);
+  };
+
+  return {
+    start,
+    stop,
+    isRunning: () => refreshId !== null || tickId !== null,
+  };
+}
+
+/** One countdown step. Wraps back to the full window instead of hitting zero. */
+export function nextCountdown(previous, windowSeconds) {
+  return previous <= 1 ? windowSeconds : previous - 1;
+}

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -3,6 +3,9 @@ import { getModelsByProviderId } from "open-sse/config/providerModels.js";
 // ─── Constants ───────────────────────────────────────────────────────────────
 export const QUOTA_CACHE_KEY = "quotaCacheData";
 export const REFRESH_INTERVAL_MS = 60000;
+// The countdown counts the same window down in seconds; derived so the two
+// cannot drift apart.
+export const COUNTDOWN_SECONDS = REFRESH_INTERVAL_MS / 1000;
 // Claude usage/quota endpoint rate-limits; poll it less often than other providers
 export const CLAUDE_REFRESH_INTERVAL_MS = 600000;
 export const DEPLETED_QUOTA_THRESHOLD = 5;

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -586,8 +586,13 @@ export function parseQuotaData(provider, data) {
         }
         break;
 
+      case "opencode-go":
       case "deepseek":
-        // Credit balance — remainingPercentage only (no absolute remaining).
+        // Credit balance, and OpenCode Go's percent-per-window: forward
+        // remainingPercentage and never an absolute `remaining` (the UI reads
+        // `remaining` as a 0-100 percentage). For a used=percent/total=100 row
+        // the default branch happens to compute the same number, so this case
+        // is for intent and for staying correct if the shape ever changes.
         if (data.quotas) {
           Object.entries(data.quotas).forEach(([name, quota]) => {
             normalizedQuotas.push({

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { EventEmitter } from "events";
 import { getAdapter } from "../driver.js";
 import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
@@ -7,6 +8,23 @@ function maskApiKey(key) {
   if (!key || typeof key !== "string") return null;
   if (key.length <= 8) return key.charAt(0) + "***";
   return key.slice(0, 8) + "***";
+}
+
+/**
+ * A stable, non-secret identity for one API key, used to bucket usage stats.
+ *
+ * The mask cannot serve: keys are minted as sk-{machineId}-{keyId}-{crc}, so
+ * every key on one install shares its first 8 characters and maskApiKey()
+ * folds all of them onto a single bucket (#3640). The key itself cannot serve
+ * either: these bucket names are returned to the dashboard, which is what
+ * AUDIT-002 forbids. The key's own id satisfies both; a deleted or unregistered
+ * key falls back to a digest, so it still gets its own bucket without the
+ * secret ever reaching the response.
+ */
+function apiKeyIdentity(apiKey, keyInfo) {
+  if (!apiKey || typeof apiKey !== "string") return "local-no-key";
+  if (keyInfo?.id) return keyInfo.id;
+  return "anon-" + createHash("sha256").update(apiKey).digest("hex").slice(0, 12);
 }
 
 const PENDING_TIMEOUT_MS = 60 * 1000;
@@ -500,7 +518,7 @@ export async function getUsageStats(period = "all") {
         if (dateKey > (stats.byAccount[accountKey].lastUsed || "")) stats.byAccount[accountKey].lastUsed = dateKey;
       }
 
-      for (const [akKey, ak] of Object.entries(day.byApiKey || {})) {
+      for (const [, ak] of Object.entries(day.byApiKey || {})) {
         const rawModel = ak.rawModel || "";
         const provider = ak.provider || "";
         const providerDisplayName = providerNodeNameMap[provider] || provider;
@@ -509,6 +527,10 @@ export async function getUsageStats(period = "all") {
         const keyName = keyInfo?.name || (apiKeyVal ? apiKeyVal.slice(0, 8) + "..." : "Local (No API Key)");
         const apiKeyMasked = maskApiKey(apiKeyVal);
         const apiKeyKey = apiKeyMasked || "local-no-key";
+        // The stored daily bucket is named by the raw key (aggregateEntryToDay
+        // writes `${apiKey}|${model}|${provider}`). Re-derive the response
+        // bucket so the secret stays in storage and never leaves in the payload.
+        const akKey = `${apiKeyIdentity(apiKeyVal, keyInfo)}|${rawModel}|${provider || "unknown"}`;
         if (!stats.byApiKey[akKey]) {
           stats.byApiKey[akKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cachedTokens: 0, cost: 0, rawModel, provider: providerDisplayName, apiKeyMasked, keyName, apiKeyKey, lastUsed: dateKey };
         }
@@ -555,7 +577,7 @@ export async function getUsageStats(period = "all") {
       }
 
       const apiKeyKey = (e.apiKey && typeof e.apiKey === "string")
-        ? `${e.apiKey}|${e.model}|${e.provider || "unknown"}`
+        ? `${apiKeyIdentity(e.apiKey, apiKeyMap[e.apiKey])}|${e.model}|${e.provider || "unknown"}`
         : "local-no-key";
       if (stats.byApiKey[apiKeyKey] && new Date(ts) > new Date(stats.byApiKey[apiKeyKey].lastUsed)) stats.byApiKey[apiKeyKey].lastUsed = ts;
 
@@ -627,7 +649,10 @@ export async function getUsageStats(period = "all") {
         const keyInfo = apiKeyMap[r.apiKey];
         const keyName = keyInfo?.name || r.apiKey.slice(0, 8) + "...";
         const apiKeyMasked = maskApiKey(r.apiKey);
-        const akKey = `${apiKeyMasked}|${r.model}|${r.provider || "unknown"}`;
+        // Not the mask: every key on one install shares its first 8 characters,
+        // so masking folded them all onto one bucket and the first key seen
+        // absorbed the rest of the install's requests, tokens and cost (#3640).
+        const akKey = `${apiKeyIdentity(r.apiKey, keyInfo)}|${r.model}|${r.provider || "unknown"}`;
         if (!stats.byApiKey[akKey]) {
           stats.byApiKey[akKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cachedTokens: 0, cost: 0, rawModel: r.model, provider: providerDisplayName, apiKeyMasked, keyName, apiKeyKey: apiKeyMasked, lastUsed: r.timestamp };
         }

--- a/tests/unit/opencode-go-usage-3334.test.js
+++ b/tests/unit/opencode-go-usage-3334.test.js
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: vi.fn(),
+}));
+
+import { proxyAwareFetch } from "../../open-sse/utils/proxyFetch.js";
+import { getUsageForProvider } from "../../open-sse/services/usage.js";
+import {
+  USAGE_SUPPORTED_PROVIDERS,
+  USAGE_APIKEY_PROVIDERS,
+} from "../../src/shared/constants/providers.js";
+import {
+  parseQuotaData,
+  getRemainingPercentage,
+} from "../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js";
+
+const USAGE_URL = "https://opencode.ai/zen/go/v1/usage";
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// Mirrors the upstream route (anomalyco/opencode
+// packages/console/app/src/routes/zen/go/v1/usage.ts): every window carries
+// status + a floored 0..100 percent + an ISO resetsAt, and all three are
+// always emitted.
+const FULL_USAGE = {
+  usage: {
+    rolling: { status: "ok", percent: 12, resetsAt: "2026-08-15T18:00:00.000Z" },
+    weekly: { status: "ok", percent: 47, resetsAt: "2026-08-20T00:00:00.000Z" },
+    monthly: { status: "rate-limited", percent: 100, resetsAt: "2026-09-01T00:00:00.000Z" },
+  },
+};
+
+describe("opencode-go registry usage flags", () => {
+  it("is listed for the apikey quota dashboard", () => {
+    expect(USAGE_SUPPORTED_PROVIDERS).toContain("opencode-go");
+    expect(USAGE_APIKEY_PROVIDERS).toContain("opencode-go");
+  });
+
+  it("carries the usage endpoint in the registry, not in the fetcher", async () => {
+    const registry = (await import("../../open-sse/providers/registry/opencode-go.js")).default;
+    expect(registry.transport.usage.url).toBe(USAGE_URL);
+  });
+});
+
+describe("getUsageForProvider(opencode-go)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("GETs the usage endpoint with the Bearer apiKey", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse(FULL_USAGE));
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+
+    expect(usage.message).toBeUndefined();
+    expect(usage.plan).toBe("OpenCode Go");
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = proxyAwareFetch.mock.calls[0];
+    expect(url).toBe(USAGE_URL);
+    expect(opts.method).toBe("GET");
+    expect(opts.headers.Authorization).toBe("Bearer oc-test");
+  });
+
+  it("maps each window to a percent bar with the remainder derived", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse(FULL_USAGE));
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+
+    expect(usage.quotas.Rolling).toMatchObject({ used: 12, total: 100, remainingPercentage: 88 });
+    expect(usage.quotas.Weekly).toMatchObject({ used: 47, total: 100, remainingPercentage: 53 });
+    expect(usage.quotas.Monthly).toMatchObject({ used: 100, total: 100, remainingPercentage: 0 });
+    expect(usage.quotas.Weekly.resetAt).toBe("2026-08-20T00:00:00.000Z");
+  });
+
+  // Labels stay duration-free: weekly resets on a calendar week boundary and
+  // monthly on the subscription anniversary, so "7d"/"30d" would be wrong.
+  it("labels windows without asserting a span", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse(FULL_USAGE));
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+
+    expect(Object.keys(usage.quotas)).toEqual(["Rolling", "Weekly", "Monthly"]);
+  });
+
+  it("skips a window it cannot read instead of emitting a 0% bar", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(
+      jsonResponse({ usage: { rolling: { percent: 5 }, weekly: null, monthly: { percent: "n/a" } } }),
+    );
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+
+    expect(Object.keys(usage.quotas)).toEqual(["Rolling"]);
+    expect(usage.quotas.Rolling.resetAt).toBeNull();
+  });
+
+  it("clamps a percentage outside 0..100", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse({ usage: { weekly: { percent: 130 } } }));
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+
+    expect(usage.quotas.Weekly).toMatchObject({ used: 100, remainingPercentage: 0 });
+  });
+
+  it("reports rather than throws when the payload carries no window", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse({ usage: {} }));
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+
+    expect(usage.quotas).toEqual({});
+    expect(usage.message).toMatch(/no quota windows/i);
+  });
+
+  it("returns a message on a missing key and never calls out", async () => {
+    const missing = await getUsageForProvider({ provider: "opencode-go" });
+    expect(missing.message).toMatch(/api key/i);
+    expect(proxyAwareFetch).not.toHaveBeenCalled();
+  });
+
+  it("calls 401 an invalid key", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(
+      jsonResponse({ type: "error", error: { type: "AuthError", message: "Unauthorized" } }, 401),
+    );
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "bad" });
+
+    expect(usage.message).toMatch(/invalid or expired/i);
+  });
+
+  // Upstream answers 403 EntitlementError when the key is fine but the account
+  // has no Go plan. Calling that an invalid key sends the user to reissue a
+  // working one.
+  it("reports 403 as a missing subscription, not a bad key", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(
+      jsonResponse(
+        { type: "error", error: { type: "EntitlementError", message: "OpenCode Go subscription required." } },
+        403,
+      ),
+    );
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+
+    expect(usage.message).toBe("OpenCode Go subscription required.");
+    expect(usage.message).not.toMatch(/invalid|expired/i);
+  });
+
+  it("surfaces the upstream error message rather than the JSON envelope", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(
+      jsonResponse({ type: "error", error: { type: "ServerError", message: "upstream unavailable" } }, 503),
+    );
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+
+    expect(usage.message).toContain("503");
+    expect(usage.message).toContain("upstream unavailable");
+    expect(usage.message).not.toContain("{");
+  });
+
+  it("returns a message on a non-JSON body and on a transport failure", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(new Response("<html>gateway</html>", { status: 200 }));
+    const garbled = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+    expect(garbled.message).toMatch(/not json/i);
+
+    proxyAwareFetch.mockRejectedValueOnce(new Error("socket hang up"));
+    const down = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+    expect(down.message).toMatch(/socket hang up/i);
+  });
+});
+
+describe("parseQuotaData(opencode-go)", () => {
+  const RAW = {
+    plan: "OpenCode Go",
+    quotas: {
+      Rolling: { used: 12, total: 100, remainingPercentage: 88, resetAt: null },
+      Monthly: { used: 90, total: 100, remainingPercentage: 10, resetAt: null },
+    },
+  };
+
+  it("forwards remainingPercentage for every window", () => {
+    const rows = parseQuotaData("opencode-go", RAW);
+
+    expect(rows.map((r) => r.name)).toEqual(["Rolling", "Monthly"]);
+    expect(rows[0]).toMatchObject({ total: 100, remainingPercentage: 88 });
+    expect(rows[1]).toMatchObject({ total: 100, remainingPercentage: 10 });
+  });
+
+  // The rendered number is what matters, and QuotaTable derives it through
+  // getRemainingPercentage — pin that, not just the field being present.
+  it("renders the remaining percentage the provider reported", () => {
+    const rows = parseQuotaData("opencode-go", RAW);
+
+    expect(rows.map(getRemainingPercentage)).toEqual([88, 10]);
+  });
+});

--- a/tests/unit/quota-refresh-timers-3470.test.js
+++ b/tests/unit/quota-refresh-timers-3470.test.js
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createRefreshTimers,
+  nextCountdown,
+} from "../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/refreshTimers.js";
+import {
+  COUNTDOWN_SECONDS,
+  REFRESH_INTERVAL_MS,
+} from "../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js";
+
+/**
+ * The quota tracker created its intervals in two places — the auto-refresh
+ * effect and the `visibilitychange` handler — and each cleared only what its
+ * own ref pointed at. A second start therefore orphaned the first pair, and the
+ * countdown fell two seconds per second (#3470).
+ *
+ * `createRefreshTimers` is the single owner: `start()` stops first.
+ */
+function build() {
+  const ticks = [];
+  const refreshes = [];
+  const timers = createRefreshTimers({
+    onRefresh: () => refreshes.push(1),
+    onTick: () => ticks.push(1),
+    refreshIntervalMs: REFRESH_INTERVAL_MS,
+  });
+  return { timers, ticks, refreshes };
+}
+
+describe("createRefreshTimers", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("ticks once per second", () => {
+    const { timers, ticks } = build();
+    timers.start();
+    vi.advanceTimersByTime(5000);
+    expect(ticks.length).toBe(5);
+  });
+
+  it("does not double the tick rate when start is called twice", () => {
+    const { timers, ticks } = build();
+    timers.start();
+    // The hidden→visible resume used to add a second pair of intervals.
+    timers.start();
+    vi.advanceTimersByTime(5000);
+    expect(ticks.length).toBe(5);
+  });
+
+  it("stays single-rate across a hide/show cycle", () => {
+    const { timers, ticks } = build();
+    timers.start();
+    vi.advanceTimersByTime(2000);
+    timers.stop();
+    vi.advanceTimersByTime(10_000);
+    expect(ticks.length).toBe(2);
+    timers.start();
+    vi.advanceTimersByTime(3000);
+    expect(ticks.length).toBe(5);
+  });
+
+  it("stops both timers, and stop is idempotent", () => {
+    const { timers, ticks, refreshes } = build();
+    timers.start();
+    timers.stop();
+    timers.stop();
+    vi.advanceTimersByTime(REFRESH_INTERVAL_MS * 2);
+    expect(ticks.length).toBe(0);
+    expect(refreshes.length).toBe(0);
+    expect(timers.isRunning()).toBe(false);
+  });
+
+  it("refreshes on the configured interval, not on the tick", () => {
+    const { timers, refreshes } = build();
+    timers.start();
+    vi.advanceTimersByTime(REFRESH_INTERVAL_MS - 1000);
+    expect(refreshes.length).toBe(0);
+    vi.advanceTimersByTime(1000);
+    expect(refreshes.length).toBe(1);
+  });
+
+  it("reports whether it is running", () => {
+    const { timers } = build();
+    expect(timers.isRunning()).toBe(false);
+    timers.start();
+    expect(timers.isRunning()).toBe(true);
+    timers.stop();
+    expect(timers.isRunning()).toBe(false);
+  });
+
+  it("always calls the latest callback, so a re-render need not restart it", () => {
+    let current = "first";
+    const seen = [];
+    const timers = createRefreshTimers({
+      onRefresh: () => seen.push(current),
+      onTick: () => {},
+      refreshIntervalMs: 1000,
+    });
+    timers.start();
+    vi.advanceTimersByTime(1000);
+    current = "second";
+    vi.advanceTimersByTime(1000);
+    timers.stop();
+    expect(seen).toEqual(["first", "second"]);
+  });
+});
+
+describe("nextCountdown", () => {
+  it("counts down one second at a time", () => {
+    expect(nextCountdown(60, COUNTDOWN_SECONDS)).toBe(59);
+    expect(nextCountdown(2, COUNTDOWN_SECONDS)).toBe(1);
+  });
+
+  it("wraps to the full window instead of hitting zero", () => {
+    expect(nextCountdown(1, COUNTDOWN_SECONDS)).toBe(COUNTDOWN_SECONDS);
+    expect(nextCountdown(0, COUNTDOWN_SECONDS)).toBe(COUNTDOWN_SECONDS);
+  });
+
+  it("keeps the countdown window and the refresh interval in step", () => {
+    expect(COUNTDOWN_SECONDS).toBe(REFRESH_INTERVAL_MS / 1000);
+  });
+});

--- a/tests/unit/security-audit.test.js
+++ b/tests/unit/security-audit.test.js
@@ -48,15 +48,17 @@ describe("AUDIT-002: API key masking", () => {
     expect(livePath.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("byApiKey object keys should use masked key, not raw key", () => {
+  it("byApiKey object keys should never contain the raw key", () => {
     const source = fs.readFileSync(
       path.resolve("src/lib/db/repos/usageRepo.js"),
       "utf-8"
     );
-    // The 24h path should use apiKeyMasked in the akKey template
-    expect(source).toContain("${apiKeyMasked}|${r.model}|${r.provider");
-    // Should NOT use raw r.apiKey in the key
+    // Neither aggregation path may name a response bucket after the secret.
     expect(source).not.toContain("${r.apiKey}|${r.model}|${r.provider");
+    expect(source).not.toContain("${e.apiKey}|${e.model}|${e.provider");
+    // Both derive the bucket name through the shared non-secret identity.
+    expect(source).toContain("function apiKeyIdentity(");
+    expect((source.match(/apiKeyIdentity\(/g) || []).length).toBeGreaterThanOrEqual(4);
   });
 });
 

--- a/tests/unit/usage-api-key-prefix-collision-3640.test.js
+++ b/tests/unit/usage-api-key-prefix-collision-3640.test.js
@@ -1,0 +1,113 @@
+// #3640 — "Usage by API Key" collapsed distinct keys that share an 8-char prefix.
+//
+// Keys are minted as sk-{machineId}-{keyId}-{crc}, so every key issued by one
+// install shares its first 8 characters. The 24h/today branch of getUsageStats
+// grouped on maskApiKey(key), which is exactly those 8 characters, so all keys
+// landed in one bucket: the first one seen kept its name and absorbed the rest
+// of the install's requests, tokens and cost.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { generateApiKeyWithMachine } from "../../src/shared/utils/apiKey.js";
+
+const originalDataDir = process.env.DATA_DIR;
+let tempDir;
+let db;
+
+beforeAll(async () => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-apikey-3640-"));
+  process.env.DATA_DIR = tempDir;
+  vi.resetModules();
+  db = await import("@/lib/db/index.js");
+  await db.initDb();
+});
+
+afterAll(() => {
+  // Best-effort: the adapter has no close(), so on Windows the open SQLite
+  // handle makes rmSync raise EPERM. The OS reclaims the temp dir either way,
+  // and failing teardown must not mask the assertions above.
+  try {
+    if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  } catch {}
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+});
+
+describe("usage by API key (#3640)", () => {
+  it("two keys from one install really do share their first 8 characters", () => {
+    const machineId = "00275ae3";
+    const first = generateApiKeyWithMachine(machineId).key;
+    const second = generateApiKeyWithMachine(machineId).key;
+
+    expect(first).not.toBe(second);
+    expect(first.slice(0, 8)).toBe(second.slice(0, 8));
+  });
+
+  it("keeps a separate bucket, name and totals for each key", async () => {
+    const machineId = "00275ae3";
+    const clientA = await db.createApiKey("Client-A", machineId);
+    const clientB = await db.createApiKey("Client-B", machineId);
+    expect(clientA.key.slice(0, 8)).toBe(clientB.key.slice(0, 8));
+
+    const record = (apiKey, promptTokens) =>
+      db.saveRequestUsage({
+        provider: "google",
+        model: "gemini-3.7-flash-high",
+        connectionId: "c-3640",
+        apiKey,
+        tokens: { prompt_tokens: promptTokens, completion_tokens: 1 },
+        endpoint: "/v1/chat/completions",
+        status: "ok",
+      });
+
+    await record(clientA.key, 10);
+    await record(clientB.key, 20);
+    await record(clientB.key, 30);
+
+    const stats = await db.getUsageStats("24h");
+    const buckets = Object.values(stats.byApiKey);
+    expect(buckets).toHaveLength(2);
+
+    const byName = Object.fromEntries(buckets.map((b) => [b.keyName, b]));
+    expect(Object.keys(byName).sort()).toEqual(["Client-A", "Client-B"]);
+    expect(byName["Client-A"].requests).toBe(1);
+    expect(byName["Client-A"].promptTokens).toBe(10);
+    expect(byName["Client-B"].requests).toBe(2);
+    expect(byName["Client-B"].promptTokens).toBe(50);
+  });
+
+  it("still reports the key masked, never in full", async () => {
+    const stats = await db.getUsageStats("24h");
+    for (const bucket of Object.values(stats.byApiKey)) {
+      expect(bucket.apiKeyMasked).toMatch(/\*\*\*$/);
+      expect(bucket.apiKeyMasked.length).toBeLessThanOrEqual(11);
+    }
+  });
+});
+
+describe("AUDIT-002 at runtime: the raw key must not reach the response", () => {
+  it("no period puts the raw key in a byApiKey bucket name or payload", async () => {
+    const secret = (await db.createApiKey("Audit-Probe", "00275ae3")).key;
+    await db.saveRequestUsage({
+      provider: "google",
+      model: "gemini-3.7-flash-high",
+      connectionId: "c-audit",
+      apiKey: secret,
+      tokens: { prompt_tokens: 5, completion_tokens: 5 },
+      endpoint: "/v1/chat/completions",
+      status: "ok",
+    });
+
+    // The daily-summary periods read usageDaily, whose stored bucket names are
+    // built from the raw key. Before this fix they were copied into the
+    // response verbatim, which is exactly what the source-text check missed.
+    for (const period of ["24h", "today", "7d", "30d", "all"]) {
+      const stats = await db.getUsageStats(period);
+      expect(JSON.stringify(stats.byApiKey), `period=${period}`).not.toContain(secret);
+      for (const name of Object.keys(stats.byApiKey)) {
+        expect(name, `period=${period}`).not.toContain(secret);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Three usage/quota fixes that were sitting in separate PRs (#3337, #3537, #3650), rebased onto current `master`. Independent commits.

| commit | defect |
|---|---|
| `feat(opencode-go)` (#3334) | OpenCode Go subscription quota was not surfaced on the dashboard |
| `fix(quota)` (#3470) | the auto-refresh countdown ran two interval owners, so the timer jumped and fired twice |
| `fix(usage)` (#3640) | usage was bucketed by an API key's **mask**, and every key minted on one machine shares its first 8 characters — so separate keys collapsed into one row |

The `#3640` one is the load-bearing fix: bucketing by the mask both mis-attributed usage and, in the obvious "just group by the raw key" alternative, would have put the key itself on the dashboard. It buckets by key identity instead, which is why `tests/unit/security-audit.test.js` is touched — that suite pins that no raw key reaches the response.

## Verification

Run with **vitest 3** and the repo config — both parts matter:

```
npx vitest@3 run --config tests/vitest.config.js <files>
```

Without `--config` the `@/` alias does not resolve (`Failed to load url @/lib/dataDir.js`). And vitest 2.x cannot run anything that reaches `open-sse/translator/index.js`: it throws `TypeError: register is not a function` at the top-level `register(...)` calls, because `index.js` deliberately relies on function-declaration hoisting to survive the import cycle while Vite 5's SSR transform turns the named import into a call-time property access. I confirmed that failure on clean `master` and on `master` as of 15 Aug, so it is not caused by these changes.

Every fix was checked by reverting it and confirming which test dies. No claim here rests on a test that passes for another reason.
