### PR TITLE
feat: add model-level circuit breaker for combos

### DIFF
--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -6,6 +6,15 @@ import { checkFallbackError, formatRetryAfter } from "./accountFallback.js";
 import { unavailableResponse } from "../utils/error.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { extractTextContent } from "../translator/formats/gemini.js";
+import {
+  beginComboModelAttempt,
+  classifyComboFailure,
+  inspectSuccessfulComboResponse,
+  parseRetryAfterMs,
+  recordComboModelFailure,
+  recordComboModelSuccess,
+  runManualComboModelProbe,
+} from "./comboCircuitBreaker.js";
 
 // Hard capabilities = input modalities; missing one drops request data (e.g. image
 // stripped). Must be prioritized. Soft (e.g. search) only degrades a feature.
@@ -271,13 +280,14 @@ export function getComboModelsFromData(modelStr, combosData) {
  * @param {Object} options.body - Request body
  * @param {string[]} options.models - Array of model strings to try
  * @param {Function} options.handleSingleModel - Function to handle single model: (body, modelStr) => Promise<Response>
+ * @param {Function} [options.probeSingleModel] - Isolated health probe executor: (probeBody, modelStr) => Promise<Response>
  * @param {Object} options.log - Logger object
  * @param {string} [options.comboName] - Name of the combo (for round-robin tracking)
  * @param {string} [options.comboStrategy] - Strategy: "fallback" or "round-robin"
  * @param {number|string} [options.comboStickyLimit=1] - Requests per combo model before switching
  * @returns {Promise<Response>}
  */
-export async function handleComboChat({ body, models, handleSingleModel, log, comboName, comboStrategy, comboStickyLimit = 1, autoSwitch = true }) {
+export async function handleComboChat({ body, models, handleSingleModel, probeSingleModel = null, log, comboName, comboStrategy, comboStickyLimit = 1, autoSwitch = true }) {
   // Apply rotation strategy if enabled
   let rotatedModels = getRotatedModels(models, comboName, comboStrategy, comboStickyLimit);
 
@@ -299,15 +309,79 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
 
   for (let i = 0; i < rotatedModels.length; i++) {
     const modelStr = rotatedModels[i];
-    log.info("COMBO", `Trying model ${i + 1}/${rotatedModels.length}: ${modelStr}`);
+    const circuit = beginComboModelAttempt(modelStr);
+    if (!circuit.allowed) {
+      log.info("CIRCUIT", `Skipping ${modelStr} (${circuit.reason})`, {
+        state: circuit.state?.state,
+        nextProbeAt: circuit.state?.nextProbeAt,
+      });
+      continue;
+    }
+
+    // Chat combos can provide an isolated single-model executor. Use it to run a
+    // minimal completion before releasing an OPEN model back to real user traffic.
+    if (circuit.halfOpen && typeof probeSingleModel === "function") {
+      log.info("CIRCUIT", `Probing ${modelStr} before release`);
+      const probe = await runManualComboModelProbe(
+        modelStr,
+        (probeBody) => probeSingleModel(probeBody, modelStr),
+        { reserved: true },
+      );
+      if (!probe.ok) {
+        lastError = `Recovery probe failed: ${probe.error}`;
+        if (!lastStatus) lastStatus = 503;
+        log.warn("CIRCUIT", `Recovery probe failed for ${modelStr}; keeping circuit open`, {
+          error: probe.error,
+          nextProbeAt: probe.circuit?.nextProbeAt,
+        });
+        continue;
+      }
+      log.info("CIRCUIT", `Recovery probe passed for ${modelStr}; circuit closed`);
+    }
+
+    log.info("COMBO", `Trying model ${i + 1}/${rotatedModels.length}: ${modelStr}${circuit.halfOpen && !probeSingleModel ? " [recovery probe]" : ""}`);
+    const startedAt = Date.now();
 
     try {
       const result = await handleSingleModel(body, modelStr);
       
-      // Success (2xx) - return response
+      // A 2xx only counts as success after the payload is proven non-empty. For
+      // streams, hold the response until the first meaningful event so fallback is
+      // still possible when an upstream returns HTTP 200 with an empty/stalled body.
       if (result.ok) {
+        const inspected = await inspectSuccessfulComboResponse(result, { startedAt });
+        if (!inspected.ok) {
+          const breakerState = recordComboModelFailure(modelStr, {
+            reason: inspected.reason,
+            status: 502,
+            latencyMs: inspected.latencyMs,
+            immediate: true,
+          });
+          lastError = inspected.reason;
+          if (!lastStatus) lastStatus = 502;
+          log.warn("CIRCUIT", `Model ${modelStr} returned an unusable successful response`, {
+            reason: inspected.reason,
+            state: breakerState.state,
+          });
+          continue;
+        }
+
+        if (inspected.slow) {
+          const breakerState = recordComboModelFailure(modelStr, {
+            reason: "slow_response",
+            status: 200,
+            latencyMs: inspected.latencyMs,
+          });
+          log.warn("CIRCUIT", `Model ${modelStr} exceeded the latency threshold`, {
+            latencyMs: inspected.latencyMs,
+            state: breakerState.state,
+          });
+          return inspected.response;
+        }
+
+        recordComboModelSuccess(modelStr, { latencyMs: inspected.latencyMs });
         log.info("COMBO", `Model ${modelStr} succeeded`);
-        return result;
+        return inspected.response;
       }
 
       // Extract error info from response
@@ -329,6 +403,25 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
       // Normalize error text to string (Worker-safe)
       if (typeof errorText !== "string") {
         try { errorText = JSON.stringify(errorText); } catch { errorText = String(errorText); }
+      }
+
+      const classification = classifyComboFailure(result.status, errorText);
+      let circuitRetryAfterMs = parseRetryAfterMs(result);
+      if (!circuitRetryAfterMs && retryAfter) {
+        const retryAt = new Date(retryAfter).getTime();
+        if (Number.isFinite(retryAt) && retryAt > Date.now()) circuitRetryAfterMs = retryAt - Date.now();
+      }
+      const breakerState = recordComboModelFailure(modelStr, {
+        ...classification,
+        status: result.status,
+        latencyMs: Date.now() - startedAt,
+        retryAfterMs: circuitRetryAfterMs,
+      });
+      if (breakerState.state === "open") {
+        log.warn("CIRCUIT", `Opened circuit for ${modelStr}`, {
+          reason: breakerState.lastReason,
+          nextProbeAt: breakerState.nextProbeAt,
+        });
       }
 
       // Check if should fallback to next model
@@ -356,7 +449,12 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
       // Catch unexpected exceptions to ensure fallback continues
       lastError = error.message || String(error);
       if (!lastStatus) lastStatus = 500;
-      log.warn("COMBO", `Model ${modelStr} threw error, trying next`, { error: lastError });
+      const breakerState = recordComboModelFailure(modelStr, {
+        reason: /timeout|timed out|stall/i.test(lastError) ? "timeout" : "request_exception",
+        status: 500,
+        latencyMs: Date.now() - startedAt,
+      });
+      log.warn("COMBO", `Model ${modelStr} threw error, trying next`, { error: lastError, circuit: breakerState.state });
     }
   }
 

--- a/open-sse/services/comboCircuitBreaker.js
+++ b/open-sse/services/comboCircuitBreaker.js
@@ -1,0 +1,404 @@
+const STATE_KEY = "__9routerComboModelCircuitBreakerState";
+
+export const CIRCUIT_STATE = Object.freeze({
+  CLOSED: "closed",
+  OPEN: "open",
+  HALF_OPEN: "half-open",
+});
+
+export const COMBO_CIRCUIT_DEFAULTS = Object.freeze({
+  failureThreshold: 3,
+  slowResponseThresholdMs: 30_000,
+  openDurationMs: 60_000,
+  unsupportedModelCooldownMs: 5 * 60_000,
+  maxOpenDurationMs: 15 * 60_000,
+  firstEventTimeoutMs: 30_000,
+});
+
+function stateStore() {
+  if (!globalThis[STATE_KEY]) globalThis[STATE_KEY] = new Map();
+  return globalThis[STATE_KEY];
+}
+
+function nowIso(now = Date.now()) {
+  return new Date(now).toISOString();
+}
+
+function freshState(model) {
+  return {
+    model,
+    state: CIRCUIT_STATE.CLOSED,
+    consecutiveFailures: 0,
+    openCount: 0,
+    probeInFlight: false,
+    lastReason: null,
+    lastStatus: null,
+    lastLatencyMs: null,
+    lastFailureAt: null,
+    lastSuccessAt: null,
+    lastStateChangeAt: nowIso(),
+    nextProbeAt: null,
+  };
+}
+
+function getMutableState(model) {
+  const store = stateStore();
+  if (!store.has(model)) store.set(model, freshState(model));
+  return store.get(model);
+}
+
+function publicState(state) {
+  return { ...state };
+}
+
+export function getComboCircuitState(model) {
+  return publicState(getMutableState(model));
+}
+
+export function getComboCircuitSnapshot({ includeClosed = false } = {}) {
+  return [...stateStore().values()]
+    .filter((entry) => includeClosed || entry.state !== CIRCUIT_STATE.CLOSED)
+    .map(publicState)
+    .sort((a, b) => a.model.localeCompare(b.model));
+}
+
+export function getComboCircuitConfig() {
+  return { ...COMBO_CIRCUIT_DEFAULTS };
+}
+
+export function clearComboCircuitBreakerState() {
+  stateStore().clear();
+}
+
+export function resetComboCircuitBreaker(model) {
+  stateStore().set(model, freshState(model));
+  return getComboCircuitState(model);
+}
+
+function computeBackoffMs(state, requestedCooldownMs, unsupportedModel) {
+  const base = Math.max(
+    requestedCooldownMs || COMBO_CIRCUIT_DEFAULTS.openDurationMs,
+    unsupportedModel ? COMBO_CIRCUIT_DEFAULTS.unsupportedModelCooldownMs : 0,
+  );
+  const multiplier = 2 ** Math.min(Math.max(state.openCount - 1, 0), 4);
+  return Math.min(base * multiplier, COMBO_CIRCUIT_DEFAULTS.maxOpenDurationMs);
+}
+
+export function beginComboModelAttempt(model, now = Date.now()) {
+  const state = getMutableState(model);
+
+  if (state.state === CIRCUIT_STATE.CLOSED) {
+    return { allowed: true, halfOpen: false, state: publicState(state) };
+  }
+
+  if (state.state === CIRCUIT_STATE.HALF_OPEN) {
+    return { allowed: false, halfOpen: false, reason: "probe-in-flight", state: publicState(state) };
+  }
+
+  const nextProbeMs = state.nextProbeAt ? new Date(state.nextProbeAt).getTime() : 0;
+  if (nextProbeMs > now) {
+    return { allowed: false, halfOpen: false, reason: "circuit-open", state: publicState(state) };
+  }
+
+  state.state = CIRCUIT_STATE.HALF_OPEN;
+  state.probeInFlight = true;
+  state.lastStateChangeAt = nowIso(now);
+  return { allowed: true, halfOpen: true, reason: "recovery-probe", state: publicState(state) };
+}
+
+export function recordComboModelSuccess(model, { latencyMs = null, now = Date.now() } = {}) {
+  const state = getMutableState(model);
+  state.state = CIRCUIT_STATE.CLOSED;
+  state.consecutiveFailures = 0;
+  state.openCount = 0;
+  state.probeInFlight = false;
+  state.lastReason = null;
+  state.lastStatus = 200;
+  state.lastLatencyMs = latencyMs;
+  state.lastSuccessAt = nowIso(now);
+  state.lastStateChangeAt = nowIso(now);
+  state.nextProbeAt = null;
+  return publicState(state);
+}
+
+export function recordComboModelFailure(model, {
+  reason = "upstream_failure",
+  status = null,
+  latencyMs = null,
+  retryAfterMs = null,
+  immediate = false,
+  now = Date.now(),
+} = {}) {
+  const state = getMutableState(model);
+  const unsupportedModel = reason === "unsupported_model";
+
+  state.consecutiveFailures += 1;
+  state.probeInFlight = false;
+  state.lastReason = reason;
+  state.lastStatus = status;
+  state.lastLatencyMs = latencyMs;
+  state.lastFailureAt = nowIso(now);
+
+  const shouldOpen = state.state === CIRCUIT_STATE.HALF_OPEN
+    || immediate
+    || state.consecutiveFailures >= COMBO_CIRCUIT_DEFAULTS.failureThreshold;
+
+  if (!shouldOpen) return publicState(state);
+
+  state.state = CIRCUIT_STATE.OPEN;
+  state.openCount += 1;
+  state.lastStateChangeAt = nowIso(now);
+  const cooldownMs = computeBackoffMs(state, retryAfterMs, unsupportedModel);
+  state.nextProbeAt = nowIso(now + cooldownMs);
+  return publicState(state);
+}
+
+export function parseRetryAfterMs(response, now = Date.now()) {
+  const raw = response?.headers?.get?.("retry-after");
+  if (!raw) return null;
+  const seconds = Number(raw);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  const dateMs = new Date(raw).getTime();
+  return Number.isFinite(dateMs) && dateMs > now ? dateMs - now : null;
+}
+
+export function classifyComboFailure(status, errorText = "") {
+  const text = String(errorText || "").toLowerCase();
+  if (
+    text.includes("model") && (
+      text.includes("not supported")
+      || text.includes("unsupported")
+      || text.includes("not found")
+      || text.includes("does not exist")
+    )
+  ) {
+    return { reason: "unsupported_model", immediate: true };
+  }
+  if (status === 429 || status === 402) return { reason: "rate_limited", immediate: true };
+  if (status === 502 || status === 503 || status === 504) return { reason: "upstream_unavailable", immediate: false };
+  if (status >= 500) return { reason: "upstream_error", immediate: false };
+  return { reason: `http_${status || "error"}`, immediate: false };
+}
+
+function hasMeaningfulStreamData(text, contentType) {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+
+  if (contentType.includes("text/event-stream")) {
+    return text.split(/\r?\n/).some((line) => {
+      if (!line.startsWith("data:")) return false;
+      const payload = line.slice(5).trim();
+      return payload.length > 0 && payload !== "[DONE]";
+    });
+  }
+
+  if (contentType.includes("ndjson") || contentType.includes("stream+json")) {
+    return text.split(/\r?\n/).some((line) => line.trim().length > 0);
+  }
+
+  return true;
+}
+
+async function readWithTimeout(reader, timeoutMs) {
+  let timer;
+  try {
+    return await Promise.race([
+      reader.read(),
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error("first-event-timeout")), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function rebuildResponse(response, reader, bufferedChunks) {
+  const stream = new ReadableStream({
+    start(controller) {
+      for (const chunk of bufferedChunks) controller.enqueue(chunk);
+      (async () => {
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) {
+              controller.close();
+              return;
+            }
+            controller.enqueue(value);
+          }
+        } catch (error) {
+          controller.error(error);
+        }
+      })();
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+
+  return new Response(stream, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: new Headers(response.headers),
+  });
+}
+
+export async function inspectSuccessfulComboResponse(response, {
+  startedAt = Date.now(),
+  firstEventTimeoutMs = COMBO_CIRCUIT_DEFAULTS.firstEventTimeoutMs,
+} = {}) {
+  const contentType = String(response?.headers?.get?.("content-type") || "").toLowerCase();
+  const isStreaming = contentType.includes("text/event-stream")
+    || contentType.includes("ndjson")
+    || contentType.includes("stream+json");
+  const isBinary = contentType.startsWith("audio/")
+    || contentType.startsWith("image/")
+    || contentType.startsWith("video/")
+    || contentType.includes("application/octet-stream");
+
+  if (!response?.body) {
+    return { ok: false, reason: "empty_response", latencyMs: Date.now() - startedAt, response };
+  }
+
+  const contentLength = response.headers?.get?.("content-length");
+  if (contentLength === "0") {
+    return { ok: false, reason: "empty_response", latencyMs: Date.now() - startedAt, response };
+  }
+
+  // Binary combo outputs (TTS/image/etc.) should not be decoded just to prove
+  // semantic text. A non-zero/unknown-length response body is sufficient here.
+  if (isBinary) {
+    const latencyMs = Date.now() - startedAt;
+    return {
+      ok: true,
+      slow: latencyMs > COMBO_CIRCUIT_DEFAULTS.slowResponseThresholdMs,
+      latencyMs,
+      response,
+    };
+  }
+
+  if (!isStreaming) {
+    const text = await response.clone().text();
+    const latencyMs = Date.now() - startedAt;
+    if (!text.trim()) return { ok: false, reason: "empty_response", latencyMs, response };
+    return {
+      ok: true,
+      slow: latencyMs > COMBO_CIRCUIT_DEFAULTS.slowResponseThresholdMs,
+      latencyMs,
+      response,
+    };
+  }
+
+  const reader = response.body.getReader();
+  const bufferedChunks = [];
+  const decoder = new TextDecoder();
+  let decoded = "";
+  const deadline = Date.now() + firstEventTimeoutMs;
+
+  try {
+    while (Date.now() < deadline) {
+      const remaining = Math.max(1, deadline - Date.now());
+      const { done, value } = await readWithTimeout(reader, remaining);
+      if (done) {
+        await reader.cancel().catch(() => {});
+        return { ok: false, reason: "empty_stream", latencyMs: Date.now() - startedAt, response: null };
+      }
+      if (value?.byteLength) {
+        bufferedChunks.push(value);
+        decoded += decoder.decode(value, { stream: true });
+      }
+      if (hasMeaningfulStreamData(decoded, contentType)) {
+        const latencyMs = Date.now() - startedAt;
+        return {
+          ok: true,
+          slow: latencyMs > COMBO_CIRCUIT_DEFAULTS.slowResponseThresholdMs,
+          latencyMs,
+          response: rebuildResponse(response, reader, bufferedChunks),
+        };
+      }
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => {});
+    return {
+      ok: false,
+      reason: error?.message === "first-event-timeout" ? "first_event_timeout" : "stream_probe_error",
+      latencyMs: Date.now() - startedAt,
+      response: null,
+    };
+  }
+
+  await reader.cancel().catch(() => {});
+  return { ok: false, reason: "first_event_timeout", latencyMs: Date.now() - startedAt, response: null };
+}
+
+export function buildComboProbeBody(model) {
+  return {
+    model,
+    messages: [{ role: "user", content: "Reply with OK." }],
+    max_tokens: 8,
+    stream: false,
+  };
+}
+
+/**
+ * Run a minimal real inference against the exact provider/model before releasing
+ * a quarantined combo model. When `reserved` is true, beginComboModelAttempt()
+ * already owns the HALF_OPEN slot and this function completes that probe.
+ */
+export async function runManualComboModelProbe(model, execute, { reserved = false } = {}) {
+  const state = getMutableState(model);
+  if (state.probeInFlight && !reserved) {
+    return { ok: false, error: "A recovery probe is already in progress", circuit: publicState(state) };
+  }
+
+  if (!reserved) {
+    state.state = CIRCUIT_STATE.HALF_OPEN;
+    state.probeInFlight = true;
+    state.lastStateChangeAt = nowIso();
+  }
+  const startedAt = Date.now();
+
+  try {
+    const response = await execute(buildComboProbeBody(model));
+    if (!response?.ok) {
+      let errorText = response?.statusText || "Probe failed";
+      try {
+        const body = await response.clone().text();
+        if (body.trim()) errorText = body;
+      } catch {}
+      const classification = classifyComboFailure(response?.status, errorText);
+      const circuit = recordComboModelFailure(model, {
+        ...classification,
+        status: response?.status || 500,
+        retryAfterMs: parseRetryAfterMs(response),
+        latencyMs: Date.now() - startedAt,
+        immediate: true,
+      });
+      return { ok: false, error: errorText, circuit };
+    }
+
+    const inspected = await inspectSuccessfulComboResponse(response, { startedAt });
+    if (!inspected.ok || inspected.slow) {
+      const reason = inspected.ok ? "slow_response" : inspected.reason;
+      const circuit = recordComboModelFailure(model, {
+        reason,
+        status: inspected.ok ? 200 : 502,
+        latencyMs: inspected.latencyMs,
+        immediate: true,
+      });
+      return { ok: false, error: reason, circuit };
+    }
+
+    const circuit = recordComboModelSuccess(model, { latencyMs: inspected.latencyMs });
+    return { ok: true, circuit };
+  } catch (error) {
+    const circuit = recordComboModelFailure(model, {
+      reason: "probe_exception",
+      status: 500,
+      latencyMs: Date.now() - startedAt,
+      immediate: true,
+    });
+    return { ok: false, error: error?.message || String(error), circuit };
+  }
+}

--- a/src/app/(dashboard)/dashboard/combos/ComboCircuitBreakerPanel.js
+++ b/src/app/(dashboard)/dashboard/combos/ComboCircuitBreakerPanel.js
@@ -1,0 +1,168 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Card } from "@/shared/components";
+
+function humanizeReason(reason) {
+  if (!reason) return "Unknown failure";
+  return reason.replaceAll("_", " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function formatWhen(value) {
+  if (!value) return "—";
+  const ms = new Date(value).getTime() - Date.now();
+  if (!Number.isFinite(ms)) return value;
+  if (ms <= 0) return "Ready for recovery probe";
+  const seconds = Math.ceil(ms / 1000);
+  if (seconds < 60) return `in ${seconds}s`;
+  return `in ${Math.ceil(seconds / 60)}m`;
+}
+
+function StateBadge({ state }) {
+  const label = state === "half-open" ? "Half-open" : "Open";
+  const classes = state === "half-open"
+    ? "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400"
+    : "border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400";
+
+  return (
+    <span className={`inline-flex rounded-full border px-2 py-0.5 text-[11px] font-medium ${classes}`}>
+      {label}
+    </span>
+  );
+}
+
+export default function ComboCircuitBreakerPanel() {
+  const [circuits, setCircuits] = useState([]);
+  const [config, setConfig] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [testing, setTesting] = useState(null);
+  const [message, setMessage] = useState(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const response = await fetch("/api/combos/circuit-breaker", { cache: "no-store" });
+      if (!response.ok) return;
+      const data = await response.json();
+      setCircuits(Array.isArray(data.circuits) ? data.circuits : []);
+      setConfig(data.config || null);
+    } catch {
+      // Keep the panel passive if the endpoint is temporarily unavailable.
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const timer = setInterval(refresh, 5000);
+    return () => clearInterval(timer);
+  }, [refresh]);
+
+  const testNow = async (model) => {
+    setTesting(model);
+    setMessage(null);
+    try {
+      const response = await fetch("/api/combos/circuit-breaker", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model }),
+      });
+      const data = await response.json();
+      if (response.ok && data.ok) {
+        setMessage({ type: "success", text: `${model} passed the recovery probe and was released.` });
+      } else {
+        setMessage({ type: "error", text: `${model} failed the recovery probe: ${data.error || "unknown error"}` });
+      }
+      await refresh();
+    } catch (error) {
+      setMessage({ type: "error", text: error?.message || "Recovery probe failed" });
+    } finally {
+      setTesting(null);
+    }
+  };
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="material-symbols-outlined text-[20px] text-primary">electric_bolt</span>
+              <h2 className="font-semibold text-text-main">Combo Circuit Breaker</h2>
+            </div>
+            <p className="mt-1 text-sm text-text-muted">
+              Unhealthy combo models are quarantined and skipped until a recovery probe succeeds.
+            </p>
+          </div>
+          {config && (
+            <div className="text-xs text-text-muted sm:text-right">
+              <div>{config.failureThreshold} consecutive failures</div>
+              <div>{Math.round(config.slowResponseThresholdMs / 1000)}s latency threshold</div>
+            </div>
+          )}
+        </div>
+
+        {message && (
+          <div className={`rounded-lg border px-3 py-2 text-sm ${
+            message.type === "success"
+              ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+              : "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300"
+          }`}>
+            {message.text}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="text-sm text-text-muted">Loading circuit state…</div>
+        ) : circuits.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border px-4 py-5 text-sm text-text-muted">
+            No combo models are quarantined.
+          </div>
+        ) : (
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="w-full min-w-[760px] text-left text-sm">
+              <thead className="bg-black/[0.025] text-xs text-text-muted dark:bg-white/[0.025]">
+                <tr>
+                  <th className="px-3 py-2 font-medium">Model</th>
+                  <th className="px-3 py-2 font-medium">State</th>
+                  <th className="px-3 py-2 font-medium">Reason</th>
+                  <th className="px-3 py-2 font-medium">Failures</th>
+                  <th className="px-3 py-2 font-medium">Last latency</th>
+                  <th className="px-3 py-2 font-medium">Next recovery probe</th>
+                  <th className="px-3 py-2 text-right font-medium">Action</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {circuits.map((entry) => (
+                  <tr key={entry.model}>
+                    <td className="px-3 py-2">
+                      <code className="font-mono text-xs text-text-main">{entry.model}</code>
+                    </td>
+                    <td className="px-3 py-2"><StateBadge state={entry.state} /></td>
+                    <td className="px-3 py-2 text-xs text-text-muted">{humanizeReason(entry.lastReason)}</td>
+                    <td className="px-3 py-2 text-xs text-text-muted">{entry.consecutiveFailures}</td>
+                    <td className="px-3 py-2 text-xs text-text-muted">
+                      {Number.isFinite(entry.lastLatencyMs) ? `${entry.lastLatencyMs} ms` : "—"}
+                    </td>
+                    <td className="px-3 py-2 text-xs text-text-muted">{formatWhen(entry.nextProbeAt)}</td>
+                    <td className="px-3 py-2 text-right">
+                      <button
+                        type="button"
+                        disabled={testing === entry.model || entry.state === "half-open"}
+                        onClick={() => testNow(entry.model)}
+                        className="inline-flex items-center gap-1 rounded-lg border border-primary/30 px-2.5 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/5 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        <span className="material-symbols-outlined text-[15px]">network_check</span>
+                        {testing === entry.model ? "Testing…" : "Test now"}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/dashboard/combos/layout.js
+++ b/src/app/(dashboard)/dashboard/combos/layout.js
@@ -1,0 +1,10 @@
+import ComboCircuitBreakerPanel from "./ComboCircuitBreakerPanel";
+
+export default function CombosLayout({ children }) {
+  return (
+    <div className="flex flex-col gap-6">
+      {children}
+      <ComboCircuitBreakerPanel />
+    </div>
+  );
+}

--- a/src/app/api/combos/circuit-breaker/route.js
+++ b/src/app/api/combos/circuit-breaker/route.js
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { handleSingleModelChat } from "@/sse/handlers/chat.js";
+import {
+  getComboCircuitConfig,
+  getComboCircuitSnapshot,
+  runManualComboModelProbe,
+} from "open-sse/services/comboCircuitBreaker.js";
+
+export async function GET() {
+  return NextResponse.json({
+    circuits: getComboCircuitSnapshot({ includeClosed: false }),
+    config: getComboCircuitConfig(),
+    checkedAt: new Date().toISOString(),
+  });
+}
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const model = typeof body?.model === "string" ? body.model.trim() : "";
+
+    if (!model || !model.includes("/")) {
+      return NextResponse.json({ error: "A provider/model identifier is required" }, { status: 400 });
+    }
+
+    const result = await runManualComboModelProbe(
+      model,
+      (probeBody) => handleSingleModelChat(
+        probeBody,
+        model,
+        null,
+        null,
+        null,
+        { probeMode: true },
+      ),
+    );
+
+    return NextResponse.json({
+      ...result,
+      model,
+      testedAt: new Date().toISOString(),
+    }, { status: result.ok ? 200 : 503 });
+  } catch (error) {
+    return NextResponse.json({
+      ok: false,
+      error: error?.message || "Circuit breaker probe failed",
+      testedAt: new Date().toISOString(),
+    }, { status: 500 });
+  }
+}

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -131,6 +131,7 @@ export async function handleChat(request, clientRawRequest = null) {
         (b, m) => handleSingleModelChat(b, m, clientRawRequest, request, apiKey),
         adapterAdded
       ),
+      probeSingleModel: (probeBody, m) => handleSingleModelChat(probeBody, m, null, null, null, { probeMode: true }),
       log,
       comboName: modelStr,
       comboStrategy,
@@ -151,6 +152,7 @@ export async function handleChat(request, clientRawRequest = null) {
         (b, m) => handleSingleModelChat(b, m, clientRawRequest, request, apiKey),
         adapterAdded
       ),
+      probeSingleModel: (probeBody, m) => handleSingleModelChat(probeBody, m, null, null, null, { probeMode: true }),
       log,
       comboName: modelStr,
       comboStrategy: getActiveAdapterStrategy(requiredCapabilities, settings)
@@ -161,9 +163,12 @@ export async function handleChat(request, clientRawRequest = null) {
 }
 
 /**
- * Handle single model chat request
+ * Handle one resolved model directly. Exported so internal health probes can
+ * validate a quarantined combo model without routing through the combo again.
+ * `probeMode` returns the first upstream failure without persisting account locks
+ * or rotating through the credential pool.
  */
-async function handleSingleModelChat(body, modelStr, clientRawRequest = null, request = null, apiKey = null) {
+export async function handleSingleModelChat(body, modelStr, clientRawRequest = null, request = null, apiKey = null, options = {}) {
   const modelInfo = await getModelInfo(modelStr);
 
   // If provider is null, this might be a combo name - check and handle
@@ -208,6 +213,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
           (b, m) => handleSingleModelChat(b, m, clientRawRequest, request, apiKey),
           adapterAdded
         ),
+        probeSingleModel: (probeBody, m) => handleSingleModelChat(probeBody, m, null, null, null, { probeMode: true }),
         log,
         comboName: modelStr,
         comboStrategy,
@@ -308,6 +314,10 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     });
 
     if (result.success) return result.response;
+
+    // A circuit-breaker health probe must not poison or rotate the credential pool
+    // when the failure is model/provider scoped. Return the first upstream failure.
+    if (options.probeMode) return result.response;
 
     // Antigravity 409/429: refresh live quota to get exact resetAt before locking
     let quotaResetMs = null;

--- a/tests/unit/combo-circuit-breaker.test.js
+++ b/tests/unit/combo-circuit-breaker.test.js
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { handleComboChat } from "../../open-sse/services/combo.js";
+import {
+  CIRCUIT_STATE,
+  COMBO_CIRCUIT_DEFAULTS,
+  beginComboModelAttempt,
+  classifyComboFailure,
+  clearComboCircuitBreakerState,
+  getComboCircuitState,
+  inspectSuccessfulComboResponse,
+  recordComboModelFailure,
+  recordComboModelSuccess,
+  runManualComboModelProbe,
+} from "../../open-sse/services/comboCircuitBreaker.js";
+
+const log = {
+  info: vi.fn(),
+  warn: vi.fn(),
+};
+
+describe("combo model circuit breaker", () => {
+  beforeEach(() => {
+    clearComboCircuitBreakerState();
+    vi.clearAllMocks();
+  });
+
+  it("opens after consecutive failures, skips traffic, then allows one half-open recovery request", () => {
+    const model = "provider/model-a";
+    const now = Date.now();
+
+    recordComboModelFailure(model, { reason: "upstream_unavailable", status: 503, now });
+    recordComboModelFailure(model, { reason: "upstream_unavailable", status: 503, now: now + 1 });
+    expect(getComboCircuitState(model).state).toBe(CIRCUIT_STATE.CLOSED);
+
+    recordComboModelFailure(model, { reason: "upstream_unavailable", status: 503, now: now + 2 });
+    const opened = getComboCircuitState(model);
+    expect(opened.state).toBe(CIRCUIT_STATE.OPEN);
+    expect(beginComboModelAttempt(model, now + 3).allowed).toBe(false);
+
+    const probeAt = new Date(opened.nextProbeAt).getTime();
+    const probe = beginComboModelAttempt(model, probeAt);
+    expect(probe.allowed).toBe(true);
+    expect(probe.halfOpen).toBe(true);
+    expect(beginComboModelAttempt(model, probeAt + 1).allowed).toBe(false);
+
+    recordComboModelSuccess(model, { latencyMs: 120, now: probeAt + 2 });
+    expect(getComboCircuitState(model).state).toBe(CIRCUIT_STATE.CLOSED);
+  });
+
+  it("keeps circuit state isolated per provider/model", () => {
+    recordComboModelFailure("provider/model-a", {
+      reason: "unsupported_model",
+      status: 404,
+      immediate: true,
+    });
+
+    expect(getComboCircuitState("provider/model-a").state).toBe(CIRCUIT_STATE.OPEN);
+    expect(getComboCircuitState("provider/model-b").state).toBe(CIRCUIT_STATE.CLOSED);
+  });
+
+  it("opens immediately for unsupported models", () => {
+    recordComboModelFailure("provider/dead-model", {
+      reason: "unsupported_model",
+      status: 401,
+      immediate: true,
+    });
+
+    const state = getComboCircuitState("provider/dead-model");
+    expect(state.state).toBe(CIRCUIT_STATE.OPEN);
+    expect(new Date(state.nextProbeAt).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("classifies rate limits as immediate circuit failures", () => {
+    expect(classifyComboFailure(429, "rate limited")).toEqual({
+      reason: "rate_limited",
+      immediate: true,
+    });
+  });
+
+  it("detects an empty successful response", async () => {
+    const response = new Response("", {
+      status: 200,
+      headers: { "Content-Type": "application/json", "Content-Length": "0" },
+    });
+
+    const inspected = await inspectSuccessfulComboResponse(response);
+    expect(inspected.ok).toBe(false);
+    expect(inspected.reason).toBe("empty_response");
+  });
+
+  it("rejects an SSE stream that ends without a meaningful event", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      },
+    });
+    const response = new Response(stream, {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+
+    const inspected = await inspectSuccessfulComboResponse(response, { firstEventTimeoutMs: 100 });
+    expect(inspected.ok).toBe(false);
+    expect(inspected.reason).toBe("empty_stream");
+  });
+
+  it("preserves a valid streaming response after first-event validation", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"Hi"}}]}\n\n'));
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      },
+    });
+    const response = new Response(stream, {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+
+    const inspected = await inspectSuccessfulComboResponse(response, { firstEventTimeoutMs: 100 });
+    expect(inspected.ok).toBe(true);
+    expect(await inspected.response.text()).toContain("Hi");
+  });
+
+  it("marks a valid response as slow when latency exceeds the threshold", async () => {
+    const response = new Response('{"choices":[{"message":{"content":"ok"}}]}', {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const inspected = await inspectSuccessfulComboResponse(response, {
+      startedAt: Date.now() - COMBO_CIRCUIT_DEFAULTS.slowResponseThresholdMs - 1,
+    });
+    expect(inspected.ok).toBe(true);
+    expect(inspected.slow).toBe(true);
+  });
+
+  it("releases an open model only after a successful real inference probe", async () => {
+    const model = "provider/recovering-model";
+    recordComboModelFailure(model, {
+      reason: "upstream_unavailable",
+      status: 503,
+      immediate: true,
+    });
+
+    const execute = vi.fn(async (probeBody) => {
+      expect(probeBody.model).toBe(model);
+      expect(probeBody.stream).toBe(false);
+      expect(probeBody.messages?.[0]?.content).toBe("Reply with OK.");
+      return new Response('{"choices":[{"message":{"content":"OK"}}]}', {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const result = await runManualComboModelProbe(model, execute);
+    expect(result.ok).toBe(true);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(getComboCircuitState(model).state).toBe(CIRCUIT_STATE.CLOSED);
+  });
+
+  it("keeps a model open when its recovery probe fails", async () => {
+    const model = "provider/still-dead-model";
+    recordComboModelFailure(model, {
+      reason: "upstream_unavailable",
+      status: 503,
+      immediate: true,
+    });
+
+    const result = await runManualComboModelProbe(
+      model,
+      async () => new Response('{"error":{"message":"still unavailable"}}', {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(getComboCircuitState(model).state).toBe(CIRCUIT_STATE.OPEN);
+  });
+
+  it("skips an open model inside a combo and immediately tries the next one", async () => {
+    const dead = "provider/dead-model";
+    const healthy = "provider/healthy-model";
+    recordComboModelFailure(dead, {
+      reason: "unsupported_model",
+      status: 401,
+      immediate: true,
+    });
+
+    const handler = vi.fn(async (_body, model) => {
+      if (model === dead) throw new Error("dead model should have been skipped");
+      return new Response('{"choices":[{"message":{"content":"ok"}}]}', {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const response = await handleComboChat({
+      body: { messages: [{ role: "user", content: "hello" }] },
+      models: [dead, healthy],
+      handleSingleModel: handler,
+      log,
+      comboName: "test-combo",
+      comboStrategy: "fallback",
+    });
+
+    expect(response.ok).toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(expect.any(Object), healthy);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a model-level circuit breaker to Combo routing so unhealthy `provider/model` entries are quarantined instead of adding repeated failures and latency to every request.

Related to #3129 and #2951.

## Behavior

- Tracks `CLOSED -> OPEN -> HALF_OPEN -> CLOSED` per exact model.
- Skips open circuits during Combo routing.
- Quarantines unsupported models, rate limits, repeated 5xx/timeouts/slow responses, and empty HTTP 200/stream responses.
- Validates the first meaningful streaming event before considering a model successful.
- Runs a minimal real inference probe (`Reply with OK.`) before releasing a quarantined model.
- Probe mode does not persist account locks or rotate through the credential pool.
- Adds a Combo Circuit Breaker dashboard panel with state, reason, failures, latency, next recovery probe, and **Test now**.

## Tests

Adds unit coverage for circuit transitions, model isolation, rate limits, empty responses/streams, slow responses, successful/failed recovery probes, and Combo fallback around an open circuit.

## Notes

- No new dependencies.
- Circuit state is in-memory via `globalThis`.
- Branch is a single commit on top of current `master` (`v0.5.69`).