### PR TITLE
fix(stream): record the turn when a client hangs up mid-stream (#3488)

### DIFF
--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -484,6 +484,23 @@ export function createSSEStream(options = {}) {
         console.log("Error in flush:", error);
         finalizeStream();
       }
+    },
+
+    // A client that goes away mid-stream cancels the readable, and the Streams
+    // spec then calls `cancel` instead of `flush` -- never both. Recording lived
+    // only in `flush`, so an aborted request left no usage row, no request detail
+    // and nothing in Recent Requests, even though the provider had already
+    // generated (and been charged for) the partial answer. finalizeStream() is
+    // idempotent, so the terminal-event path in transform() still wins when the
+    // client closes after the answer completed.
+    //
+    // RUNTIME SCOPE: this is the Node path. Every disconnect signal in Next
+    // descends from the response's 'close' event, which Bun's node:http
+    // ServerResponse does not emit on a client hangup, so under `start:bun`
+    // nothing cancels this stream and finalizeStream() still only ever runs from
+    // flush() -- exactly as before this change.
+    cancel() {
+      finalizeStream();
     }
   });
 }

--- a/tests/unit/stream-cancel-records-turn.test.js
+++ b/tests/unit/stream-cancel-records-turn.test.js
@@ -1,0 +1,109 @@
+// #3488 — a client that hangs up mid-stream left no trace: no usage row, no
+// request detail, nothing in Recent Requests, even though the provider had
+// already generated (and been charged for) the partial answer.
+//
+// createSSEStream recorded the turn from `flush` only. The Streams spec calls
+// `flush` when the upstream ends and `cancel` when the readable is cancelled —
+// one or the other, never both — so cancelling the reader skipped recording
+// entirely. These tests drive the transformer through both endings and assert
+// the turn is recorded exactly once either way.
+
+import { describe, it, expect, vi } from "vitest";
+
+import { createSSETransformStreamWithLogger } from "../../open-sse/utils/stream.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+const encoder = new TextEncoder();
+
+function build(onStreamComplete) {
+  return createSSETransformStreamWithLogger(
+    FORMATS.OPENAI,
+    FORMATS.OPENAI,
+    "openai",
+    null,
+    null,
+    "gpt-4o",
+    "conn-1",
+    { model: "gpt-4o", messages: [{ role: "user", content: "hi" }] },
+    onStreamComplete,
+  );
+}
+
+// This TransformStream is constructed without a readable queuing strategy, so
+// its readable high-water mark is the default 0 and every `writer.write()`
+// blocks until something reads. A test that writes and only then reads
+// deadlocks — which is what the first two attempts at this file did, five
+// seconds at a time. Keep a reader pumping for the whole test instead.
+function pump(readable) {
+  const reader = readable.getReader();
+  const finished = (async () => {
+    try {
+      for (;;) {
+        const { done } = await reader.read();
+        if (done) return;
+      }
+    } catch {
+      // cancel() rejects the pending read; that is the path under test.
+    }
+  })();
+  return { reader, finished };
+}
+
+const DELTA = 'data: {"choices":[{"delta":{"content":"partial answer"}}]}';
+const BLANK = String.fromCharCode(10, 10);
+const partial = DELTA + BLANK;
+const done = "data: [DONE]" + BLANK;
+
+describe("a stream cancelled mid-answer still records the turn (#3488)", () => {
+  it("records when the client goes away before any terminal event", async () => {
+    const onStreamComplete = vi.fn();
+    const transform = build(onStreamComplete);
+
+    const { reader } = pump(transform.readable);
+    const writer = transform.writable.getWriter();
+    await writer.write(encoder.encode(partial));
+
+    // The client goes away. Cancelling the readable is what the response close
+    // does, and it is why `flush` never runs on this path.
+    await reader.cancel("client-hangup");
+
+    expect(onStreamComplete).toHaveBeenCalledTimes(1);
+    const [content] = onStreamComplete.mock.calls[0];
+    expect(content.content).toContain("partial answer");
+  });
+
+  it("still records exactly once when the upstream ends normally", async () => {
+    const onStreamComplete = vi.fn();
+    const transform = build(onStreamComplete);
+
+    const { finished } = pump(transform.readable);
+    const writer = transform.writable.getWriter();
+    await writer.write(encoder.encode(partial));
+    await writer.close();
+    await finished;
+
+    expect(onStreamComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not record twice when the client closes after the answer completed", async () => {
+    const onStreamComplete = vi.fn();
+    const transform = build(onStreamComplete);
+
+    const { reader } = pump(transform.readable);
+    const writer = transform.writable.getWriter();
+    await writer.write(encoder.encode(partial));
+    await writer.write(encoder.encode(done));
+
+    // finalizeStream() already ran from the terminal event inside transform().
+    // A late disconnect must not add a second row.
+    //
+    // On measuring it: this passes with the `finalized` guard removed too, so it
+    // does not pin that guard. It cannot — once transform() has seen [DONE] the
+    // readable is already closed, so cancel() is never invoked and there is no
+    // second call to suppress. What it does pin is the user-visible property,
+    // which a future cancel path that fires unconditionally would break.
+    await reader.cancel("client-hangup");
+
+    expect(onStreamComplete).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes the half of #3488 that is still open, rewritten against current `master` rather than replaying my earlier patch — `master` has since grown `finalizeStream()`, which does most of what that patch's `finishStream()` did, so the old diff no longer applies and should not.

## What is left

`finalizeStream()` is called from `flush()`, and from `transform()` on a terminal event — the comment above it says why: *"a client that closes right after the terminal event cancels the reader, and flush() never runs."*

The transformer has no `cancel`. The Streams spec calls `flush` when the upstream ends and `cancel` when the readable is cancelled, one or the other and never both, so a client that goes away **before** any terminal event still records nothing: no usage row, no request detail, nothing in Recent Requests — while the provider has already generated, and been charged for, the partial answer.

The change is `cancel()` routed to the same `finalizeStream()`. Four lines of code; the rest is the comment explaining the runtime scope.

**Runtime scope.** This is the Node path. Every disconnect signal in Next descends from the response's `'close'` event, which Bun's `node:http` `ServerResponse` does not emit on a client hangup, so under `start:bun` nothing cancels this stream and `finalizeStream()` still only ever runs from `flush()` — exactly as before. I would rather state that than let the fix look more complete than it is.

## Verification

```
npx vitest@3 run --config tests/vitest.config.js tests/unit/stream-cancel-records-turn.test.js
→ 3 passed
```

(Both parts matter: without `--config` the `@/` alias does not resolve, and vitest 2.x cannot load anything that reaches `open-sse/translator/index.js`.)

Checked by reverting: **removing `cancel()` fails 2 of the 3 tests.**

Two things I measured that are worth writing down, because both cost me time and both would mislead the next reader:

- **The tests keep a reader pumping for their whole body.** This `TransformStream` is built without a readable queuing strategy, so its high-water mark is the default `0` and every `writer.write()` blocks until something reads. My first two attempts wrote and only then read, and deadlocked five seconds at a time — the failure looks like a hang in the code under test, and is not.
- **The third test does not pin the `finalized` guard, and says so in a comment.** I removed the guard to check, and it still passed. It cannot fail: once `transform()` has seen `[DONE]` the readable is already closed, so `cancel()` is never invoked and there is no second call to suppress. The test still earns its place — it pins the user-visible property that a future cancel path firing unconditionally would break — but I am not claiming coverage I do not have.
