### PR TITLE
feat(models): declare capabilities on combo entries in /v1/models (#3901)

### DIFF
--- a/open-sse/services/comboCapabilities.js
+++ b/open-sse/services/comboCapabilities.js
@@ -1,0 +1,55 @@
+/**
+ * Capabilities a combo pool can honour.
+ *
+ * A request routed to a combo may land on any member — `reorderModelsByCapability`
+ * sorts by fit but never drops a model, so fallback can reach any of them. The
+ * pool can therefore only promise a feature every member has: declaring
+ * `tools: true` because one member supports them is a promise the fallback
+ * breaks, silently, on the turn it matters.
+ *
+ * Only the flags a downstream client reads to decide what to send are reported.
+ * The rest of the capability record (thinking wire format, budget ranges, token
+ * limits) describes how to talk to one specific model and does not survive being
+ * merged across a pool, so it is deliberately left off.
+ *
+ * `capsFor` receives one member reference ("alias/model-id") and returns that
+ * model's capabilities; passing it in keeps this pure and lets the caller own
+ * the alias-to-provider mapping.
+ */
+
+// Every member has a definite answer for these: getCapabilitiesForModel merges
+// with DEFAULT_CAPABILITIES, so an unknown model reports the default rather than
+// nothing. That is what makes the conservative AND safe here — there is no
+// "unknown" to mistake for false.
+export const COMBO_REPORTED_CAPABILITIES = [
+  "tools",
+  "vision",
+  "reasoning",
+  "search",
+  "pdf",
+  "audioInput",
+  "videoInput",
+  "imageOutput",
+  "audioOutput",
+];
+
+export function comboCapabilities(members, capsFor) {
+  if (!Array.isArray(members)) return null;
+
+  const usable = members.filter((ref) => typeof ref === "string" && ref.trim() !== "");
+  if (usable.length === 0) return null;
+
+  const result = {};
+  for (const field of COMBO_REPORTED_CAPABILITIES) {
+    let supported = true;
+    for (const ref of usable) {
+      const caps = capsFor(ref);
+      if (caps?.[field] !== true) {
+        supported = false;
+        break;
+      }
+    }
+    result[field] = supported;
+  }
+  return result;
+}

--- a/tests/unit/combo-capabilities-3901.test.js
+++ b/tests/unit/combo-capabilities-3901.test.js
@@ -1,0 +1,90 @@
+// #3901 — combo entries in GET /v1/models carried no `capabilities` object at
+// all, while every single-provider entry declares one. Codex CLI reads that
+// field to decide what tool schema to send, so a combo made it downgrade to two
+// stub tools with empty `parameters.properties` — the model was handed nothing
+// it could actually call, and nothing reported an error.
+
+import { describe, it, expect } from "vitest";
+
+import {
+  comboCapabilities,
+  COMBO_REPORTED_CAPABILITIES,
+} from "../../open-sse/services/comboCapabilities.js";
+
+// Stand-in for getCapabilitiesForModel: a table keyed by member reference.
+const table = (rows) => (ref) => rows[ref];
+
+describe("comboCapabilities (#3901)", () => {
+  it("declares a feature every member has", () => {
+    const caps = comboCapabilities(
+      ["cu/grok", "ag/gemini"],
+      table({
+        "cu/grok": { tools: true, vision: true },
+        "ag/gemini": { tools: true, vision: true },
+      }),
+    );
+    expect(caps.tools).toBe(true);
+    expect(caps.vision).toBe(true);
+  });
+
+  it("withholds a feature one member lacks, even when the others have it", () => {
+    // This is the whole point. Reordering by capability fit does not drop a
+    // member, so fallback can still land on the one without tools; promising
+    // `tools: true` because the first member has them breaks exactly there,
+    // silently, on the turn a tool is needed.
+    const caps = comboCapabilities(
+      ["cu/grok", "kr/text-only"],
+      table({
+        "cu/grok": { tools: true, vision: true },
+        "kr/text-only": { tools: false, vision: false },
+      }),
+    );
+    expect(caps.tools).toBe(false);
+    expect(caps.vision).toBe(false);
+  });
+
+  it("treats a missing member record as not supporting the feature", () => {
+    // capsFor is getCapabilitiesForModel in production, which always answers —
+    // an unknown model gets DEFAULT_CAPABILITIES rather than undefined. If the
+    // lookup ever does come back empty, the pool must not inherit an optimistic
+    // true from its other members.
+    const caps = comboCapabilities(
+      ["cu/grok", "zz/unknown"],
+      table({ "cu/grok": { tools: true } }),
+    );
+    expect(caps.tools).toBe(false);
+  });
+
+  it("reports each flag independently", () => {
+    const caps = comboCapabilities(
+      ["a/one", "b/two"],
+      table({
+        "a/one": { tools: true, vision: true, reasoning: false },
+        "b/two": { tools: true, vision: false, reasoning: false },
+      }),
+    );
+    expect(caps.tools).toBe(true);
+    expect(caps.vision).toBe(false);
+    expect(caps.reasoning).toBe(false);
+  });
+
+  it("returns null for a combo with no usable members", () => {
+    // An absent `capabilities` is what the bug looked like, so it must only
+    // happen when there is genuinely nothing to report — never as a silent
+    // fallback for a combo that does have members.
+    expect(comboCapabilities([], table({}))).toBe(null);
+    expect(comboCapabilities(null, table({}))).toBe(null);
+    expect(comboCapabilities(["", "   "], table({}))).toBe(null);
+  });
+
+  it("reports the flags a client reads, and not the per-model wire details", () => {
+    const caps = comboCapabilities(["a/one"], table({ "a/one": { tools: true } }));
+    expect(Object.keys(caps).sort()).toEqual([...COMBO_REPORTED_CAPABILITIES].sort());
+    // thinkingFormat, thinkingRange, contextWindow and maxOutput describe how to
+    // talk to one specific model; merged across a pool they would be wrong
+    // rather than merely incomplete.
+    for (const field of ["thinkingFormat", "thinkingRange", "contextWindow", "maxOutput"]) {
+      expect(caps).not.toHaveProperty(field);
+    }
+  });
+});


### PR DESCRIPTION
Closes #3901.

Every single-provider entry in `GET /v1/models` declares a `capabilities` object. A combo declared none at all:

```json
{"id":"gpt-5.6-sol","object":"model","owned_by":"combo"}
```

Codex CLI reads that field to decide what tool schema to send on the actual call. Seeing no declared tool support it downgrades, and the reporter's `requestDetails` shows what reaches the provider: two stub tools with empty `parameters.properties` — nothing the model can call, and no error anywhere in the chain. A combo looks like a model that cannot use tools, and the failure reads as the model being bad at its job.

## What it declares

**Only what every member honours.** `reorderModelsByCapability` sorts a combo's members by fit but never drops one — the comment on it says so, "never drops a model (fallback intact)" — so a request can still land on any member. Declaring `tools: true` because the first member supports them is a promise fallback breaks silently, on the turn a tool is actually needed. The conservative AND is the only answer the pool can keep.

That is safe to compute because `getCapabilitiesForModel` always answers: it merges with `DEFAULT_CAPABILITIES`, so an unknown model reports the default (`tools: true`) rather than nothing. There is no "unknown" here to mistake for false.

**Only the flags a client reads to decide what to send** — `tools`, `vision`, `reasoning`, `search`, and the input/output modality flags. `thinkingFormat`, `thinkingRange`, `contextWindow` and `maxOutput` describe how to talk to one specific model; merged across a pool they would be wrong rather than merely incomplete, so they are deliberately left off.

## Verification

```
npx vitest@3 run --config tests/vitest.config.js tests/unit/combo-capabilities-3901.test.js
→ 6 passed
```

`npx next build` — 0 errors.

Checked by breaking it: **changing the AND to an OR** (one member is enough) fails 3 of the 6 — the withheld-feature case, the missing-record case, and the per-flag independence case. That is the mutation that matters here, because OR is the reading that makes the reporter's symptom go away while reintroducing the silent-failure version of it.

One test exists only to pin that an absent `capabilities` is still possible for a combo with genuinely no members, and never as a quiet fallback for one that has them — an absent field is what the bug looked like, so it must not become the error path.

## Note on overlap

This touches the same `else` branch as my #3880, which adds `context_length` / `max_completion_tokens` to combo entries by the same "smallest member" reasoning. They are independent and I have kept this one standalone against `master` so it can be taken on its own; if #3880 goes first this rebases to one hunk, and I am happy to do that.
