### PR TITLE
fix(dashboard): count down to a lock that has not expired

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js
@@ -5,6 +5,7 @@ import { getStatusVariant as getConnectionStatusVariant } from "@/shared/utils/c
 import PropTypes from "prop-types";
 import { Badge, Toggle, Tooltip } from "@/shared/components";
 import CooldownTimer from "./CooldownTimer";
+import { getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
 
 export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst, isLast, onMoveUp, onMoveDown, onToggleActive, onUpdateProxy, onEdit, onDelete, oneByOneStatus = null, autoPing = null }) {
   const [showProxyDropdown, setShowProxyDropdown] = useState(false);
@@ -87,21 +88,16 @@ export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst
   // Use useState + useEffect for impure Date.now() to avoid calling during render
   const [isCooldown, setIsCooldown] = useState(false);
 
-  // Get earliest model lock timestamp (useEffect handles the Date.now() comparison)
-  const modelLockUntil = Object.entries(connection)
-    .filter(([k]) => k.startsWith("modelLock_"))
-    .map(([, v]) => v)
-    .filter(v => !!v)
-    .sort()[0] || null;
+  // Earliest lock that has not expired. The comment this replaces said the
+  // effect handles the Date.now() comparison -- it does, but only for
+  // isCooldown. This value goes to CooldownTimer, which renders nothing once
+  // the target is in the past, so a connection with one lapsed lock and one
+  // live one showed the cooldown badge with no countdown beside it.
+  const modelLockUntil = getEarliestModelLockUntil(connection);
 
   useEffect(() => {
     const checkCooldown = () => {
-      const until = Object.entries(connection)
-        .filter(([k]) => k.startsWith("modelLock_"))
-        .map(([, v]) => v)
-        .filter(v => v && new Date(v).getTime() > Date.now())
-        .sort()[0] || null;
-      setIsCooldown(!!until);
+      setIsCooldown(!!getEarliestModelLockUntil(connection));
     };
 
     checkCooldown();

--- a/src/app/(dashboard)/dashboard/providers/components/ConnectionsCard.js
+++ b/src/app/(dashboard)/dashboard/providers/components/ConnectionsCard.js
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { getStatusVariant as getConnectionStatusVariant } from "@/shared/utils/connectionStatus";
 import PropTypes from "prop-types";
 import { Card, Badge, Button, Modal, Select, Toggle, EditConnectionModal, ConfirmModal } from "@/shared/components";
+import { getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
 
 // ── CooldownTimer ──────────────────────────────────────────────
 function CooldownTimer({ until }) {
@@ -59,16 +60,17 @@ function ConnectionRow({ connection, proxyPools, isOAuth, isFirst, isLast, onMov
   const noProxyText = boundProxyPool?.noProxy || connection.providerSpecificData?.connectionNoProxy || "";
   const proxyBadgeVariant = boundProxyPool?.isActive === true ? "success" : (boundProxyPoolId || hasLegacyProxy) ? "error" : "default";
 
-  const modelLockUntil = Object.entries(connection)
-    .filter(([k]) => k.startsWith("modelLock_"))
-    .map(([, v]) => v).filter(Boolean).sort()[0] || null;
+  // Earliest lock that has not expired. Filtering on truthiness alone returned
+  // a lock that lapsed hours ago whenever a connection carried more than one:
+  // isCooldown (computed in the effect below, which does compare against now)
+  // stayed true from the still-active lock, while this value went to
+  // CooldownTimer, which renders nothing once the target is in the past. The
+  // badge said cooldown and the countdown vanished.
+  const modelLockUntil = getEarliestModelLockUntil(connection);
 
   useEffect(() => {
     const check = () => {
-      const until = Object.entries(connection)
-        .filter(([k]) => k.startsWith("modelLock_"))
-        .map(([, v]) => v).filter(v => v && new Date(v).getTime() > Date.now()).sort()[0] || null;
-      setIsCooldown(!!until);
+      setIsCooldown(!!getEarliestModelLockUntil(connection));
     };
     check();
     const t = modelLockUntil ? setInterval(check, 1000) : null;

--- a/tests/unit/cooldown-timer-expired-lock.test.js
+++ b/tests/unit/cooldown-timer-expired-lock.test.js
@@ -1,0 +1,82 @@
+// A connection carries one flat field per model lock (`modelLock_<model>`, plus
+// `modelLock___all` for the account-level one). The provider cards picked the
+// timestamp for their countdown with
+//
+//   .filter(([k]) => k.startsWith("modelLock_")).map(([, v]) => v).filter(Boolean).sort()[0]
+//
+// — earliest lock, expired or not. `isCooldown` was computed separately, by a
+// scan that *did* compare against now. So on a connection with one lapsed lock
+// and one still live, the badge said cooldown (correct) while the value handed
+// to CooldownTimer was in the past, and CooldownTimer renders nothing once its
+// target has gone by: the countdown silently disappeared exactly when there was
+// more than one lock to count.
+//
+// `getEarliestModelLockUntil` already existed for this — its docblock says "Used
+// for UI cooldown display" — and skips expired entries. These pin its behaviour
+// and that both cards now ask it.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+import { getEarliestModelLockUntil } from "../../open-sse/services/accountFallback.js";
+
+const iso = (msFromNow) => new Date(Date.now() + msFromNow).toISOString();
+
+describe("getEarliestModelLockUntil", () => {
+  it("skips a lapsed lock and returns the earliest live one", () => {
+    // The reported shape: the lapsed lock sorts first, so the old expression
+    // returned it and the countdown had nothing to count down to.
+    const connection = {
+      id: "conn-1",
+      modelLock_old: iso(-3600_000),
+      modelLock_soon: iso(120_000),
+      modelLock_later: iso(600_000),
+    };
+    expect(getEarliestModelLockUntil(connection)).toBe(connection.modelLock_soon);
+  });
+
+  it("returns null when every lock has lapsed", () => {
+    const connection = { modelLock_a: iso(-1000), modelLock_b: iso(-60_000) };
+    expect(getEarliestModelLockUntil(connection)).toBe(null);
+  });
+
+  it("counts the account-level lock like any other", () => {
+    const connection = { modelLock___all: iso(30_000), modelLock_x: iso(90_000) };
+    expect(getEarliestModelLockUntil(connection)).toBe(connection.modelLock___all);
+  });
+
+  it("ignores fields that are not locks", () => {
+    const connection = { id: "c", lastErrorAt: iso(5_000), modelLock_x: iso(50_000) };
+    expect(getEarliestModelLockUntil(connection)).toBe(connection.modelLock_x);
+  });
+
+  it("handles a connection with no locks at all", () => {
+    expect(getEarliestModelLockUntil({ id: "c" })).toBe(null);
+    expect(getEarliestModelLockUntil(null)).toBe(null);
+  });
+});
+
+// The cards are client components and this repo has no React renderer in its
+// test setup, so the wiring is pinned at the source level. Without this, both
+// cards could go back to their own inline scan and every test above would stay
+// green — which is the shape of the bug in the first place.
+describe("the provider cards read the shared helper", () => {
+  const CARDS = [
+    "src/app/(dashboard)/dashboard/providers/components/ConnectionsCard.js",
+    "src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js",
+  ];
+
+  for (const file of CARDS) {
+    const source = readFileSync(new URL("../../" + file, import.meta.url), "utf8");
+
+    it(`${file} imports getEarliestModelLockUntil`, () => {
+      expect(source).toMatch(
+        /import\s*\{\s*getEarliestModelLockUntil\s*\}\s*from\s*["']open-sse\/services\/accountFallback\.js["']/,
+      );
+    });
+
+    it(`${file} no longer scans modelLock_ by hand`, () => {
+      expect(source).not.toMatch(/startsWith\(\s*["']modelLock_["']\s*\)/);
+    });
+  }
+});


### PR DESCRIPTION
A connection carries one flat field per model lock — `modelLock_<model>`, plus `modelLock___all` for the account-level one. Both provider cards picked the timestamp for their countdown like this:

```js
const modelLockUntil = Object.entries(connection)
  .filter(([k]) => k.startsWith("modelLock_"))
  .map(([, v]) => v).filter(Boolean).sort()[0] || null;
```

Earliest lock, **expired or not**. `isCooldown` is computed separately, a few lines below, by a scan that *does* compare against `Date.now()`.

So on a connection with one lapsed lock and one still live — which is the normal state after a per-model cooldown ends while an account-level one is running, or the other way round — the two disagree:

- `isCooldown` → `true`, from the live lock. Correct.
- `modelLockUntil` → the lapsed one, because it sorts first.

`CooldownTimer` sets its label to `""` and returns `null` as soon as its target is in the past. The badge says the connection is in cooldown and the countdown beside it is simply gone, with no error and nothing in the console. `ConnectionRow.js` even carries a comment saying the effect handles the `Date.now()` comparison — it does, but only for `isCooldown`, not for the value that reaches the timer.

## The change

`getEarliestModelLockUntil` already exists in `open-sse/services/accountFallback.js`, its docblock says *"Used for UI cooldown display"*, and it skips expired entries. Both cards now call it — for the timer target and for `isCooldown` — instead of keeping a fourth and fifth hand-rolled copy of the scan.

The literal `"modelLock_"` is currently spelled out in six places across the dashboard and once more as a local `const` in `src/app/api/models/availability/route.js`, all of them re-deriving what `MODEL_LOCK_PREFIX` and this helper already say. I have limited this PR to the two that were actually wrong; the rest is a tidy-up that can stand on its own.

## Verification

```
npx vitest@3 run --config tests/vitest.config.js tests/unit/cooldown-timer-expired-lock.test.js
→ 9 passed
```

`npx next build` — 0 errors.

The first five pin the helper's behaviour, including the exact reported shape: a lapsed lock that sorts first alongside two live ones.

The last four are a source-level check that both cards import the helper and no longer scan `modelLock_` by hand. They are there because this bug is invisible to a behavioural test — the cards are client components and this repo has no React renderer in its test setup, so a card could go back to its own inline scan with every other test still green. That is exactly how the two copies drifted apart in the first place. Reverting `ConnectionsCard.js` alone fails those two cases and nothing else, which is the check I ran.
