### PR TITLE
fix(endpoint): slow the health polls down instead of stopping them

### DIFF
--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -9,8 +9,10 @@ import {
   TUNNEL_PING_INTERVAL_MS,
   TUNNEL_PING_MAX_MS,
   STATUS_POLL_FAST_MS,
+  STATUS_POLL_SLOW_MS,
   REACHABLE_MISS_THRESHOLD,
   CLIENT_PING_FAST_MS,
+  CLIENT_PING_SLOW_MS,
 } from "./endpointConstants";
 import { clientPingUrl, clientPingAny } from "./endpointPing";
 import EndpointRow from "./components/EndpointRow";
@@ -112,8 +114,15 @@ export default function APIPageClient({ machineId }) {
     const allHealthy = tunnelHealthy && tsHealthy;
     const onVisible = () => { if (!document.hidden) syncTunnelStatus(); };
     document.addEventListener("visibilitychange", onVisible);
-    if (allHealthy) return () => document.removeEventListener("visibilitychange", onVisible);
-    const timer = setInterval(() => { if (!document.hidden) syncTunnelStatus(); }, STATUS_POLL_FAST_MS);
+    // Healthy is not a reason to stop looking. Returning here left the page with
+    // no timer at all, so a tunnel that dropped while everything was green was
+    // only noticed on the next visibilitychange -- which never fires if the tab
+    // simply stays open. Slow down instead of stopping; STATUS_POLL_SLOW_MS has
+    // been sitting beside STATUS_POLL_FAST_MS for exactly this.
+    const timer = setInterval(
+      () => { if (!document.hidden) syncTunnelStatus(); },
+      allHealthy ? STATUS_POLL_SLOW_MS : STATUS_POLL_FAST_MS,
+    );
     return () => {
       clearInterval(timer);
       document.removeEventListener("visibilitychange", onVisible);
@@ -148,8 +157,15 @@ export default function APIPageClient({ machineId }) {
     probeBoth();
     const tunnelHealthy = !tunnelEnabled || tunnelReachable;
     const tsHealthy = !tsEnabled || tsReachable;
-    if (tunnelHealthy && tsHealthy) return;
-    const id = setInterval(probeBoth, CLIENT_PING_FAST_MS);
+    // "slow when healthy" (see the comment above this effect) was never written:
+    // the healthy branch returned before any interval was created, so the probe
+    // that exists to keep the UI honest when backend DNS hiccups stopped running
+    // the moment the UI went green -- precisely when nothing else would catch a
+    // tunnel dropping underneath it.
+    const id = setInterval(
+      probeBoth,
+      tunnelHealthy && tsHealthy ? CLIENT_PING_SLOW_MS : CLIENT_PING_FAST_MS,
+    );
     return () => clearInterval(id);
   }, [tunnelEnabled, tunnelUrl, tunnelPublicUrl, tsEnabled, tsUrl, tunnelReachable, tsReachable]);
 

--- a/tests/unit/endpoint-adaptive-poll.test.js
+++ b/tests/unit/endpoint-adaptive-poll.test.js
@@ -1,0 +1,77 @@
+// The endpoint page documents an adaptive polling design:
+//
+//   // Adaptive: slow when healthy, fast when degraded; pause when tab hidden.
+//
+// Two of the three were implemented. "slow when healthy" was not: both effects
+// returned before creating any interval once everything was reachable, so the
+// page stopped polling altogether rather than slowing down. STATUS_POLL_SLOW_MS
+// and CLIENT_PING_SLOW_MS sat unused next to their FAST siblings — the design
+// was written down twice, in a comment and in a constant, and never wired.
+//
+// The consequence is the opposite of what the browser-side probe exists for:
+// its own comment says it runs so the UI stays accurate "even when backend DNS
+// hiccups", and it shut off exactly when the UI was green — the state in which
+// nothing else would notice a tunnel dropping underneath it.
+//
+// The page is a client component and this repo has no React renderer in its test
+// setup, so this is pinned at the source level. A behavioural test is not
+// available; a test that only asserted the constants exist would pass against
+// the bug, which is how it survived.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+const CLIENT = new URL(
+  "../../src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js",
+  import.meta.url,
+);
+const CONSTANTS = new URL(
+  "../../src/app/(dashboard)/dashboard/endpoint/endpointConstants.js",
+  import.meta.url,
+);
+
+const source = readFileSync(CLIENT, "utf8");
+const constants = readFileSync(CONSTANTS, "utf8");
+
+describe("the endpoint page polls slowly when healthy (not never)", () => {
+  it("both SLOW constants are declared", () => {
+    expect(constants).toMatch(/export const STATUS_POLL_SLOW_MS\s*=/);
+    expect(constants).toMatch(/export const CLIENT_PING_SLOW_MS\s*=/);
+  });
+
+  it("slow is genuinely slower than fast", () => {
+    const value = (name) => {
+      const m = constants.match(new RegExp("export const " + name + "\\s*=\\s*(\\d+)"));
+      return m ? Number(m[1]) : NaN;
+    };
+    expect(value("STATUS_POLL_SLOW_MS")).toBeGreaterThan(value("STATUS_POLL_FAST_MS"));
+    expect(value("CLIENT_PING_SLOW_MS")).toBeGreaterThan(value("CLIENT_PING_FAST_MS"));
+  });
+
+  it("the page imports both of them", () => {
+    expect(source).toMatch(/\bSTATUS_POLL_SLOW_MS\b/);
+    expect(source).toMatch(/\bCLIENT_PING_SLOW_MS\b/);
+  });
+
+  it("the status poll picks its interval from health rather than bailing out", () => {
+    expect(source).toMatch(
+      /allHealthy\s*\?\s*STATUS_POLL_SLOW_MS\s*:\s*STATUS_POLL_FAST_MS/,
+    );
+    // The early return is what stopped the timer being created at all.
+    expect(source).not.toMatch(/if\s*\(allHealthy\)\s*return\s*\(\)\s*=>/);
+  });
+
+  it("the client ping picks its interval from health rather than bailing out", () => {
+    expect(source).toMatch(
+      /tunnelHealthy\s*&&\s*tsHealthy\s*\?\s*CLIENT_PING_SLOW_MS\s*:\s*CLIENT_PING_FAST_MS/,
+    );
+    expect(source).not.toMatch(/if\s*\(tunnelHealthy\s*&&\s*tsHealthy\)\s*return;/);
+  });
+
+  it("the hidden-tab guards are still in place", () => {
+    // "pause when tab hidden" is the part of the comment that was true. Slowing
+    // the beat must not turn into a background tab probing every minute forever.
+    expect(source).toMatch(/if\s*\(document\.hidden\)\s*return;/);
+    expect(source).toMatch(/if\s*\(!document\.hidden\)\s*syncTunnelStatus\(\)/);
+  });
+});


### PR DESCRIPTION
The endpoint page states its polling design in a comment:

```js
// Adaptive: slow when healthy, fast when degraded; pause when tab hidden.
```

Two of the three are implemented. **"slow when healthy" is not.** Both effects return before an interval is ever created once everything is reachable:

```js
if (allHealthy) return () => document.removeEventListener("visibilitychange", onVisible);
const timer = setInterval(..., STATUS_POLL_FAST_MS);
```

```js
if (tunnelHealthy && tsHealthy) return;
const id = setInterval(probeBoth, CLIENT_PING_FAST_MS);
```

So the page does not slow down when healthy — it stops. `STATUS_POLL_SLOW_MS` and `CLIENT_PING_SLOW_MS` have been sitting in `endpointConstants.js` beside their `FAST` siblings, never imported. The design was written down twice, in a comment and in a pair of constants, and wired neither time.

## Why it matters more than a stale constant

It inverts what the browser-side probe is for. Its own comment:

> probes tunnel/tailscale URLs directly so UI stays "reachable" even when backend DNS (1.1.1.1) hiccups on `*.ts.net` or `*.trycloudflare.com`

It switches off exactly when the UI is green — which is the state in which nothing else is watching. The effects only re-run when their dependencies change, and their dependencies are the health flags they would have been the ones to update. On a page left open, a tunnel that drops keeps reading as reachable until the user changes tabs and `visibilitychange` fires.

## The change

Pick the interval from health rather than bailing out. The hidden-tab guards are untouched — `probeBoth` still returns immediately on `document.hidden`, and the status poll still checks it — so a background tab does no work at either speed. The miss-debounce (`REACHABLE_MISS_THRESHOLD`, 5 consecutive misses) is untouched too, so the slow path takes five minutes to flip a connection red rather than flipping on one blip.

I have deliberately not changed either constant's value; 30s and 60s are what the file already chose for this.

## Verification

`npx next build` — 0 errors.

```
npx vitest@3 run --config tests/vitest.config.js tests/unit/endpoint-adaptive-poll.test.js
→ 6 passed
```

Reverting `EndpointPageClient.js` fails 3 of the 6 and nothing else.

The tests are source-level assertions, which needs saying plainly: the page is a client component and this repo has no React renderer in its test setup, so I cannot drive the timers. A test that only asserted the SLOW constants exist would have passed against the bug — that is precisely how it survived — so these assert the call sites instead, including that the early returns are gone and that the hidden-tab guards are still there.

**This is a behaviour change, not just a tidy-up**, so it is worth being explicit: it adds one request every 30s (status) and one every 60s (client ping) to a healthy, *visible* endpoint page that previously made none. If stopping when healthy was the intent and the comment is what is wrong, say so and I will send the one-line comment fix and delete the two constants instead.
