### PR TITLE
refactor(usage): one definition of the quota colour thresholds

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaProgressBar.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaProgressBar.js
@@ -1,36 +1,18 @@
 "use client";
 
 import { cn } from "@/shared/utils/cn";
-import { formatResetTime } from "./utils";
+import { formatResetTime, quotaStatusLevel } from "./utils";
 
-// Calculate color based on remaining percentage
-const getColorClasses = (remainingPercentage) => {
-  if (remainingPercentage > 70) {
-    return {
-      text: "text-green-500",
-      bg: "bg-green-500",
-      bgLight: "bg-green-500/10",
-      emoji: "🟢"
-    };
-  }
-  
-  if (remainingPercentage >= 30) {
-    return {
-      text: "text-yellow-500",
-      bg: "bg-yellow-500",
-      bgLight: "bg-yellow-500/10",
-      emoji: "🟡"
-    };
-  }
-  
+// Presentation for each level. The thresholds themselves live in ./utils --
+// this file used to restate them, and so did QuotaTable and getStatusColor.
+const COLOR_CLASSES = {
+  green: { text: "text-green-500", bg: "bg-green-500", bgLight: "bg-green-500/10", emoji: "🟢" },
+  yellow: { text: "text-yellow-500", bg: "bg-yellow-500", bgLight: "bg-yellow-500/10", emoji: "🟡" },
   // 0-29% including 0% (out of quota) - show red
-  return {
-    text: "text-red-500",
-    bg: "bg-red-500",
-    bgLight: "bg-red-500/10",
-    emoji: "🔴"
-  };
+  red: { text: "text-red-500", bg: "bg-red-500", bgLight: "bg-red-500/10", emoji: "🔴" },
 };
+
+const getColorClasses = (remainingPercentage) => COLOR_CLASSES[quotaStatusLevel(remainingPercentage)];
 
 // Format reset time display
 const formatResetTimeDisplay = (resetTime) => {

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaTable.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaTable.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { formatResetTime, getRemainingPercentage } from "./utils";
+import { formatResetTime, getRemainingPercentage, quotaStatusLevel } from "./utils";
 
 const PAGE_SIZE = 10;
 
@@ -39,34 +39,20 @@ function formatResetTimeDisplay(resetTime) {
   }
 }
 
+// Same levels as QuotaProgressBar, different text classes on purpose: this
+// table needs dark-mode variants. Only the presentation differs; where the
+// boundaries sit comes from ./utils.
+const COLOR_CLASSES = {
+  green: { text: "text-green-600 dark:text-green-400", bg: "bg-green-500", bgLight: "bg-green-500/10", emoji: "🟢" },
+  yellow: { text: "text-yellow-600 dark:text-yellow-400", bg: "bg-yellow-500", bgLight: "bg-yellow-500/10", emoji: "🟡" },
+  red: { text: "text-red-600 dark:text-red-400", bg: "bg-red-500", bgLight: "bg-red-500/10", emoji: "🔴" },
+};
+
 /**
  * Get color classes based on remaining percentage
  */
 function getColorClasses(remainingPercentage) {
-  if (remainingPercentage > 70) {
-    return {
-      text: "text-green-600 dark:text-green-400",
-      bg: "bg-green-500",
-      bgLight: "bg-green-500/10",
-      emoji: "🟢",
-    };
-  }
-
-  if (remainingPercentage >= 30) {
-    return {
-      text: "text-yellow-600 dark:text-yellow-400",
-      bg: "bg-yellow-500",
-      bgLight: "bg-yellow-500/10",
-      emoji: "🟡",
-    };
-  }
-
-  return {
-    text: "text-red-600 dark:text-red-400",
-    bg: "bg-red-500",
-    bgLight: "bg-red-500/10",
-    emoji: "🔴",
-  };
+  return COLOR_CLASSES[quotaStatusLevel(remainingPercentage)];
 }
 
 function sortQuotas(quotas, sortMode) {

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -258,16 +258,32 @@ export function formatResetTime(date) {
   }
 }
 
+// The one place the quota thresholds live. QuotaProgressBar and QuotaTable each
+// carried their own copy of `> 70` / `>= 30`, as did getStatusEmoji below, so the
+// same policy was written out four times. They agree today; nothing made them.
+//
+// Returns the level, not a colour, because the callers disagree on presentation
+// for good reasons -- QuotaTable needs dark-mode text variants, the progress bar
+// does not -- while agreeing on where the boundaries are.
+export const QUOTA_STATUS_HEALTHY_ABOVE = 70;
+export const QUOTA_STATUS_WARNING_AT_OR_ABOVE = 30;
+
 /**
- * Get Tailwind color class based on percentage
  * @param {number} percentage - Remaining percentage (0-100)
- * @returns {string} Color name: "green" | "yellow" | "red"
+ * @returns {string} Level: "green" | "yellow" | "red"
  */
-export function getStatusColor(percentage) {
-  if (percentage > 70) return "green";
-  if (percentage >= 30) return "yellow";
+export function quotaStatusLevel(percentage) {
+  if (percentage > QUOTA_STATUS_HEALTHY_ABOVE) return "green";
+  if (percentage >= QUOTA_STATUS_WARNING_AT_OR_ABOVE) return "yellow";
   return "red"; // 0-29% including 0% (out of quota) - show red
 }
+
+/** Tailwind colour name for a remaining percentage. */
+export function getStatusColor(percentage) {
+  return quotaStatusLevel(percentage);
+}
+
+const QUOTA_STATUS_EMOJI = { green: "\u{1F7E2}", yellow: "\u{1F7E1}", red: "\u{1F534}" };
 
 /**
  * Get status emoji based on percentage
@@ -275,9 +291,7 @@ export function getStatusColor(percentage) {
  * @returns {string} Emoji: "🟢" | "🟡" | "🔴"
  */
 export function getStatusEmoji(percentage) {
-  if (percentage > 70) return "🟢";
-  if (percentage >= 30) return "🟡";
-  return "🔴"; // 0-29% including 0% (out of quota) - show red
+  return QUOTA_STATUS_EMOJI[quotaStatusLevel(percentage)];
 }
 
 /**

--- a/tests/unit/quota-status-thresholds.test.js
+++ b/tests/unit/quota-status-thresholds.test.js
@@ -1,0 +1,81 @@
+// The quota colour policy (`> 70` green, `>= 30` yellow, else red) was written
+// out four times: QuotaProgressBar, QuotaTable, getStatusColor and
+// getStatusEmoji. All four agreed, but nothing made them agree -- an edit to one
+// would have shown a model as green in the table and yellow in the progress bar
+// above it, with no test and no type to catch it.
+//
+// These tests pin the boundaries once, and then pin that the consumers still
+// read them from here rather than restating them. The second half is the part
+// that matters: the arithmetic tests below pass just as happily against four
+// copies as against one.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+import {
+  quotaStatusLevel,
+  getStatusColor,
+  getStatusEmoji,
+  QUOTA_STATUS_HEALTHY_ABOVE,
+  QUOTA_STATUS_WARNING_AT_OR_ABOVE,
+} from "../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js";
+
+const DIR = new URL(
+  "../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/",
+  import.meta.url,
+);
+const source = (name) => readFileSync(new URL(name, DIR), "utf8");
+
+describe("quota status thresholds", () => {
+  it("keeps the boundaries the four copies used to agree on", () => {
+    expect(QUOTA_STATUS_HEALTHY_ABOVE).toBe(70);
+    expect(QUOTA_STATUS_WARNING_AT_OR_ABOVE).toBe(30);
+
+    // Green is strictly above 70; 70 itself is yellow. Yellow reaches down to
+    // and includes 30. Everything below, 0 included, is red.
+    expect(quotaStatusLevel(100)).toBe("green");
+    expect(quotaStatusLevel(70.1)).toBe("green");
+    expect(quotaStatusLevel(70)).toBe("yellow");
+    expect(quotaStatusLevel(30)).toBe("yellow");
+    expect(quotaStatusLevel(29.9)).toBe("red");
+    expect(quotaStatusLevel(0)).toBe("red");
+  });
+
+  it("reports the same level through every accessor", () => {
+    const EMOJI = { green: "\u{1F7E2}", yellow: "\u{1F7E1}", red: "\u{1F534}" };
+    for (let p = 0; p <= 100; p += 0.5) {
+      const level = quotaStatusLevel(p);
+      expect(getStatusColor(p), `colour at ${p}%`).toBe(level);
+      expect(getStatusEmoji(p), `emoji at ${p}%`).toBe(EMOJI[level]);
+    }
+  });
+
+  // The wiring. Without these, reverting either component to its own inline
+  // `> 70` / `>= 30` leaves every assertion above green.
+  it("the progress bar reads the shared policy instead of restating it", () => {
+    const src = source("QuotaProgressBar.js");
+    expect(src).toMatch(/import\s*\{[^}]*quotaStatusLevel[^}]*\}\s*from\s*"\.\/utils"/);
+    expect(src).toMatch(/COLOR_CLASSES\[quotaStatusLevel\(/);
+    expect(src).not.toMatch(/remainingPercentage\s*>=?\s*(70|30)\b/);
+  });
+
+  it("the table reads the shared policy instead of restating it", () => {
+    const src = source("QuotaTable.js");
+    expect(src).toMatch(/import\s*\{[^}]*quotaStatusLevel[^}]*\}\s*from\s*"\.\/utils"/);
+    expect(src).toMatch(/COLOR_CLASSES\[quotaStatusLevel\(/);
+    expect(src).not.toMatch(/remainingPercentage\s*>=?\s*(70|30)\b/);
+  });
+
+  it("both consumers cover every level, so no percentage renders undefined", () => {
+    // COLOR_CLASSES is keyed by level; a missing key would return undefined and
+    // the component would read `.text` off it at render time.
+    for (const name of ["QuotaProgressBar.js", "QuotaTable.js"]) {
+      const src = source(name);
+      for (const level of ["green", "yellow", "red"]) {
+        expect(src, `${name} is missing the ${level} entry`).toMatch(
+          new RegExp("\\b" + level + ":\\s*\\{"),
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What this is

`> 70` green / `>= 30` yellow / else red is the quota colour policy. It was written out **four times**:

| file | copy |
| --- | --- |
| `ProviderLimits/QuotaProgressBar.js` | `getColorClasses` |
| `ProviderLimits/QuotaTable.js` | `getColorClasses` |
| `ProviderLimits/utils.js` | `getStatusColor` |
| `ProviderLimits/utils.js` | `getStatusEmoji` |

All four agree today. Nothing makes them: an edit to one would show a model green in the table and yellow in the progress bar directly above it, with no test and no type to catch it.

**No user-visible behaviour changes.** Every percentage maps to exactly the colour and emoji it did before — the first two tests sweep 0–100 in 0.5 steps to say so.

## The change

`quotaStatusLevel()` in `./utils` is now the only place the numbers appear, alongside the two named boundaries.

The two components keep their **own** class tables and map from the level. That split is deliberate: `QuotaTable` needs `dark:` text variants and the progress bar does not, so what legitimately differs between them stays separate from what should not. The two also had `bg`, `bgLight` and `emoji` duplicated verbatim; those are now one line each per level.

Net −18 lines, and an unreachable `return` left behind in `getStatusEmoji` goes with it.

## Evidence

`tests/unit/quota-status-thresholds.test.js`, 5 tests.

The first three are arithmetic and would pass just as happily against four copies as against one — so the last two are the ones doing the work: they assert each component imports `quotaStatusLevel` and no longer contains a `remainingPercentage > 70` of its own.

Two-way mutation, run locally:

| Mutation | Result |
| --- | --- |
| none | 5 / 5 pass |
| `QuotaTable.getColorClasses` restates the thresholds inline | **1 fail** — "the table reads the shared policy instead of restating it"; the four others stay green |

## Caveat

This is a tidy-up, not a bug fix — the copies have not drifted yet. If you would rather not carry a source-level test that pins how a component is written, say so and I will drop the last two tests; the consolidation stands on its own.
