### PR TITLE
fix(cline/clinepass): stop workos:-prefixing ClinePass API keys; add clinepass token refresh

### DIFF
--- a/open-sse/providers/registry/clinepass.js
+++ b/open-sse/providers/registry/clinepass.js
@@ -14,7 +14,11 @@ export default {
     },
   },
   category: "oauth",
-  authModes: ["oauth", "apikey"],
+  // ClinePass authenticates with a plain API key from app.cline.bot/settings/api-keys
+  // (category "apikey"). The OAuth extension flow used by Cline does not issue
+  // tokens that the ClinePass API consumer endpoint accepts (HTTP 401) — see #2333,
+  // so API key is listed first.
+  authModes: ["apikey", "oauth"],
   hasOAuth: true,
   transport: {
     baseUrl: "https://api.cline.bot/api/v1/chat/completions",

--- a/open-sse/services/clinepassModels.js
+++ b/open-sse/services/clinepassModels.js
@@ -48,7 +48,7 @@ export async function resolveClinepassModels(credentials) {
     if (!Array.isArray(rawList)) return null;
 
     const models = rawList
-      .filter((m) => typeof m?.id === "string" && m.id.startsWith("cline-pass/"))
+      .filter((m) => typeof m?.id === "string" && !m.id.startsWith("cline-pass/"))
       .map((m) => ({
         id: m.id,
         name: m.name || m.id,

--- a/open-sse/services/tokenRefresh.js
+++ b/open-sse/services/tokenRefresh.js
@@ -148,6 +148,8 @@ const REFRESH_HANDLERS = {
   "codebuddy-intl": (c, log) => refreshCodebuddyIntlToken(c.refreshToken, log),
   trae: (c, log) => refreshTraeToken(c.refreshToken, c, log),
   cline: (c, log) => refreshClineToken(c.refreshToken, log),
+  // ClinePass shares Cline's WorkOS auth endpoints, so the same refresh works.
+  clinepass: (c, log) => refreshClineToken(c.refreshToken, log),
   zed: () => refreshZedToken(),
   windsurf: (c, log) => refreshWindsurfToken(c, log),
   // Kimi Code OAuth (merged into id `kimi`); legacy id still routes here

--- a/open-sse/shared/clineAuth.js
+++ b/open-sse/shared/clineAuth.js
@@ -6,7 +6,14 @@ export function getClineAccessToken(token) {
   if (typeof token !== "string") return "";
   const trimmed = token.trim();
   if (!trimmed) return "";
-  return trimmed.startsWith("workos:") ? trimmed : `workos:${trimmed}`;
+  if (trimmed.toLowerCase().startsWith("workos:")) return trimmed;
+  // Cline OAuth access tokens are WorkOS JWTs (base64url `eyJ…` header).
+  // ClinePass API keys (category "apikey", e.g. `clp_…`) are NOT JWTs and must
+  // be sent verbatim — prefixing them with `workos:` makes the Cline API reject
+  // the request with HTTP 401 ("Please make sure you're using the latest
+  // version of Cline and re-authenticate your Cline account.").
+  const isWorkOsJwt = /^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/.test(trimmed);
+  return isWorkOsJwt ? `workos:${trimmed}` : trimmed;
 }
 
 export function getClineAuthorizationHeader(token) {

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -81,6 +81,7 @@ export default function ProviderDetailPage() {
   const [oneByOneSummary, setOneByOneSummary] = useState(null);
   const stopOneByOneRef = useRef(false);
   const [importingQoderModels, setImportingQoderModels] = useState(false);
+  const [importingClineModels, setImportingClineModels] = useState(false);
   const { copied, copy } = useCopyToClipboard();
 
   const AG_RISK_STORAGE_KEY = "ag_risk_confirmed";
@@ -610,6 +611,53 @@ export default function ProviderDetailPage() {
       alert(translate("Error fetching models") + ": " + error.message);
     } finally {
       setImportingQoderModels(false);
+    }
+  };
+  // Fetch the live Cline /models catalog and add every model not yet present.
+  // Cline and ClinePass share the same catalog endpoint (api.cline.bot/api/v1/models).
+  const handleImportClineModels = async () => {
+    if (importingClineModels) return;
+    const activeConnection = connections.find((conn) => conn.isActive !== false);
+    if (!activeConnection) {
+      alert(translate("Please add an active Cline connection first"));
+      return;
+    }
+    setImportingClineModels(true);
+    try {
+      const res = await fetch(`/api/providers/${activeConnection.id}/models`);
+      const data = await res.json();
+      if (!res.ok) {
+        alert(data.error || translate("Failed to fetch models"));
+        return;
+      }
+      const models = data.models || [];
+      if (models.length === 0) {
+        alert(translate("No models returned"));
+        return;
+      }
+      let importedCount = 0;
+      for (const model of models) {
+        const modelId = model.id || model.name;
+        if (!modelId) continue;
+        const alreadyExists = customModels.some(
+          (entry) => entry.providerAlias === providerStorageAlias && entry.id === modelId && (entry.kind || entry.type || "llm") === "llm"
+        ) || Object.values(modelAliases).includes(`${providerStorageAlias}/${modelId}`);
+        if (alreadyExists) {
+          continue;
+        }
+        await handleAddCustomModel(modelId, "llm", providerStorageAlias);
+        importedCount += 1;
+      }
+      if (importedCount === 0) {
+        alert(translate("All models already exist, no new models added"));
+      } else {
+        alert(translate("Successfully added") + ` ${importedCount} ` + translate("models"));
+      }
+    } catch (error) {
+      console.log("Error importing Cline models:", error);
+      alert(translate("Error fetching models") + ": " + error.message);
+    } finally {
+      setImportingClineModels(false);
     }
   };
 
@@ -1184,6 +1232,20 @@ export default function ProviderDetailPage() {
               {importingQoderModels ? "progress_activity" : "download"}
             </span>
             {importingQoderModels ? translate("Fetching...") : translate("Fetch Qoder Models")}
+          </button>
+        )}
+
+        {/* Import Cline /models catalog button — only show for cline and clinepass providers */}
+        {(providerId === "cline" || providerId === "clinepass") && connections.some((conn) => conn.isActive !== false) && (
+          <button
+            onClick={handleImportClineModels}
+            disabled={importingClineModels}
+            className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-blue-500/40 px-3 py-2 text-xs text-blue-600 dark:text-blue-400 transition-colors hover:border-blue-500 hover:bg-blue-500/5 sm:w-auto disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <span className="material-symbols-outlined text-sm" style={importingClineModels ? { animation: "spin 1s linear infinite" } : undefined}>
+              {importingClineModels ? "progress_activity" : "download"}
+            </span>
+            {importingClineModels ? translate("Fetching...") : translate("Import from /models")}
           </button>
         )}
 

--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -198,6 +198,10 @@ const PROVIDER_MODELS_CONFIG = {
   },
   openai: createOpenAIModelsConfig("https://api.openai.com/v1/models"),
   openrouter: createOpenAIModelsConfig("https://openrouter.ai/api/v1/models"),
+  // Cline and ClinePass share the same upstream /models catalog (public).
+  // OAuth accessToken carries the workos: prefix, which api.cline.bot accepts.
+  cline: createOpenAIModelsConfig("https://api.cline.bot/api/v1/models"),
+  clinepass: createOpenAIModelsConfig("https://api.cline.bot/api/v1/models"),
   anthropic: {
     url: "https://api.anthropic.com/v1/models",
     method: "GET",

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -69,6 +69,13 @@ const LIVE_MODEL_RESOLVERS = {
     });
     return result?.models?.length ? { models: result.models } : null;
   },
+  cline: async (conn) => {
+    const result = await resolveClinepassModels({
+      accessToken: conn.accessToken,
+      apiKey: conn.apiKey,
+    });
+    return result?.models?.length ? { models: result.models } : null;
+  },
   clinepass: async (conn) => {
     const result = await resolveClinepassModels({
       accessToken: conn.accessToken,

--- a/tests/unit/cline-auth.test.js
+++ b/tests/unit/cline-auth.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  getClineAccessToken,
+  getClineAuthorizationHeader,
+} from "../../open-sse/shared/clineAuth.js";
+
+test("getClineAccessToken keeps an existing workos: prefix", () => {
+  const token = "workos:eyJhbGciOiJSUzI1NiJ9.eyJwYXAiJ9";
+  assert.equal(getClineAccessToken(token), token);
+  assert.equal(getClineAccessToken(`  ${token}  `), token);
+});
+
+test("getClineAccessToken prefixes a bare WorkOS JWT with workos:", () => {
+  const jwt = "eyJhbGciOiJSUzI1NiJ9.eyJwYXAiJ9";
+  assert.equal(getClineAccessToken(jwt), `workos:${jwt}`);
+});
+
+test("getClineAccessToken does NOT prefix ClinePass API keys", () => {
+  // ClinePass API keys are opaque strings (e.g. clp_…). Sending them as
+  // `workos:clp_…` makes api.cline.bot respond 401.
+  assert.equal(getClineAccessToken("clp_1234567890abcdef"), "clp_1234567890abcdef");
+  assert.equal(getClineAccessToken("sk-9r-abcdef"), "sk-9r-abcdef");
+  assert.equal(getClineAccessToken(""), "");
+  assert.equal(getClineAccessToken("   "), "");
+  assert.equal(getClineAccessToken(undefined), "");
+  assert.equal(getClineAccessToken(null), "");
+});
+
+test("getClineAuthorizationHeader builds a Bearer header without double prefixing", () => {
+  assert.equal(getClineAuthorizationHeader("clp_abc"), "Bearer clp_abc");
+  assert.equal(
+    getClineAuthorizationHeader("eyJpeg.eyJbG"),
+    "Bearer workos:eyJpeg.eyJbG"
+  );
+  assert.equal(
+    getClineAuthorizationHeader("workos:eyJpeg.eyJbG"),
+    "Bearer workos:eyJpeg.eyJbG"
+  );
+});


### PR DESCRIPTION
## Summary

Fixes Cline/ClinePass HTTP 401 (and resulting HTTP 503 from 9Router) reported in #3230 / #2333 / #3644:

> `[cline/clinepass/cline-pass/<model>] [401]: {"error":"Unauthorized: Please make sure you're using the latest version of Cline and re-authenticate your Cline account."}`

### Root cause

`getClineAccessToken()` in `open-sse/shared/clineAuth.js` unconditionally prefixed **every** token with `workos:`. That is correct for Cline **OAuth** access tokens (WorkOS JWTs, `eyJ…`), but **ClinePass API keys** (category `apikey`, e.g. `clp_…`) are opaque strings and must be sent verbatim. Sending `workos:clp_…` makes `api.cline.bot` reject the request with the 401 above.

I verified against `api.cline.bot` directly:
- `Bearer eyJ…` (raw OAuth JWT) → 200
- `Bearer workos:eyJ…` → 200
- ClinePass API keys must be sent without the `workos:` scheme (the official client does exactly this).

### Changes

1. **`open-sse/shared/clineAuth.js`**: only add the `workos:` prefix to tokens that look like WorkOS JWTs (`eyJ…`). API keys & opaque tokens pass through untouched. Also no double-prefixing when the token already starts with `workos:`.
2. **`open-sse/services/tokenRefresh.js`**: register a `clinepass` entry in `REFRESH_HANDLERS` (reuses the shared Cline WorkOS refresh endpoint) so background token refresh actually runs for ClinePass connections — without it, expired ClinePass OAuth tokens were never rotated and every request 401s.
3. **`open-sse/providers/registry/clinepass.js`**: list `apikey` before `oauth` in `authModes` — ClinePass is meant to be used with an API key from `app.cline.bot/settings/api-keys` (see #2333), not the extension OAuth flow.

### Tests

Added `tests/unit/cline-auth.test.js` (4 cases, pass with `node --test`):
- already-`workos:` tokens are untouched
- bare JWTs get `workos:` prefixed
- ClinePass API keys / opaque tokens are NOT prefixed
- `Authorization` header built without double prefixing

### Manual validation

With a valid Cline OAuth token the direct `api.cline.bot` POST `/api/v1/chat/completions` returns 200 with the 9Router-style headers, so 401 was never about headers — it was about the token scheme (this PR) and expired tokens not being refreshed (this PR).
