### PR TITLE
feat(opencode-go): add DeepSeek V4.1 Flash

### DIFF
--- a/open-sse/providers/registry/opencode-go.js
+++ b/open-sse/providers/registry/opencode-go.js
@@ -39,6 +39,7 @@ export default {
     { id: "glm-5.1", name: "GLM 5.1", supportedFormats: ["openai"] },
     { id: "kimi-k2.7-code", name: "Kimi K2.7 Code", supportedFormats: ["openai"] },
     { id: "kimi-k2.6", name: "Kimi K2.6", supportedFormats: ["openai"] },
+    { id: "deepseek-flash", name: "DeepSeek V4.1 Flash", supportedFormats: ["openai"] },
     { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro", supportedFormats: ["openai", "claude", "openai-responses"] },
     { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash", supportedFormats: ["openai", "claude", "openai-responses"] },
     { id: "deepseek-v4-flash-vision-exp", name: "DeepSeek V4 Flash Vision (Exp)", supportedFormats: ["openai", "claude", "openai-responses"] },

--- a/tests/unit/opencode-go-deepseek-flash.check.mjs
+++ b/tests/unit/opencode-go-deepseek-flash.check.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import provider from "../../open-sse/providers/registry/opencode-go.js";
+
+const model = provider.models.find(({ id }) => id === "deepseek-flash");
+assert.ok(model, "DeepSeek V4.1 Flash phải có trong OpenCode Go");
+assert.equal(model.name, "DeepSeek V4.1 Flash");
+assert.deepEqual(model.supportedFormats, ["openai"]);
+assert.equal(provider.models.filter(({ id }) => id === "deepseek-flash").length, 1);
+assert.ok(provider.models.some(({ id }) => id === "deepseek-v4-flash"));
+assert.equal(provider.transports.find(({ format }) => format === model.supportedFormats[0]).baseUrl,
+  "https://opencode.ai/zen/go/v1/chat/completions");

--- a/tests/unit/opencode-go-models.test.js
+++ b/tests/unit/opencode-go-models.test.js
@@ -23,7 +23,7 @@ describe("OpenCode Go model catalog", () => {
     const ids = (PROVIDER_MODELS["opencode-go"] || []).map((m) => m.id);
     expect(ids).toEqual([
       "glm-5.3-flash", "glm-5.2", "glm-5.1", "kimi-k2.7-code", "kimi-k2.6",
-      "deepseek-v4-pro", "deepseek-v4-flash", "deepseek-v4-flash-vision-exp",
+      "deepseek-flash", "deepseek-v4-pro", "deepseek-v4-flash", "deepseek-v4-flash-vision-exp",
       "mimo-v2.5", "mimo-v2.5-pro",
       "minimax-m3", "minimax-m2.7", "minimax-m2.5",
       "qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus",


### PR DESCRIPTION
## Thay đổi
- Thêm DeepSeek V4.1 Flash với ID chính thức deepseek-flash cho OpenCode Go.
- Chỉ khai báo transport OpenAI chat/completions theo tài liệu; giữ nguyên DeepSeek V4 Flash cũ.
- Không sửa quota, pricing, executor hoặc provider khác.

## Nguồn
https://opencode.ai/docs/go/#usage-limits
Bảng Endpoints xác nhận ID deepseek-flash và /zen/go/v1/chat/completions. Quota do upstream quản lý.

## Kiểm thử
node tests/unit/opencode-go-deepseek-flash.check.mjs: RED trước thay đổi, GREEN sau thay đổi.
Kiểm tra ID/name/uniqueness/transport và giữ model cũ. Cập nhật expected catalog Vitest; chưa chạy Vitest/full suite. git diff --check pass. Không live provider hoặc credentials.