### PR TITLE
feat(cline): add free-tier models and API-key auth

### DIFF
--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -301,6 +301,12 @@ export const PATTERN_CAPABILITIES = [
   { pattern: "*gpt-3.5*",       caps: { contextWindow: 16385, maxOutput: 4096 } },
   { pattern: "*gpt-oss*",       caps: { reasoning: true, thinkingFormat: "openai", contextWindow: 128000 } },
 
+  // ── Cline free tier: Upstage Solar Pro + LongCat (agentic coding models;
+  // windows unverified — 200K/32K conservative, same as laguna:free).
+  // NOTE: placed before the o-series catch-alls — "solar-pro4" contains "o4".
+  { pattern: "*solar-pro*",     caps: { reasoning: true, thinkingFormat: "openai", contextWindow: 200000, maxOutput: 32000 } },
+  { pattern: "*longcat*",       caps: { reasoning: true, thinkingFormat: "openai", contextWindow: 200000, maxOutput: 32000 } },
+
   // ── OpenAI o-series (reasoning, vision) ──────────────────────────
   { pattern: "*o1-mini*",       caps: { reasoning: true, thinkingFormat: "openai", contextWindow: 128000 } },
   { pattern: "*o1*",            caps: { vision: true, reasoning: true, thinkingFormat: "openai", contextWindow: 200000, maxOutput: 100000 } },

--- a/open-sse/providers/registry/cline.js
+++ b/open-sse/providers/registry/cline.js
@@ -14,8 +14,9 @@ export default {
     },
   },
   category: "oauth",
-  authModes: ["oauth"],
+  authModes: ["oauth", "apikey"],
   hasOAuth: true,
+  authHint: "API key from app.cline.bot → Settings > API Keys, or sign in with OAuth.",
   transport: {
     baseUrl: "https://api.cline.bot/api/v1/chat/completions",
     headers: {
@@ -44,6 +45,16 @@ export default {
     { id: "google/gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview" },
     { id: "google/gemini-3.1-flash-lite-preview", name: "Gemini 3.1 Flash Lite Preview" },
     { id: "kwaipilot/kat-coder-pro", name: "KAT Coder Pro" },
+    // Free tier (verified live via GET /api/v1/ai/cline/recommended-models):
+    // usage-billed at $0 with a separate daily per-model limit, selectable
+    // on both cline and cline-pass. Limit hits surface as a
+    // "Daily free model limit reached / try again in X" error.
+    { id: "cline-free/muse-spark-1.3-contributor", name: "Muse Spark 1.3 (Free)" },
+    { id: "deepseek/deepseek-v4-flash", name: "DeepSeek V4 Flash (Free)" },
+    { id: "z-ai/glm-5.3-flash", name: "GLM 5.3 Flash (Free)" },
+    { id: "cline-free/solar-pro4", name: "Solar Pro 4 (Free)" },
+    { id: "cline-free/longcat-2.0", name: "LongCat 2.0 (Free)" },
+    { id: "poolside/laguna-s-2.1:free", name: "Laguna S 2.1 (Free)" },
   ],
   oauth: {
     appBaseUrl: "https://app.cline.bot",

--- a/tests/__baseline__/providers-baseline.json
+++ b/tests/__baseline__/providers-baseline.json
@@ -44,6 +44,7 @@
     },
     "usage": {
       "quotaApiUrl": "https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+      "quotaSummaryApiUrl": "https://daily-cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary",
       "loadProjectApiUrl": "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist",
       "tokenUrl": "https://oauth2.googleapis.com/token"
     },
@@ -131,6 +132,9 @@
       "HTTP-Referer": "https://cline.bot",
       "X-Title": "Cline"
     },
+    "quirks": {
+      "clineEnvelope": true
+    },
     "tokenUrl": "https://api.cline.bot/api/v1/auth/token",
     "refreshUrl": "https://api.cline.bot/api/v1/auth/refresh",
     "auth": {
@@ -148,6 +152,9 @@
     "headers": {
       "HTTP-Referer": "https://cline.bot",
       "X-Title": "Cline"
+    },
+    "quirks": {
+      "clineEnvelope": true
     },
     "auth": {
       "combined": true,
@@ -240,6 +247,12 @@
     "validateUrl": "https://api.deepseek.com/models",
     "reasoningInject": {
       "scope": "all"
+    },
+    "quirks": {
+      "claudeSupportedToolTypes": [
+        "web_search_20250305",
+        "web_search_20260209"
+      ]
     },
     "format": "openai",
     "transports": [
@@ -438,6 +451,9 @@
   "groq": {
     "baseUrl": "https://api.groq.com/openai/v1/chat/completions",
     "validateUrl": "https://api.groq.com/openai/v1/models",
+    "usage": {
+      "url": "https://api.groq.com/openai/v1/models"
+    },
     "format": "openai"
   },
   "hyperbolic": {
@@ -571,7 +587,8 @@
       "Anthropic-Beta": "claude-code-20250219,interleaved-thinking-2025-05-14"
     },
     "quirks": {
-      "dropOutputConfig": true
+      "dropOutputConfig": true,
+      "requireClaudeToolType": true
     },
     "reasoningInject": {
       "scope": "all"
@@ -622,7 +639,8 @@
       "Anthropic-Beta": "claude-code-20250219,interleaved-thinking-2025-05-14"
     },
     "quirks": {
-      "dropOutputConfig": true
+      "dropOutputConfig": true,
+      "requireClaudeToolType": true
     },
     "reasoningInject": {
       "scope": "all"
@@ -709,6 +727,9 @@
   "opencode-go": {
     "baseUrl": "https://opencode.ai/zen/go/v1/chat/completions",
     "headers": {},
+    "usage": {
+      "url": "https://opencode.ai/zen/go/v1/usage"
+    },
     "format": "openai",
     "transports": [
       {
@@ -949,6 +970,7 @@
       "HTTP-Referer": "https://endpoint-proxy.local",
       "X-Title": "Endpoint Proxy"
     },
+    "forceStream": true,
     "format": "openai"
   },
   "baidu": {


### PR DESCRIPTION
- Register 6 free-tier models (cline-free/*, deepseek-v4-flash, z-ai/glm-5.3-flash, laguna-s-2.1:free), verified live via GET /api/v1/ai/cline/recommended-models; usage-billed at $0 with a separate daily per-model limit
- Allow API-key connections (authModes oauth+apikey); key from app.cline.bot Settings > API Keys, sent as plain Bearer
- Add solar-pro/longcat capabilities (placed before o-series catch-alls: solar-pro4 contains o4)
- Regen providers baseline